### PR TITLE
feat: GitHub OAuth device flow

### DIFF
--- a/.claude-done
+++ b/.claude-done
@@ -1,35 +1,39 @@
-# Rename Note Tab — Done Summary
+# GitHub OAuth — Task Complete
 
 ## What was built
-Double-click a tab title to rename the note. The tab shows an inline text input (Enter saves, Escape cancels). Renaming updates the note's title, filename, H1 heading, frontmatter `title:` field, and all wiki links (`[[OldName]]` → `[[NewName]]`) across the entire vault.
 
-## Commits on `task/rename-note-tab`
-1. `caa26b6` — design: rename-note-tab wireframes (`design/rename-note-tab.pen`)
-2. `68dfab4` — feat: add `rename_note` Tauri command with wiki link updates (Rust backend)
-3. `5a8eb6a` — feat: rename note via double-click on tab — frontend wiring
-4. `ee00c2c` — test: Playwright e2e tests for rename tab feature
+GitHub Device Flow authentication, allowing users to connect their GitHub account from the Settings panel. Token is stored locally with secure file permissions. This enables future vault-from-GitHub features.
 
-## Architecture decisions
-- **Slug generation**: title → lowercase, non-alphanumeric chars replaced with hyphens, leading/trailing hyphens stripped. Same logic in Rust backend and TypeScript mock.
-- **Wiki link matching**: regex matches both title-based (`[[Old Title]]`) and path-stem-based (`[[note/old-title]]`) references, preserving pipe aliases (`[[Old Title|display]]` → `[[New Title|display]]`).
-- **State flow**: `onRenameTab` flows from TabBar → Editor → App → `useNoteActions.handleRenameNote` → Tauri backend → `useVaultLoader.replaceEntry` (updates entries + allContent atomically).
-- **H1 + frontmatter**: The rename updates both the first `# Heading` line and the `title:` frontmatter field if present.
-- **Toast feedback**: Shows "Renamed" or "Renamed — updated N wiki links" on success, "Failed to rename note" on error.
+## Files changed
 
-## Code health
-- **TabBar.tsx**: Improved from CC 23→18 by extracting `TabItem` component and `tabStyle` helper.
-- **Rust `vault.rs`**: Passed code health after extracting helpers (`build_wikilink_pattern`, `WikilinkReplacement` struct, `collect_md_files`, etc.) to keep CC under thresholds.
-- **useNoteActions.ts**: Pre-existing CC=37 (threshold 9) increased to 42. Extracted `performRename` and `buildRenamedEntry` as module-level functions. Proper fix requires splitting the monolithic hook (separate concern).
-- **App.tsx / useVaultLoader.ts**: Minor LOC/CC increases on already-above-threshold functions.
+### Rust backend
+- **`src-tauri/src/github_auth.rs`** (new) — Device flow start, token polling, user fetch, disconnect, secure token storage (0o600 permissions). Includes path-parameterized storage helpers for testability.
+- **`src-tauri/src/lib.rs`** — Registered 5 new Tauri commands: `github_start_device_flow`, `github_poll_token`, `github_get_user`, `github_disconnect`, `github_get_stored_token`
+
+### Frontend
+- **`src/hooks/useGithubAuth.ts`** (new) — Hook managing the full device flow lifecycle: init check for stored token, connect (start flow + poll), disconnect, cancel, error handling
+- **`src/components/SettingsPanel.tsx`** (new) — Settings dialog with GitHub section showing all states: disconnected, loading, device flow (with user code + "Open GitHub" button), connected (with avatar + user info), error (with retry)
+- **`src/components/StatusBar.tsx`** — Made Settings gear icon functional (was disabled placeholder)
+- **`src/App.tsx`** — Wired SettingsPanel dialog + state
+- **`src/mock-tauri.ts`** — Added mock handlers for all 5 GitHub commands (simulates 3-poll auth flow)
+
+### Tests
+- **`src/hooks/useGithubAuth.test.ts`** (new) — 9 tests: init states, connect flow, cancel, disconnect, error handling, polling success/failure
+- **`src/components/SettingsPanel.test.tsx`** (new) — 21 tests: all UI states, user interactions, edge cases
+- **`src-tauri/src/github_auth.rs`** — 28 inline Rust tests: token storage CRUD, poll classification, serialization, permissions
+
+### Design
+- **`design/github-oauth.pen`** — 3 new frames: Settings (Disconnected), Device Flow In Progress, Settings (Connected)
 
 ## Test results
-- `pnpm test` — 119/119 passed
-- `cargo test` — 147/147 passed (including 7 new rename tests)
-- `npx vite build` — success
-- Playwright e2e — 2/2 rename-tab tests pass
+- **Frontend**: 392 tests passing, coverage 84.5% (above 70% threshold)
+- **Rust**: 177 tests passing, coverage 86.37% (above 85% threshold)
+- **CodeScene**: Quality gates passed, no code health regressions
 
-## Visual verification
-Tested on `localhost:5173` via Playwright:
-- Double-click → inline input appears with current title selected
-- Type new name → Enter → tab title updates, note list updates, breadcrumb updates, toast shows "Renamed"
-- Double-click → type → Escape → title reverts, no changes made
+## Product decisions
+- **Client ID**: Stored as compile-time constant `LAPUTA_GITHUB_CLIENT_ID` — placeholder for Luca to replace after registering the OAuth App
+- **Token storage**: File at `~/.config/com.laputa.app/github_token` (macOS: `~/Library/Application Support/com.laputa.app/github_token`) with 0o600 permissions, not localStorage, for security
+- **Settings access**: Gear icon in StatusBar (was already there but disabled) — natural location next to vault switcher
+- **Polling interval**: Minimum 5s enforced per GitHub spec; auto-expires after `expires_in` seconds
+- **Revoked token handling**: If stored token fails user fetch on init, silently falls back to disconnected state (user can reconnect)
+- **Scope**: `read:user,repo` — read user profile + repo access for future vault-from-GitHub features

--- a/design/github-oauth.pen
+++ b/design/github-oauth.pen
@@ -1,0 +1,11042 @@
+{
+  "version": "2.8",
+  "children": [
+    {
+      "type": "frame",
+      "id": "qHhaj",
+      "x": 68,
+      "y": 3385,
+      "name": "Laputa App — Full Layout (Light)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "yVQFF",
+          "name": "macOS Title Bar",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "0MCME",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "c2AU6",
+                  "name": "closeBtn",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "h0zbh",
+                  "name": "minimizeBtn",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "tcqbu",
+                  "name": "maximizeBtn",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "oHDfa",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "ZTOSJ",
+              "name": "Panel: Sidebar",
+              "clip": true,
+              "width": 250,
+              "height": "fill_container",
+              "fill": "$--sidebar",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--sidebar-border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "4wMva",
+                  "name": "Filters",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "gap": 1,
+                  "padding": [
+                    8,
+                    8,
+                    16,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Q78hg",
+                      "name": "filterAll",
+                      "width": "fill_container",
+                      "fill": "#4a9eff18",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5ip58",
+                          "name": "leftAll",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "PXpWi",
+                              "name": "iconAll",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tray-fill",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "NWprl",
+                              "name": "fAllTxt",
+                              "fill": "$--primary",
+                              "content": "Untagged",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NZ9Dv",
+                          "name": "countAll",
+                          "height": 20,
+                          "fill": "$--primary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mPlUV",
+                              "name": "badgeAllTxt",
+                              "fill": "$--primary-foreground",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YLWsY",
+                      "name": "filterUntagged",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "k7LIr",
+                          "name": "leftUntagged",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "FMVlh",
+                              "name": "untaggedIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "5XllD",
+                              "name": "untaggedTxt",
+                              "fill": "$--foreground",
+                              "content": "All Notes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "aSpGv",
+                          "name": "countUntagged",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "qZUFt",
+                              "name": "untaggedBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "6",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Jahon",
+                      "name": "filterTrash",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IOiBI",
+                          "name": "leftTrash",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "X6F74",
+                              "name": "trashIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "trash",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vRMH9",
+                              "name": "trashTxt",
+                              "fill": "$--foreground",
+                              "content": "Archive",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JMpkq",
+                          "name": "countTrash",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "0cKm4",
+                              "name": "trashBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6RMbq",
+                      "name": "filterChanges",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DpdBu",
+                          "name": "leftChanges",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "VTusA",
+                              "name": "iconChanges",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "git-branch",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qvq5O",
+                              "name": "fChangesTxt",
+                              "fill": "$--foreground",
+                              "content": "Changes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qAMES",
+                          "name": "countChanges",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "nkzVk",
+                              "name": "badgeChangesTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SSEUP",
+                  "name": "Sections",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    8,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nM2Cn",
+                      "name": "projGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6,
+                        8,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ouIl9",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Rx1Cp",
+                              "name": "leftProj",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "t5WJJ",
+                                  "name": "projIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "wrench",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-red"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "S3sGC",
+                                  "name": "projLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Projects",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "FKwSS",
+                              "name": "projChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "IHzFh",
+                          "name": "projItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "iiFcl",
+                              "name": "proj1Txt",
+                              "fill": "$--accent-red",
+                              "content": "Laputa App",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LdaU9",
+                          "name": "projItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XRll4",
+                              "name": "proj2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Portfolio Rewrite",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Vmykd",
+                          "name": "projItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "0PqQQ",
+                              "name": "proj3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "AI Habit Tracker",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WAQtn",
+                      "name": "respGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "aSi3l",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "lov6B",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Em4ns",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "medal",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "WPRCo",
+                                  "name": "respLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Responsibilities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "6hDdQ",
+                              "name": "respChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FmUu0",
+                      "name": "procGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Dat6o",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "iJlgx",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "I2J1R",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "AToF0",
+                                  "name": "Procedures",
+                                  "fill": "$--foreground",
+                                  "content": "Procedures",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "meEIL",
+                              "name": "procChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "T4NG2",
+                      "name": "peopleGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Q01iL",
+                          "name": "peopleHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "eE6Ca",
+                              "name": "leftPeople",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "jOmVa",
+                                  "name": "peopleIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "users",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "caelD",
+                                  "name": "peopleLbl",
+                                  "fill": "$--foreground",
+                                  "content": "People",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "TkuS1",
+                              "name": "peopleChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BY1Qx",
+                      "name": "eventsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "v28d8",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "TPyOc",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "ELRMi",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "OlI6Q",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Events",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "TZwK8",
+                              "name": "eventsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "trKNW",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qdbZ3",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "JP83M",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Q57kF",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "tag",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DeVxP",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Topics",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "nzAcm",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZWXuk",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CQaLg",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "2SMcN",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "0N8UH",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6XB2H",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Notes",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "NmBSB",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2cQBp",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "0f10v",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                0
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "xBv1X",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "viWPL",
+                                  "name": "eventsLbl",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Create new type",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "8lLHp",
+                  "name": "Commit Area",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "YYjuy",
+                      "name": "commitBtn",
+                      "width": "fill_container",
+                      "fill": "$--primary",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "YF44G",
+                          "name": "commitIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "git-commit-horizontal",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary-foreground"
+                        },
+                        {
+                          "type": "text",
+                          "id": "vpzJm",
+                          "name": "commitTxt",
+                          "fill": "$--primary-foreground",
+                          "content": "Commit & Push",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vhU5z",
+                          "name": "commitBadge",
+                          "height": 18,
+                          "fill": "#ffffff40",
+                          "cornerRadius": 9,
+                          "padding": [
+                            0,
+                            5
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "sdvYT",
+                              "name": "commitBadgeTxt",
+                              "fill": "$--white",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "IIvWr",
+              "name": "Resize Handle",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "zFIJv",
+              "name": "Panel: NoteList",
+              "clip": true,
+              "width": 300,
+              "height": "fill_container",
+              "fill": "$--card",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "uZJVN",
+                  "name": "NoteList Header",
+                  "width": "fill_container",
+                  "height": 45,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hmbdb",
+                      "name": "nlTitle",
+                      "fill": "$--foreground",
+                      "content": "Laputa App",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m6AeW",
+                      "name": "nlActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "8gMXE",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "magnifying-glass",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "YqvSN",
+                          "name": "plusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "0aJUm",
+                  "name": "Note Items",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "y9y05",
+                      "name": "Backlinks Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tMsM4",
+                          "name": "Note Item Selected",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E9E9E7"
+                          },
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "id": "npYuc",
+                              "name": "leftAccent",
+                              "fill": "$--accent-red",
+                              "width": 3,
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "a33Wx",
+                              "name": "noteSelContent",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "AZkyx",
+                                  "name": "noteSelRow",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "j7GDJ",
+                                      "name": "titleGroup",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "j7o2Q",
+                                          "name": "noteSelTitle",
+                                          "fill": "$--foreground",
+                                          "content": "Laputa App",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "BnkTG",
+                                          "name": "ico",
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "wrench",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Ac5Ds",
+                                  "name": "noteSelSnip",
+                                  "fill": "$--foreground",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Personal knowledge and life management desktop app...",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "9ASsT",
+                                  "name": "noteSelTime",
+                                  "fill": "$--accent-red",
+                                  "content": "2m ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7G8pN",
+                      "name": "Related Notes Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fDxtF",
+                          "name": "Related Notes Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "UBRdO",
+                              "name": "rnLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8Z4Wq",
+                                  "name": "rnLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "RELATED NOTES",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "vpnZr",
+                                  "name": "rnCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "X9LIR",
+                              "name": "rnRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "fzVWu",
+                                  "name": "rnFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "wuqsO",
+                                  "name": "rnPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "SbjLq",
+                                  "name": "rnChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AsAKG",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "QX5A1",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "rYdta",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "PC9XN",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Portfolio Rewrite",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "oI64Y",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "S9JPj",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Redesigning portfolio site with modern stack and updated visual language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "lU75x",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "u6E6Z",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ZjCz3",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "mxCzu",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "INenY",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Sample note 2",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "gz6qS",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "s141z",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Lorem ipsum dolor sit amet consequetur with modern stack and updated language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "SvGnt",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1GwHB",
+                      "name": "Events Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fp4xI",
+                          "name": "Events Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "MNNuU",
+                              "name": "evLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "BNxZp",
+                                  "name": "evLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "EVENTS",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qcEvw",
+                                  "name": "evCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WCyfc",
+                              "name": "evRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SpCoO",
+                                  "name": "evFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "G1DCl",
+                                  "name": "evPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "sAalN",
+                                  "name": "evChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "k7CjA",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "og5Gz",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "ttBdk",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "KI8Bf",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Grant",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "LdRjU",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "FfPXa",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "BHh4Z",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AQ51u",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "SHgK3",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "3rIet",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "dCwzu",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Matteo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "l8O2I",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "1L4oo",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "3oBam",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "MeqjO",
+              "name": "Resize Handle 2",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "zAbPt",
+              "name": "Panel: Editor",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$--background",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NdYcO",
+                  "name": "Tab Bar",
+                  "width": "fill_container",
+                  "height": 45,
+                  "fill": "$--sidebar",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--sidebar-border"
+                  },
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nVUGr",
+                      "name": "Tab Active",
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kBpGX",
+                          "name": "tab1Txt",
+                          "fill": "$--foreground",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "Bb2AE",
+                          "name": "tab1Close",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GYeyL",
+                      "name": "Tab Inactive",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1,
+                          "bottom": 1
+                        },
+                        "fill": "$--sidebar-border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kZ1bn",
+                          "name": "tab2Txt",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "RwyYI",
+                          "name": "tab2Close",
+                          "opacity": 0,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sbpmq",
+                      "name": "tabSpacer",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "$--border"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WF97k",
+                      "name": "tabControls",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1,
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_around",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "rfSoS",
+                          "name": "iconPlus",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "t0u6z",
+                          "name": "iconSplit",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "columns",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "kbe1P",
+                          "name": "iconExpand",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrows-out-simple",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rTdKS",
+                  "name": "Editor Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "NfyTF",
+                      "name": "Editor Left",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hvoFh",
+                          "name": "Info Bar",
+                          "width": "fill_container",
+                          "height": 45,
+                          "fill": "$--background",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "bTP0I",
+                              "name": "infoLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Msj7v",
+                                  "name": "breadcrumbType",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Project",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wqdMG",
+                                  "name": "breadcrumbSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "›",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "FzENd",
+                                  "name": "breadcrumbName",
+                                  "fill": "$--foreground",
+                                  "content": "Laputa App",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "pvTmc",
+                                  "name": "dotSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "9ga1R",
+                                  "name": "modifiedTxt",
+                                  "fill": "$--accent-yellow",
+                                  "content": "M",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "3bzDp",
+                              "name": "infoRight",
+                              "gap": 12,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "9Ctb0",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "magnifying-glass",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "csHzz",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "git-branch",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "2s6Of",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cursor-text",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "JVSlj",
+                                  "name": "iconAI",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sparkle",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "k3AiV",
+                                  "name": "iconMore",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "dots-three",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vvETz",
+                          "name": "Editor Content",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": [
+                            32,
+                            64
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "b6up3",
+                              "name": "editorP1",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Personal knowledge and life management desktop app, built with Tauri v2 + React + TypeScript + CodeMirror 6. It reads a vault of markdown files with YAML frontmatter and presents them in a four-panel UI inspired by Bear Notes.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "a2S43",
+                              "name": "editorH2",
+                              "fill": "$--foreground",
+                              "content": "Architecture",
+                              "lineHeight": 1.3,
+                              "fontFamily": "Inter",
+                              "fontSize": 24,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "wgvQa",
+                              "name": "editorP2",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The app uses a four-panel layout: Sidebar for navigation, NoteList for browsing, Editor for content, and Inspector for metadata. All data lives in markdown files with YAML frontmatter, git-versioned.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GGP97",
+                      "name": "Inspector",
+                      "clip": true,
+                      "width": 260,
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FbHy7",
+                          "name": "Inspector Header",
+                          "width": "fill_container",
+                          "height": 45,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "sA7Dx",
+                              "name": "leftGroup",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "0ccF1",
+                                  "name": "propIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sliders-horizontal",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "T2vTZ",
+                                  "name": "inspTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Properties",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "NQOhZ",
+                              "name": "sidebarIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "x",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LYFki",
+                          "name": "Inspector Body",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "8g61y",
+                              "name": "Properties Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "VhH4P",
+                                  "name": "addPropBtn",
+                                  "width": "fill_container",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$--border"
+                                  },
+                                  "padding": [
+                                    6,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Q9z8F",
+                                      "name": "addPropTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "+ Add property",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "6PwTH",
+                                  "name": "propType",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Vt2BC",
+                                      "name": "propTypeLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TYPE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "uvBiY",
+                                      "name": "propTypeVal",
+                                      "fill": "$--foreground",
+                                      "content": "Project",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "FDbay",
+                                  "name": "propStatus",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "e426F",
+                                      "name": "propStatusLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "STATUS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "o2rZM",
+                                      "name": "propStatusBadge",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 16,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "transparent"
+                                      },
+                                      "gap": 8,
+                                      "padding": [
+                                        1,
+                                        6
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "QM7L3",
+                                          "name": "Badge Text",
+                                          "fill": "$--accent-green",
+                                          "content": "ACTIVE",
+                                          "lineHeight": 1.33,
+                                          "textAlign": "center",
+                                          "textAlignVertical": "middle",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 1.2
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "NmRLv",
+                              "name": "Relationships Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 16,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "WFVAr",
+                                  "name": "relGroup1",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "0N729",
+                                      "name": "relGrp1Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "BELONGS TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "zLl8F",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "kw9vC",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Laputa",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "RFvoz",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ybi8Q",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "VNcmt",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Building",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "UVPwc",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "L6knW",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "jwU3Z",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "laPFL",
+                                  "name": "relGroup2",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "LOXUL",
+                                      "name": "relGrp2Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "RELATED TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "qLTYD",
+                                      "name": "relMigrationBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-red-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "GBk2u",
+                                          "name": "migrationTxt",
+                                          "fill": "$--accent-red",
+                                          "content": "Shadcn Migration",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "Sy14T",
+                                          "name": "expIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "flask",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "u8ijV",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "PUXx5",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "6PUnO",
+                              "name": "Backlinks Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "PllIu",
+                                  "name": "blTitle",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ZbgbI",
+                                      "name": "blTitleTxt",
+                                      "rotation": -0.5285936385085725,
+                                      "fill": "$--muted-foreground",
+                                      "content": "BACKLINKS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "eRoDO",
+                                  "name": "blItem1",
+                                  "fill": "$--primary",
+                                  "content": "Portfolio Rewrite",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "u1olR",
+                                  "name": "blItem2",
+                                  "fill": "$--primary",
+                                  "content": "Meeting with Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "oUd9s",
+                                  "name": "blItem3",
+                                  "fill": "$--primary",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yf0wj",
+                              "name": "History Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "dG7rj",
+                                  "name": "histTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "HISTORY",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "z2Mdy",
+                                  "name": "histItem1",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "AsiWz",
+                                      "name": "histItem1Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "a089f44 · feat: migrate to shadcn/ui",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "BdVhi",
+                                      "name": "histItem1Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 16, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "piJNC",
+                                  "name": "histItem2",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "0PWoX",
+                                      "name": "histItem2Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "5a4b4ac · feat: emoji favicon",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "xySNW",
+                                      "name": "histItem2Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 15, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "x1AHT",
+          "name": "lightStatusBar",
+          "width": "fill_container",
+          "height": 30,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            8
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "e2UzJ",
+              "name": "Status Left",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "mlD58",
+                  "name": "versionIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "box",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "hRBRa",
+                  "name": "versionText",
+                  "fill": "$--muted-foreground",
+                  "content": "v0.4.2",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "bFwrw",
+                  "name": "sep1",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "ey3Gr",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "Kz0sS",
+                  "name": "branchText",
+                  "fill": "$--muted-foreground",
+                  "content": "main",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "6IY1E",
+                  "name": "sep2",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "IjEG1",
+                  "name": "syncIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-green"
+                },
+                {
+                  "type": "text",
+                  "id": "srxkr",
+                  "name": "syncText",
+                  "fill": "$--muted-foreground",
+                  "content": "Synced 2m ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4jgQF",
+              "name": "Status Right",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "3RPmA",
+                  "name": "aiIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-purple"
+                },
+                {
+                  "type": "text",
+                  "id": "t0NOA",
+                  "name": "aiText",
+                  "fill": "$--muted-foreground",
+                  "content": "Claude Sonnet 4",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "16V7i",
+                  "name": "sep3",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "PXVrd",
+                  "name": "notesCount",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "2FxCi",
+                  "name": "notesText",
+                  "fill": "$--muted-foreground",
+                  "content": "1,247 notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "pB6ds",
+                  "name": "sep4",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "fRHKs",
+                  "name": "bellIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "bell",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "2sEBS",
+                  "name": "settingsIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mOf4J",
+      "x": 0,
+      "y": 4457,
+      "name": "Color Palette — shadcn/ui Theme (Light)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "width": 1440,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 32,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "rmJdn",
+          "name": "cTitle",
+          "fill": "$--foreground",
+          "content": "Color Palette — shadcn/ui Theme Variables (Light)",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "text",
+          "id": "V79Zu",
+          "name": "cSub",
+          "fill": "$--muted-foreground",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "All colors from src/index.css. Variables support light/dark mode via .dark class.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "Xbdzq",
+          "name": "primLbl",
+          "fill": "$--foreground",
+          "content": "Primary Colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "NyoC7",
+          "name": "primRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "Inb1x",
+              "name": "sw1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "HRsVC",
+                  "name": "sw1b",
+                  "fill": "$--background",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "jV89s",
+                  "name": "sw1n",
+                  "fill": "$--foreground",
+                  "content": "--background",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "qOUUY",
+                  "name": "sw1v",
+                  "fill": "$--muted-foreground",
+                  "content": "L: #FFFFFF / D: #0f0f1a",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QytAQ",
+              "name": "sw2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "TMuHH",
+                  "name": "sw2b",
+                  "fill": "$--foreground",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "k9qK4",
+                  "name": "sw2n",
+                  "fill": "$--foreground",
+                  "content": "--foreground",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "BfEn7",
+                  "name": "sw2v",
+                  "fill": "$--muted-foreground",
+                  "content": "L: #37352F / D: #e0e0e0",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gJZtB",
+              "name": "sw3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "RRsQg",
+                  "name": "sw3b",
+                  "fill": "$--primary",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "CtJe4",
+                  "name": "sw3n",
+                  "fill": "$--foreground",
+                  "content": "--primary",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "1iFr6",
+                  "name": "sw3v",
+                  "fill": "$--muted-foreground",
+                  "content": "#155DFF",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mbvua",
+              "name": "sw4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "fajNZ",
+                  "name": "sw4b",
+                  "fill": "$--primary-foreground",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "wVJ7z",
+                  "name": "sw4n",
+                  "fill": "$--foreground",
+                  "content": "--primary-foreground",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "Oum5Q",
+                  "name": "sw4v",
+                  "fill": "$--muted-foreground",
+                  "content": "L: #FFFFFF / D: #ffffff",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "UvI4d",
+          "name": "accLbl",
+          "fill": "$--foreground",
+          "content": "Accent & Semantic Colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "jOmo7",
+          "name": "accRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "uFXJ3",
+              "name": "a1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "NRr0w",
+                  "name": "a1b",
+                  "fill": "$--accent-blue",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "ECVqk",
+                  "name": "a1n",
+                  "fill": "$--foreground",
+                  "content": "--accent-blue",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "csKEt",
+              "name": "a2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "5IiT2",
+                  "name": "a2b",
+                  "fill": "$--accent-green",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "aCPba",
+                  "name": "a2n",
+                  "fill": "$--foreground",
+                  "content": "--accent-green",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "XbY7C",
+              "name": "a3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "I9qCz",
+                  "name": "a3b",
+                  "fill": "$--accent-yellow",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "DfZVh",
+                  "name": "a3n",
+                  "fill": "$--foreground",
+                  "content": "--accent-yellow",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nROw3",
+              "name": "a4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "IcIoP",
+                  "name": "a4b",
+                  "fill": "$--accent-red",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "eGgz6",
+                  "name": "a4n",
+                  "fill": "$--foreground",
+                  "content": "--destructive",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "J95fv",
+              "name": "a5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "o03fQ",
+                  "name": "a5b",
+                  "fill": "$--accent-purple",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "H9VWy",
+                  "name": "a5n",
+                  "fill": "$--foreground",
+                  "content": "--accent-purple",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "GcYle",
+          "name": "lightLightLbl",
+          "fill": "$--foreground",
+          "content": "Accent Light Backgrounds",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "Ju2xp",
+          "name": "accLightRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "5dnn5",
+              "name": "al1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "7kcqW",
+                  "name": "ll1b",
+                  "fill": "$--accent-blue-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "dBCbF",
+                  "name": "ll1n",
+                  "fill": "$--foreground",
+                  "content": "--accent-blue-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "W0t0j",
+              "name": "al2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "1vepp",
+                  "name": "ll2b",
+                  "fill": "$--accent-green-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "6kUyf",
+                  "name": "ll2n",
+                  "fill": "$--foreground",
+                  "content": "--accent-green-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zyV1j",
+              "name": "al3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "yUDBN",
+                  "name": "ll3b",
+                  "fill": "$--accent-yellow-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "dmfZ4",
+                  "name": "ll3n",
+                  "fill": "$--foreground",
+                  "content": "--accent-yellow-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yGmmo",
+              "name": "al4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "eLu8o",
+                  "name": "ll4b",
+                  "fill": "$--accent-red-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "PVLwR",
+                  "name": "ll4n",
+                  "fill": "$--foreground",
+                  "content": "--accent-red-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0BO2b",
+              "name": "al5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "6FBws",
+                  "name": "ll5b",
+                  "fill": "$--accent-purple-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "i2DfV",
+                  "name": "ll5n",
+                  "fill": "$--foreground",
+                  "content": "--accent-purple-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "JFocf",
+          "name": "surfLbl",
+          "fill": "$--foreground",
+          "content": "Surface & Border Colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "YAJLW",
+          "name": "surfRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "JHS3j",
+              "name": "s1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "9Bj41",
+                  "name": "s1b",
+                  "fill": "$--card",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "wn4ua",
+                  "name": "s1n",
+                  "fill": "$--foreground",
+                  "content": "--card",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Fyvfd",
+              "name": "s2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "UFLw5",
+                  "name": "s2b",
+                  "fill": "$--sidebar",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--sidebar-border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "gngfL",
+                  "name": "s2n",
+                  "fill": "$--foreground",
+                  "content": "--sidebar",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zbyEJ",
+              "name": "s3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "WnmQD",
+                  "name": "s3b",
+                  "fill": "$--secondary",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "wnkxR",
+                  "name": "s3n",
+                  "fill": "$--foreground",
+                  "content": "--secondary",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Z2FuK",
+              "name": "s4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "lNPnc",
+                  "name": "s4b",
+                  "fill": "$--border",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "x9aeh",
+                  "name": "s4n",
+                  "fill": "$--foreground",
+                  "content": "--border / --input",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TDDQ0",
+              "name": "s5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "MwHOe",
+                  "name": "s5b",
+                  "fill": "$--muted-foreground",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "dHZj5",
+                  "name": "s5n",
+                  "fill": "$--foreground",
+                  "content": "--muted-foreground",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "HZonq",
+      "x": 0,
+      "y": 5252,
+      "name": "Typography & Spacing Specs (Light)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "width": 1440,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 32,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "nGLlU",
+          "name": "tTitle",
+          "fill": "$--foreground",
+          "content": "Typography Scale (Light)",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "text",
+          "id": "gkQqO",
+          "name": "tSub",
+          "fill": "$--muted-foreground",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "Fonts: Inter, IBM Plex Mono. Base: 14px. System fallback: -apple-system, BlinkMacSystemFont, sans-serif.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "QL9fK",
+          "name": "t1",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "px1l7",
+              "name": "t1s",
+              "fill": "$--foreground",
+              "content": "Heading 1",
+              "lineHeight": 1.2,
+              "fontFamily": "Inter",
+              "fontSize": 32,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "3UWKu",
+              "name": "t1d",
+              "fill": "$--muted-foreground",
+              "content": "32px / Bold / lh 1.2 — Editor H1",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Yjhit",
+          "name": "t2",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "iFzl0",
+              "name": "t2s",
+              "fill": "$--foreground",
+              "content": "Heading 2",
+              "lineHeight": 1.3,
+              "fontFamily": "Inter",
+              "fontSize": 24,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "cF55I",
+              "name": "t2d",
+              "fill": "$--muted-foreground",
+              "content": "24px / Semibold / lh 1.3 — Editor H2",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "bBHMa",
+          "name": "t3",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "kpSyr",
+              "name": "t3s",
+              "fill": "$--foreground",
+              "content": "App Title",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "700",
+              "letterSpacing": -0.3
+            },
+            {
+              "type": "text",
+              "id": "xUuNz",
+              "name": "t3d",
+              "fill": "$--muted-foreground",
+              "content": "17px / Bold / ls -0.3 — Sidebar header",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Lsh7F",
+          "name": "t4",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "vTRSs",
+              "name": "t4s",
+              "fill": "$--foreground",
+              "content": "Body Text",
+              "lineHeight": 1.6,
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "fKa3p",
+              "name": "t4d",
+              "fill": "$--muted-foreground",
+              "content": "16px / Regular / lh 1.6 — Editor paragraphs",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rpOTz",
+          "name": "t5",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "VXY3Z",
+              "name": "t5s",
+              "fill": "$--foreground",
+              "content": "UI Label / Button",
+              "lineHeight": 1.43,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "F6GQz",
+              "name": "t5d",
+              "fill": "$--muted-foreground",
+              "content": "14px / Medium / lh 1.43 — Buttons, NoteList header, Inspector labels",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "H6Rgt",
+          "name": "t6",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "xWvbj",
+              "name": "t6s",
+              "fill": "$--foreground",
+              "content": "Sidebar Item",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "bvBBm",
+              "name": "t6d",
+              "fill": "$--muted-foreground",
+              "content": "13px / Medium — Sidebar nav items, filter items, search",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GrFAq",
+          "name": "t7",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "vY8j4",
+              "name": "t7s",
+              "fill": "$--muted-foreground",
+              "content": "SECTION HEADER",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 0.5
+            },
+            {
+              "type": "text",
+              "id": "okws6",
+              "name": "t7d",
+              "fill": "$--muted-foreground",
+              "content": "11px / Semibold / ls 0.5 — Sidebar sections, type pills",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "awxls",
+          "name": "t8",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "mD3f5",
+              "name": "t8s",
+              "fill": "$--foreground",
+              "content": "ALL-CAPS LABEL",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "text",
+              "id": "jFpLw",
+              "name": "t8d",
+              "fill": "$--muted-foreground",
+              "content": "11px / Semibold / ls 1.2 / IBM Plex Mono — Section labels, metadata tags",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ToLzL",
+          "name": "t9",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "LEsxW",
+              "name": "t9s",
+              "fill": "$--muted-foreground",
+              "content": "OVERLINE TEXT",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 10,
+              "fontWeight": "500",
+              "letterSpacing": 1.5
+            },
+            {
+              "type": "text",
+              "id": "HQ3Df",
+              "name": "t9d",
+              "fill": "$--muted-foreground",
+              "content": "10px / Medium / ls 1.5 / IBM Plex Mono — Overlines, category labels, timestamps",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "3tiJ7",
+          "name": "div1",
+          "fill": "$--border",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "text",
+          "id": "b2Mt9",
+          "name": "spTitle",
+          "fill": "$--foreground",
+          "content": "Spacing & Layout Reference",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "frame",
+          "id": "o6ETJ",
+          "name": "pnlRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "HhbOn",
+              "name": "p1",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "YBekR",
+                  "name": "p1t",
+                  "fill": "$--foreground",
+                  "content": "Sidebar: 250px",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "dT8Xe",
+                  "name": "p1d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --sidebar | padding: 8px container, 12px 16px header, 6px 16px items",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aYkMZ",
+              "name": "p2",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Eycne",
+                  "name": "p2t",
+                  "fill": "$--foreground",
+                  "content": "NoteList: 300px",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "lyTZN",
+                  "name": "p2d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --card | padding: 14px 16px header, 8px 12px search/pills, 10px 16px items",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "E6G3g",
+              "name": "p3",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Xy5Gl",
+                  "name": "p3t",
+                  "fill": "$--foreground",
+                  "content": "Editor: flexible",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "y4svr",
+                  "name": "p3d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --background | padding: 32px 64px content, 7px 14px tabs, gap: 16px",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RBPav",
+              "name": "p4",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xKUWC",
+                  "name": "p4t",
+                  "fill": "$--foreground",
+                  "content": "Inspector: 280px",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "u81W5",
+                  "name": "p4d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --sidebar | padding: 14px 12px header, 12px body, 16px section gap, 8px prop gap",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "VvZyF",
+          "name": "radLbl",
+          "fill": "$--foreground",
+          "content": "Border Radius",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "OwJH7",
+          "name": "radRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "DHrzV",
+              "name": "r1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 4,
+                  "id": "V35oi",
+                  "name": "r1b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "HVQpq",
+                  "name": "r1n",
+                  "fill": "$--foreground",
+                  "content": "4px (sm) — chips",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wp350",
+              "name": "r2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 6,
+                  "id": "E031z",
+                  "name": "r2b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "rDLff",
+                  "name": "r2n",
+                  "fill": "$--foreground",
+                  "content": "6px (md) — buttons, inputs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "d6tJt",
+              "name": "r3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "PNkS4",
+                  "name": "r3b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "rZGXb",
+                  "name": "r3n",
+                  "fill": "$--foreground",
+                  "content": "8px (lg) — cards, dialogs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UAZ8u",
+              "name": "r4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 16,
+                  "id": "wgMVG",
+                  "name": "r4b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "zw3RY",
+                  "name": "r4n",
+                  "fill": "$--foreground",
+                  "content": "16px — badges",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "kIrXE",
+          "name": "div2",
+          "fill": "$--border",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "text",
+          "id": "FYw8k",
+          "name": "compTitle",
+          "fill": "$--foreground",
+          "content": "shadcn/ui Component Inventory",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "frame",
+          "id": "7Q1Fi",
+          "name": "compRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "XfUwj",
+              "name": "cg1",
+              "width": "fill_container",
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ly7m0",
+                  "name": "cg1t",
+                  "fill": "$--accent-green",
+                  "content": "In Use",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "Re89a",
+                  "name": "cg1r1",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Button — 5 variants (Default, Secondary, Outline, Ghost, Destructive)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "ILbjW",
+                  "name": "cg1r2",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Input — Default text input with label group",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "eurqS",
+                  "name": "cg1r3",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Dialog — Modal overlay (CreateNote, Commit)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "AZyZP",
+                  "name": "cg1r4",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Badge — 4 variants (Default, Secondary, Outline, Destructive)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "WtehQ",
+              "name": "cg2",
+              "width": "fill_container",
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "KaMZ9",
+                  "name": "cg2t",
+                  "fill": "$--accent-yellow",
+                  "content": "Available (Not Yet Used)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "F8wam",
+                  "name": "cg2r1",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "DropdownMenu — Context / dropdown menus",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Nl1aV",
+                  "name": "cg2r2",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Tabs — Tab navigation component",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "0sBwH",
+                  "name": "cg2r3",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Tooltip, Select, Card, Separator, ScrollArea",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trSB1",
+      "x": 1600,
+      "y": 3385,
+      "name": "Trash — Sidebar Filter",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 260,
+      "height": 400,
+      "fill": "$--sidebar",
+      "layout": "vertical",
+      "gap": 0,
+      "padding": [
+        8,
+        6
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "trFAll",
+          "name": "filterAll",
+          "width": "fill_container",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trIAll",
+              "name": "iconAll",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "file-text",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "trTAll",
+              "name": "txtAll",
+              "fill": "$--foreground",
+              "content": "All Notes",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trFFav",
+          "name": "filterFav",
+          "width": "fill_container",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trIFav",
+              "name": "iconFav",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "star",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "trTFav",
+              "name": "txtFav",
+              "fill": "$--foreground",
+              "content": "Favorites",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trFArc",
+          "name": "filterArchive",
+          "width": "fill_container",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trIArc",
+              "name": "iconArchive",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "archive",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "trTArc",
+              "name": "txtArchive",
+              "fill": "$--foreground",
+              "content": "Archive",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "frame",
+              "id": "trBArc",
+              "name": "badgeArc",
+              "height": 20,
+              "fill": "$--muted",
+              "cornerRadius": 9999,
+              "padding": [
+                0,
+                6
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trBTArc",
+                  "fill": "$--muted-foreground",
+                  "content": "2",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trFTr",
+          "name": "filterTrash",
+          "width": "fill_container",
+          "fill": "#ef444418",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trITr",
+              "name": "iconTrash",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "trash",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--destructive"
+            },
+            {
+              "type": "text",
+              "id": "trTTr",
+              "name": "txtTrash",
+              "fill": "$--destructive",
+              "content": "Trash",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "trBTr",
+              "name": "badgeTrash",
+              "height": 20,
+              "fill": "$--destructive",
+              "cornerRadius": 9999,
+              "padding": [
+                0,
+                6
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trBTTr",
+                  "fill": "#ffffff",
+                  "content": "3",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trNL1",
+      "x": 1600,
+      "y": 3815,
+      "name": "Trash — Note List View",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 340,
+      "height": 360,
+      "fill": "$--card",
+      "layout": "vertical",
+      "gap": 0,
+      "children": [
+        {
+          "type": "frame",
+          "id": "trNLH",
+          "name": "header",
+          "width": "fill_container",
+          "height": 45,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "children": [
+            {
+              "type": "text",
+              "id": "trNLT",
+              "fill": "$--foreground",
+              "content": "Trash",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trN1",
+          "name": "trashedNote1",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "trN1H",
+              "name": "titleRow",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trN1T",
+                  "fill": "$--foreground",
+                  "content": "Old Draft Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "trN1B",
+                  "name": "trashedBadge",
+                  "height": 16,
+                  "fill": "#ef444418",
+                  "cornerRadius": 4,
+                  "padding": [
+                    1,
+                    4
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "trN1BT",
+                      "fill": "$--destructive",
+                      "content": "TRASHED",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "trN1S",
+              "fill": "$--muted-foreground",
+              "content": "Some draft content that is no longer needed...",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "400"
+            },
+            {
+              "type": "text",
+              "id": "trN1D",
+              "fill": "$--muted-foreground",
+              "content": "5d ago",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "400"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trN2",
+          "name": "trashedNote2Warning",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
+          "fill": "#ef44440a",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "trN2H",
+              "name": "titleRow",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trN2T",
+                  "fill": "$--foreground",
+                  "content": "Deprecated API Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "trN2B",
+                  "name": "warningBadge",
+                  "height": 16,
+                  "fill": "$--destructive",
+                  "cornerRadius": 4,
+                  "padding": [
+                    1,
+                    4
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "trN2BT",
+                      "fill": "#ffffff",
+                      "content": "30+ DAYS",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "trN2S",
+              "fill": "$--muted-foreground",
+              "content": "Old API documentation that was replaced...",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "400"
+            },
+            {
+              "type": "text",
+              "id": "trN2D",
+              "fill": "$--destructive",
+              "content": "Trashed 35d ago — will be permanently deleted",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "500"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trRI1",
+      "x": 1970,
+      "y": 3385,
+      "name": "Trash — Relationship Indicator",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 300,
+      "height": 200,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        16
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "trRIL",
+          "fill": "$--muted-foreground",
+          "content": "BELONGS TO",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 0.5
+        },
+        {
+          "type": "frame",
+          "id": "trRN",
+          "name": "normalRef",
+          "width": "fill_container",
+          "fill": "$--accent-blue-light",
+          "cornerRadius": 6,
+          "padding": [
+            6,
+            10
+          ],
+          "gap": 6,
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "children": [
+            {
+              "type": "text",
+              "id": "trRNT",
+              "fill": "$--accent-blue",
+              "content": "Build Laputa App",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "500"
+            },
+            {
+              "type": "icon_font",
+              "id": "trRNI",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "wrench",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--accent-blue"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trRT",
+          "name": "trashedRef",
+          "width": "fill_container",
+          "fill": "$--muted",
+          "cornerRadius": 6,
+          "padding": [
+            6,
+            10
+          ],
+          "gap": 6,
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "opacity": 0.7,
+          "children": [
+            {
+              "type": "frame",
+              "id": "trRTL",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "trRTTI",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "trash",
+                  "iconFontFamily": "phosphor",
+                  "weight": 700,
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "trRTT",
+                  "fill": "$--muted-foreground",
+                  "content": "Old Draft Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "trRTTX",
+                  "fill": "$--muted-foreground",
+                  "content": "(trashed)",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "400"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "trRTI",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "file-text",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trRA",
+          "name": "archivedRef",
+          "width": "fill_container",
+          "fill": "$--muted",
+          "cornerRadius": 6,
+          "padding": [
+            6,
+            10
+          ],
+          "gap": 6,
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "opacity": 0.7,
+          "children": [
+            {
+              "type": "frame",
+              "id": "trRAL",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trRAT",
+                  "fill": "$--muted-foreground",
+                  "content": "Website Redesign",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "trRATX",
+                  "fill": "$--muted-foreground",
+                  "content": "(archived)",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "400"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "trRAI",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "wrench",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trW30",
+      "x": 1970,
+      "y": 3615,
+      "name": "Trash — 30-Day Auto-Delete Warning",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 340,
+      "height": 120,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        16
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "trW3L",
+          "fill": "$--muted-foreground",
+          "content": "Warning banner shown at top of trash view:",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "500"
+        },
+        {
+          "type": "frame",
+          "id": "trW3B",
+          "name": "warningBanner",
+          "width": "fill_container",
+          "fill": "#ef44440f",
+          "cornerRadius": 8,
+          "padding": [
+            10,
+            12
+          ],
+          "gap": 8,
+          "alignItems": "center",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#ef444430"
+          },
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trW3I",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "warning",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--destructive"
+            },
+            {
+              "type": "frame",
+              "id": "trW3T",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trW3T1",
+                  "fill": "$--destructive",
+                  "content": "Notes in trash for 30+ days will be permanently deleted",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "trW3T2",
+                  "fill": "$--muted-foreground",
+                  "content": "1 note is past the 30-day retention period",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "400"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dt0",
+      "name": "Draggable Tabs — Default State",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dt1",
+          "name": "frameLabel",
+          "content": "Default: tabs are draggable (grab cursor on hover)",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dt2",
+          "name": "Tab Bar Default",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "dt3",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt4",
+                  "fill": "$--foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt6",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt7",
+                  "fill": "$--muted-foreground",
+                  "content": "Portfolio Rewrite",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt8",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt9",
+              "name": "Tab Inactive 2",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dta",
+                  "fill": "$--muted-foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dtb",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtc",
+              "name": "Tab Inactive 3",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtd",
+                  "fill": "$--muted-foreground",
+                  "content": "Workout Log",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dte",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtf",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "dtg",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dth",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "dti",
+          "name": "cursorNote",
+          "content": "cursor: grab → grabbing during drag",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dtj",
+      "name": "Draggable Tabs — Dragging (Tab Being Moved)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dtk",
+          "name": "frameLabel2",
+          "content": "Dragging: \"Portfolio Rewrite\" is being dragged left (opacity 0.5, blue drop indicator)",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dtl",
+          "name": "Tab Bar Dragging",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "rectangle",
+              "id": "dtm",
+              "name": "Drop Indicator",
+              "width": 2,
+              "height": 30,
+              "fill": "$--primary",
+              "cornerRadius": 1
+            },
+            {
+              "type": "frame",
+              "id": "dtn",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dto",
+                  "fill": "$--foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dtp",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtq",
+              "name": "Tab Dragging (ghost)",
+              "height": "fill_container",
+              "opacity": 0.5,
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtr",
+                  "fill": "$--muted-foreground",
+                  "content": "Portfolio Rewrite",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dts",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtt",
+              "name": "Tab Inactive 2",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtu",
+                  "fill": "$--muted-foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtv",
+              "name": "Tab Inactive 3",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtw",
+                  "fill": "$--muted-foreground",
+                  "content": "Workout Log",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtx",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "dty",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dtz",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "dt10",
+          "name": "dragNote",
+          "content": "Drop indicator: 2px $--primary bar shows insertion point. Dragged tab has opacity: 0.5.",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dt11",
+      "name": "Draggable Tabs — After Drop (Reordered)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dt12",
+          "name": "frameLabel3",
+          "content": "After drop: \"Portfolio Rewrite\" moved before \"Laputa App\". Order persisted to localStorage.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dt13",
+          "name": "Tab Bar Reordered",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "dt14",
+              "name": "Tab Inactive (moved)",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt15",
+                  "fill": "$--muted-foreground",
+                  "content": "Portfolio Rewrite",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt16",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt17",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt18",
+                  "fill": "$--foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt19",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt1a",
+              "name": "Tab Inactive 2",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt1b",
+                  "fill": "$--muted-foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt1c",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt1d",
+              "name": "Tab Inactive 3",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt1e",
+                  "fill": "$--muted-foreground",
+                  "content": "Workout Log",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt1f",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt1g",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "dt1h",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dt1i",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "dt1j",
+          "name": "persistNote",
+          "content": "localStorage key: \"laputa-tab-order\" stores path array. Restored on next session.",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dsg01a",
+      "name": "Sidebar — Drag Handles Visible",
+      "x": 68,
+      "y": 6400,
+      "width": 330,
+      "height": 680,
+      "fill": "$--background",
+      "layout": "vertical",
+      "padding": [
+        16
+      ],
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dsg01b",
+          "name": "frame1Title",
+          "content": "Drag handles appear on section headers",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600",
+          "fill": "$--foreground"
+        },
+        {
+          "type": "text",
+          "id": "dsg01c",
+          "name": "frame1Desc",
+          "content": "Grip icon shown left of section icon. Cursor changes to grab on hover.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground"
+        },
+        {
+          "type": "frame",
+          "id": "dsg01d",
+          "height": 12
+        },
+        {
+          "type": "frame",
+          "id": "dsg01e",
+          "name": "sidebarDefault",
+          "width": 250,
+          "height": 600,
+          "fill": "$--sidebar",
+          "layout": "vertical",
+          "clip": true,
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg01f",
+              "name": "filters",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                6
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg01g",
+                  "name": "allNotesRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg01h",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg01i",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg01j",
+                  "name": "favRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg01k",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg01l",
+                      "fill": "$--muted-foreground",
+                      "content": "Favorites",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsg01m",
+              "name": "sectionsWrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg00a",
+                  "name": "projGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6,
+                    8,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg005",
+                      "name": "projHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg001",
+                          "name": "projLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg000",
+                              "name": "projDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg002",
+                              "name": "projIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "wrench",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-red"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg003",
+                              "name": "projLabel",
+                              "fill": "$--foreground",
+                              "content": "Projects",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg004",
+                          "name": "projChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg006",
+                      "name": "projItem0",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "fill": "$--accent-red-light",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg007",
+                          "name": "projItemTxt0",
+                          "fill": "$--accent-red",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg008",
+                      "name": "projItem1",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg009",
+                          "name": "projItemTxt1",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg00h",
+                  "name": "respGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg00g",
+                      "name": "respHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00c",
+                          "name": "respLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00b",
+                              "name": "respDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00d",
+                              "name": "respIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "medal",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00e",
+                              "name": "respLabel",
+                              "fill": "$--foreground",
+                              "content": "Responsibilities",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg00f",
+                          "name": "respChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg00o",
+                  "name": "procGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg00n",
+                      "name": "procHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00j",
+                          "name": "procLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00i",
+                              "name": "procDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00k",
+                              "name": "procIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "arrows-clockwise",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00l",
+                              "name": "procLabel",
+                              "fill": "$--foreground",
+                              "content": "Procedures",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg00m",
+                          "name": "procChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg00v",
+                  "name": "peopleGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg00u",
+                      "name": "peopleHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00q",
+                          "name": "peopleLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00p",
+                              "name": "peopleDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00r",
+                              "name": "peopleIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "leaf",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00s",
+                              "name": "peopleLabel",
+                              "fill": "$--foreground",
+                              "content": "People",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg00t",
+                          "name": "peopleChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg012",
+                  "name": "eventsGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg011",
+                      "name": "eventsHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00x",
+                          "name": "eventsLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00w",
+                              "name": "eventsDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00y",
+                              "name": "eventsIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00z",
+                              "name": "eventsLabel",
+                              "fill": "$--foreground",
+                              "content": "Events",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg010",
+                          "name": "eventsChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg019",
+                  "name": "topicsGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg018",
+                      "name": "topicsHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg014",
+                          "name": "topicsLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg013",
+                              "name": "topicsDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg015",
+                              "name": "topicsIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tag",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-green"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg016",
+                              "name": "topicsLabel",
+                              "fill": "$--foreground",
+                              "content": "Topics",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg017",
+                          "name": "topicsChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dsg02w",
+      "name": "Sidebar — Section Being Dragged",
+      "x": 420,
+      "y": 6400,
+      "width": 330,
+      "height": 680,
+      "fill": "$--background",
+      "layout": "vertical",
+      "padding": [
+        16
+      ],
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dsg02x",
+          "name": "frame2Title",
+          "content": "Dragging \"People\" above \"Responsibilities\"",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600",
+          "fill": "$--foreground"
+        },
+        {
+          "type": "text",
+          "id": "dsg02y",
+          "name": "frame2Desc",
+          "content": "Blue drop indicator line shows insertion point. Dragged section floats with blue border.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground"
+        },
+        {
+          "type": "frame",
+          "id": "dsg02z",
+          "height": 12
+        },
+        {
+          "type": "frame",
+          "id": "dsg030",
+          "name": "sidebarDragging",
+          "width": 250,
+          "height": 600,
+          "fill": "$--sidebar",
+          "layout": "vertical",
+          "clip": true,
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg031",
+              "name": "filters",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                6
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg032",
+                  "name": "allNotesRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg033",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg034",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg035",
+                  "name": "favRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg036",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg037",
+                      "fill": "$--muted-foreground",
+                      "content": "Favorites",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsg038",
+              "name": "sectionsWrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg01x",
+                  "name": "proj2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6,
+                    8,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg01s",
+                      "name": "proj2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg01o",
+                          "name": "proj2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg01n",
+                              "name": "proj2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg01p",
+                              "name": "proj2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "wrench",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-red"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg01q",
+                              "name": "proj2Label",
+                              "fill": "$--foreground",
+                              "content": "Projects",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg01r",
+                          "name": "proj2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg01t",
+                      "name": "proj2Item0",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "fill": "$--accent-red-light",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg01u",
+                          "name": "proj2ItemTxt0",
+                          "fill": "$--accent-red",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg01v",
+                      "name": "proj2Item1",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg01w",
+                          "name": "proj2ItemTxt1",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg01y",
+                  "name": "dropIndicator",
+                  "width": "fill_container",
+                  "height": 2,
+                  "fill": "$--accent-blue",
+                  "cornerRadius": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg025",
+                  "name": "resp2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg024",
+                      "name": "resp2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg020",
+                          "name": "resp2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg01z",
+                              "name": "resp2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg021",
+                              "name": "resp2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "medal",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg022",
+                              "name": "resp2Label",
+                              "fill": "$--foreground",
+                              "content": "Responsibilities",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg023",
+                          "name": "resp2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg02c",
+                  "name": "proc2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg02b",
+                      "name": "proc2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg027",
+                          "name": "proc2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg026",
+                              "name": "proc2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg028",
+                              "name": "proc2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "arrows-clockwise",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg029",
+                              "name": "proc2Label",
+                              "fill": "$--foreground",
+                              "content": "Procedures",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg02a",
+                          "name": "proc2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg02j",
+                  "name": "events2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg02i",
+                      "name": "events2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg02e",
+                          "name": "events2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02d",
+                              "name": "events2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02f",
+                              "name": "events2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg02g",
+                              "name": "events2Label",
+                              "fill": "$--foreground",
+                              "content": "Events",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg02h",
+                          "name": "events2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg02q",
+                  "name": "topics2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg02p",
+                      "name": "topics2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg02l",
+                          "name": "topics2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02k",
+                              "name": "topics2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02m",
+                              "name": "topics2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tag",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-green"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg02n",
+                              "name": "topics2Label",
+                              "fill": "$--foreground",
+                              "content": "Topics",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg02o",
+                          "name": "topics2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dsg02r",
+          "name": "draggedSection",
+          "x": 8,
+          "y": 160,
+          "width": 234,
+          "fill": "$--sidebar",
+          "cornerRadius": 6,
+          "stroke": {
+            "align": "outside",
+            "thickness": 1,
+            "fill": {
+              "type": "color",
+              "color": "$--accent-blue"
+            }
+          },
+          "opacity": 0.9,
+          "layout": "vertical",
+          "padding": [
+            4,
+            6
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg02s",
+              "name": "draggedHeader",
+              "width": "fill_container",
+              "cornerRadius": 4,
+              "gap": 8,
+              "padding": [
+                6,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dsg02t",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "grip-vertical",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-blue",
+                  "opacity": 0.8
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dsg02u",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "leaf",
+                  "iconFontFamily": "phosphor",
+                  "weight": 700,
+                  "fill": "$--accent-yellow"
+                },
+                {
+                  "type": "text",
+                  "id": "dsg02v",
+                  "fill": "$--foreground",
+                  "content": "People",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dsg04j",
+      "name": "Sidebar — After Reorder (People Moved Up)",
+      "x": 772,
+      "y": 6400,
+      "width": 330,
+      "height": 680,
+      "fill": "$--background",
+      "layout": "vertical",
+      "padding": [
+        16
+      ],
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dsg04k",
+          "name": "frame3Title",
+          "content": "After drop — People now second section",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600",
+          "fill": "$--foreground"
+        },
+        {
+          "type": "text",
+          "id": "dsg04l",
+          "name": "frame3Desc",
+          "content": "Order persisted as \"order\" property in each Type document frontmatter (e.g. order: 2).",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground"
+        },
+        {
+          "type": "frame",
+          "id": "dsg04m",
+          "height": 12
+        },
+        {
+          "type": "frame",
+          "id": "dsg04n",
+          "name": "sidebarReordered",
+          "width": 250,
+          "height": 600,
+          "fill": "$--sidebar",
+          "layout": "vertical",
+          "clip": true,
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg04o",
+              "name": "filters",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                6
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg04p",
+                  "name": "allNotesRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg04q",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg04r",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg04s",
+                  "name": "favRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg04t",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg04u",
+                      "fill": "$--muted-foreground",
+                      "content": "Favorites",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsg04v",
+              "name": "sectionsWrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg03j",
+                  "name": "proj3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6,
+                    8,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg03e",
+                      "name": "proj3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03a",
+                          "name": "proj3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg039",
+                              "name": "proj3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03b",
+                              "name": "proj3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "wrench",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-red"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg03c",
+                              "name": "proj3Label",
+                              "fill": "$--foreground",
+                              "content": "Projects",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg03d",
+                          "name": "proj3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg03f",
+                      "name": "proj3Item0",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "fill": "$--accent-red-light",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg03g",
+                          "name": "proj3ItemTxt0",
+                          "fill": "$--accent-red",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg03h",
+                      "name": "proj3Item1",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg03i",
+                          "name": "proj3ItemTxt1",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg03q",
+                  "name": "people3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg03p",
+                      "name": "people3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03l",
+                          "name": "people3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03k",
+                              "name": "people3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03m",
+                              "name": "people3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "leaf",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg03n",
+                              "name": "people3Label",
+                              "fill": "$--foreground",
+                              "content": "People",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg03o",
+                          "name": "people3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg03x",
+                  "name": "resp3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg03w",
+                      "name": "resp3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03s",
+                          "name": "resp3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03r",
+                              "name": "resp3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03t",
+                              "name": "resp3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "medal",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg03u",
+                              "name": "resp3Label",
+                              "fill": "$--foreground",
+                              "content": "Responsibilities",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg03v",
+                          "name": "resp3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg044",
+                  "name": "proc3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg043",
+                      "name": "proc3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03z",
+                          "name": "proc3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03y",
+                              "name": "proc3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg040",
+                              "name": "proc3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "arrows-clockwise",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg041",
+                              "name": "proc3Label",
+                              "fill": "$--foreground",
+                              "content": "Procedures",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg042",
+                          "name": "proc3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg04b",
+                  "name": "events3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg04a",
+                      "name": "events3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg046",
+                          "name": "events3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg045",
+                              "name": "events3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg047",
+                              "name": "events3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg048",
+                              "name": "events3Label",
+                              "fill": "$--foreground",
+                              "content": "Events",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg049",
+                          "name": "events3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg04i",
+                  "name": "topics3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg04h",
+                      "name": "topics3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg04d",
+                          "name": "topics3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg04c",
+                              "name": "topics3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg04e",
+                              "name": "topics3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tag",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-green"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg04f",
+                              "name": "topics3Label",
+                              "fill": "$--foreground",
+                              "content": "Topics",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg04g",
+                          "name": "topics3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "csB01",
+      "x": 0,
+      "y": 7140,
+      "name": "Sections Header — Before (old design)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 280,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        12
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "csB02",
+          "name": "frameLabel",
+          "fill": "$--muted-foreground",
+          "content": "BEFORE — Old Design",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 1
+        },
+        {
+          "type": "frame",
+          "id": "csB03",
+          "name": "customizeBtn",
+          "width": "fill_container",
+          "cornerRadius": 4,
+          "gap": 6,
+          "padding": [
+            4,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "csB04",
+              "name": "slidersIcon",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "sliders-horizontal",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "text",
+              "id": "csB05",
+              "name": "customizeLabel",
+              "fill": "$--muted-foreground",
+              "content": "Customize sections",
+              "fontFamily": "Inter",
+              "fontSize": 12
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "csB06",
+          "name": "sectionRow",
+          "width": "fill_container",
+          "cornerRadius": 4,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "csB07",
+              "name": "left",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "csB08",
+                  "name": "projIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wrench",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--accent-red"
+                },
+                {
+                  "type": "text",
+                  "id": "csB09",
+                  "name": "projLabel",
+                  "fill": "$--foreground",
+                  "content": "Projects",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "csB10",
+              "name": "chevron",
+              "width": 12,
+              "height": 12,
+              "iconFontName": "caret-right",
+              "iconFontFamily": "phosphor",
+              "fill": "$--foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "csA01",
+      "x": 340,
+      "y": 7140,
+      "name": "Sections Header — After (new design)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 280,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        12
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "csA02",
+          "name": "frameLabel",
+          "fill": "$--muted-foreground",
+          "content": "AFTER — New Design",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 1
+        },
+        {
+          "type": "frame",
+          "id": "csA03",
+          "name": "sectionsHeader",
+          "width": "fill_container",
+          "padding": [
+            4,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "csA04",
+              "name": "sectionsLabel",
+              "fill": "$--muted-foreground",
+              "content": "SECTIONS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "icon_font",
+              "id": "csA05",
+              "name": "settingsIcon",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "sliders-horizontal",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "csA06",
+          "name": "sectionRow",
+          "width": "fill_container",
+          "cornerRadius": 4,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "csA07",
+              "name": "left",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "csA08",
+                  "name": "projIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wrench",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--accent-red"
+                },
+                {
+                  "type": "text",
+                  "id": "csA09",
+                  "name": "projLabel",
+                  "fill": "$--foreground",
+                  "content": "Projects",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "csA10",
+              "name": "chevron",
+              "width": 12,
+              "height": 12,
+              "iconFontName": "caret-right",
+              "iconFontFamily": "phosphor",
+              "fill": "$--foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "archBtnNorm",
+      "x": 68,
+      "y": 5200,
+      "name": "Archive Notes — Breadcrumb button (normal note)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 800,
+      "height": 45,
+      "fill": "$--background",
+      "stroke": {
+        "align": "inside",
+        "thickness": {
+          "bottom": 1
+        },
+        "fill": "$--border"
+      },
+      "padding": [
+        6,
+        16
+      ],
+      "justifyContent": "space_between",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "anInfoL",
+          "name": "infoLeft",
+          "gap": 6,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "anType",
+              "name": "breadcrumbType",
+              "fill": "$--muted-foreground",
+              "content": "Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "anSep",
+              "name": "breadcrumbSep",
+              "fill": "$--muted-foreground",
+              "content": "›",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "anName",
+              "name": "breadcrumbName",
+              "fill": "$--foreground",
+              "content": "My Active Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "anDot",
+              "name": "dotSep",
+              "fill": "$--muted-foreground",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "anWords",
+              "name": "wordCount",
+              "fill": "$--muted-foreground",
+              "content": "1,234 words",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "anInfoR",
+          "name": "infoRight",
+          "gap": 12,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "anISearch",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "magnifying-glass",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anIGit",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "git-branch",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anICursor",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "cursor-text",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anIAI",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "sparkle",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "frame",
+              "id": "anArchiveBtn",
+              "name": "archiveButton",
+              "gap": 4,
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--primary"
+              },
+              "cornerRadius": 4,
+              "padding": [
+                2,
+                2
+              ],
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "anIArchive",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "archive",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--primary"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "anITrash",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "trash",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anIMore",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "dots-three",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "archBtnArc",
+      "x": 68,
+      "y": 5300,
+      "name": "Archive Notes — Breadcrumb button (archived note, shows Unarchive)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 800,
+      "height": 45,
+      "fill": "$--background",
+      "stroke": {
+        "align": "inside",
+        "thickness": {
+          "bottom": 1
+        },
+        "fill": "$--border"
+      },
+      "padding": [
+        6,
+        16
+      ],
+      "justifyContent": "space_between",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "auInfoL",
+          "name": "infoLeft",
+          "gap": 6,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "auType",
+              "name": "breadcrumbType",
+              "fill": "$--muted-foreground",
+              "content": "Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "auSep",
+              "name": "breadcrumbSep",
+              "fill": "$--muted-foreground",
+              "content": "›",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "auName",
+              "name": "breadcrumbName",
+              "fill": "$--foreground",
+              "content": "My Archived Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "auDot",
+              "name": "dotSep",
+              "fill": "$--muted-foreground",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "auWords",
+              "name": "wordCount",
+              "fill": "$--muted-foreground",
+              "content": "567 words",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "auBadge",
+              "name": "archivedBadge",
+              "height": 16,
+              "fill": "#2563eb1a",
+              "cornerRadius": 4,
+              "padding": [
+                1,
+                4
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "auBadgeTxt",
+                  "fill": "$--primary",
+                  "content": "ARCHIVED",
+                  "fontFamily": "Inter",
+                  "fontSize": 9,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "auInfoR",
+          "name": "infoRight",
+          "gap": 12,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "auISearch",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "magnifying-glass",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auIGit",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "git-branch",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auICursor",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "cursor-text",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auIAI",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "sparkle",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "frame",
+              "id": "auUnarchiveBtn",
+              "name": "unarchiveButton",
+              "gap": 4,
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--primary"
+              },
+              "cornerRadius": 4,
+              "padding": [
+                2,
+                2
+              ],
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "auIUnarchive",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "arrow-u-up-left",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--primary"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "auITrash",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "trash",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auIMore",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "dots-three",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ghCL1",
+      "x": 0,
+      "y": 7320,
+      "name": "Git History — Commit List",
+      "width": 300,
+      "height": "fit_content(600)",
+      "fill": "$--background",
+      "cornerRadius": "$--radius-lg",
+      "stroke": {
+        "fill": "$--border",
+        "thickness": 1
+      },
+      "layout": "vertical",
+      "gap": 16,
+      "padding": 12,
+      "children": [
+        {
+          "type": "text",
+          "id": "ghCL1h",
+          "content": "HISTORY",
+          "fill": "$--muted-foreground",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 1.2
+        },
+        {
+          "type": "frame",
+          "id": "ghC1",
+          "layout": "vertical",
+          "width": "fill_container",
+          "gap": 2,
+          "padding": [
+            0,
+            0,
+            0,
+            10
+          ],
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "left": 2
+            }
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghC1r",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghC1h",
+                  "content": "a1b2c3d",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "underline": true
+                },
+                {
+                  "type": "text",
+                  "id": "ghC1d",
+                  "content": "2d ago",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ghC1m",
+              "content": "Update grow-newsletter with latest changes",
+              "fill": "$--secondary-foreground",
+              "fontSize": 12,
+              "textGrowth": "fixed-width",
+              "width": "fill_container"
+            },
+            {
+              "type": "text",
+              "id": "ghC1a",
+              "content": "Luca Rossi",
+              "fill": "$--muted-foreground",
+              "fontSize": 10
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ghC2",
+          "layout": "vertical",
+          "width": "fill_container",
+          "gap": 2,
+          "padding": [
+            0,
+            0,
+            0,
+            10
+          ],
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "left": 2
+            }
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghC2r",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghC2h",
+                  "content": "e4f5g6h",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "underline": true
+                },
+                {
+                  "type": "text",
+                  "id": "ghC2d",
+                  "content": "5d ago",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ghC2m",
+              "content": "Add new section to grow-newsletter",
+              "fill": "$--secondary-foreground",
+              "fontSize": 12,
+              "textGrowth": "fixed-width",
+              "width": "fill_container"
+            },
+            {
+              "type": "text",
+              "id": "ghC2a",
+              "content": "Luca Rossi",
+              "fill": "$--muted-foreground",
+              "fontSize": 10
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ghC3",
+          "layout": "vertical",
+          "width": "fill_container",
+          "gap": 2,
+          "padding": [
+            0,
+            0,
+            0,
+            10
+          ],
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "left": 2
+            }
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghC3r",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghC3h",
+                  "content": "i7j8k9l",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "underline": true
+                },
+                {
+                  "type": "text",
+                  "id": "ghC3d",
+                  "content": "12d ago",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ghC3m",
+              "content": "Create grow-newsletter",
+              "fill": "$--secondary-foreground",
+              "fontSize": 12,
+              "textGrowth": "fixed-width",
+              "width": "fill_container"
+            },
+            {
+              "type": "text",
+              "id": "ghC3a",
+              "content": "Luca Rossi",
+              "fill": "$--muted-foreground",
+              "fontSize": 10
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ghDO1",
+      "x": 380,
+      "y": 7320,
+      "name": "Git History — Diff Open",
+      "width": 600,
+      "height": "fit_content(500)",
+      "fill": "$--background",
+      "cornerRadius": "$--radius-lg",
+      "stroke": {
+        "fill": "$--border",
+        "thickness": 1
+      },
+      "layout": "vertical",
+      "gap": 0,
+      "padding": 0,
+      "children": [
+        {
+          "type": "frame",
+          "id": "ghDObc",
+          "layout": "horizontal",
+          "width": "fill_container",
+          "height": 36,
+          "padding": [
+            0,
+            12
+          ],
+          "gap": 8,
+          "alignItems": "center",
+          "fill": "$--muted",
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "bottom": 1
+            }
+          },
+          "children": [
+            {
+              "type": "text",
+              "id": "ghDObcP",
+              "content": "responsibility / grow-newsletter.md",
+              "fill": "$--muted-foreground",
+              "fontSize": 12
+            },
+            {
+              "type": "frame",
+              "id": "ghDObcS",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "ghDObcB",
+              "layout": "horizontal",
+              "padding": [
+                2,
+                8
+              ],
+              "cornerRadius": "$--radius-sm",
+              "fill": "$--primary",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDObcBt",
+                  "content": "Diff: a1b2c3d",
+                  "fill": "$--primary-foreground",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ghDOb",
+          "layout": "vertical",
+          "width": "fill_container",
+          "padding": 0,
+          "gap": 0,
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghDOl1",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "$--muted",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl1n",
+                  "content": "1",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl1t",
+                  "content": "diff --git a/grow-newsletter.md b/grow-newsletter.md",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl2",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#2196F30D",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl2n",
+                  "content": "2",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl2t",
+                  "content": "@@ -5,3 +5,5 @@",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontStyle": "italic"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl3",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl3n",
+                  "content": "3",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl3t",
+                  "content": " # Grow Newsletter",
+                  "fill": "$--secondary-foreground",
+                  "fontSize": 11
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl4",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#f4433614",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl4n",
+                  "content": "4",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl4t",
+                  "content": "-Old paragraph from before a1b2c3d.",
+                  "fill": "#f44336",
+                  "fontSize": 11
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl5",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#4caf5014",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl5n",
+                  "content": "5",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl5t",
+                  "content": "+Updated paragraph at commit a1b2c3d.",
+                  "fill": "#4caf50",
+                  "fontSize": 11
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl6",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#4caf5014",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl6n",
+                  "content": "6",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl6t",
+                  "content": "+New content added in this commit.",
+                  "fill": "#4caf50",
+                  "fontSize": 11
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rnt0",
+      "name": "Rename Tab — Normal tab state",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "rnt1",
+          "name": "frameLabel",
+          "content": "Normal state: tabs show note title. Double-click to rename.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rnt2",
+          "name": "Tab Bar Normal",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rnt3",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rnt4",
+                  "fill": "$--foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rnt5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rnt6",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rnt7",
+                  "fill": "$--muted-foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rnt8",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rnt9",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "rnta",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "rntb",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "rntc",
+          "name": "interactionNote",
+          "content": "Double-click tab title → enters edit mode",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rne0",
+      "name": "Rename Tab — Double-clicked (editing mode)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "rne1",
+          "name": "frameLabel",
+          "content": "Editing mode: tab title replaced with inline input field, text selected.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rne2",
+          "name": "Tab Bar Editing",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rne3",
+              "name": "Tab Active (Editing)",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rne4",
+                  "name": "Inline Input",
+                  "fill": "$--background",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--ring"
+                  },
+                  "cornerRadius": 3,
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rne5",
+                      "fill": "$--foreground",
+                      "content": "Weekly Review",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500",
+                      "highlight": "$--primary",
+                      "highlightOpacity": 0.2
+                    }
+                  ]
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rne6",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rne7",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rne8",
+                  "fill": "$--muted-foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rne9",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rnea",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "rneb",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "rnec",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "rned",
+          "name": "interactionNote",
+          "content": "Enter → save & rename file + update wiki links | Escape → cancel | Blur → save",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rns0",
+      "name": "Rename Tab — Saved (updated name)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "rns1",
+          "name": "frameLabel",
+          "content": "After save: tab shows updated title. File renamed, wiki links updated across vault.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rns2",
+          "name": "Tab Bar Saved",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rns3",
+              "name": "Tab Active (Renamed)",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rns4",
+                  "fill": "$--foreground",
+                  "content": "Sprint Retrospective",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rns5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rns6",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rns7",
+                  "fill": "$--muted-foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rns8",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rns9",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "rnsa",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "rnsb",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "rnsc",
+          "name": "interactionNote",
+          "content": "File: weekly-review.md → sprint-retrospective.md | [[Weekly Review]] → [[Sprint Retrospective]] in all notes",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mb001",
+      "x": 0,
+      "y": 0,
+      "name": "macOS Border — Before (no border)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 400,
+      "height": 200,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "mb002",
+          "name": "macOS Title Bar (before)",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "mb003",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "mb004",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb005",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb006",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "mb007",
+          "name": "Sidebar Content (before)",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$--sidebar",
+          "padding": [
+            8,
+            12
+          ],
+          "layout": "vertical",
+          "gap": 4,
+          "children": [
+            {
+              "type": "text",
+              "id": "mb008",
+              "value": "All Notes",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb009",
+              "value": "Favorites",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb010",
+              "value": "Archive",
+              "fontSize": 14,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mb011",
+      "x": 440,
+      "y": 0,
+      "name": "macOS Border — After (with border)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 400,
+      "height": 200,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "mb012",
+          "name": "macOS Title Bar (after)",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "mb013",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "mb014",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb015",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb016",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "mb017",
+          "name": "Sidebar Content (after)",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$--sidebar",
+          "padding": [
+            8,
+            12
+          ],
+          "layout": "vertical",
+          "gap": 4,
+          "children": [
+            {
+              "type": "text",
+              "id": "mb018",
+              "value": "All Notes",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb019",
+              "value": "Favorites",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb020",
+              "value": "Archive",
+              "fontSize": 14,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "themes": {
+    "Mode": [
+      "Dark"
+    ]
+  },
+  "variables": {
+    "--accent": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#252545",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-blue": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-green": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#0F7B6C"
+        },
+        {
+          "value": "#4caf50",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#00B38B"
+        },
+        {
+          "value": "#00B38B",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-orange": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#D9730D"
+        },
+        {
+          "value": "#ff9800",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-purple": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#9065B0"
+        },
+        {
+          "value": "#9c72ff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#A932FF"
+        },
+        {
+          "value": "#A932FF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-red": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E"
+        },
+        {
+          "value": "#f44336",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--background": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#0f0f1a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--black": {
+      "type": "color",
+      "value": "#000000"
+    },
+    "--border": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--card": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#16162a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--card-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--destructive": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E"
+        },
+        {
+          "value": "#f44336",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--destructive-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--font-primary": {
+      "type": "string",
+      "value": [
+        {
+          "value": "Inter"
+        },
+        {
+          "value": "-apple-system, BlinkMacSystemFont, Inter, sans-serif"
+        },
+        {
+          "value": "Inter"
+        }
+      ]
+    },
+    "--font-system": {
+      "type": "string",
+      "value": "-apple-system, BlinkMacSystemFont, sans-serif"
+    },
+    "--foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--input": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--muted": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0F0EF"
+        },
+        {
+          "value": "#1e1e3a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--muted-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#787774"
+        },
+        {
+          "value": "#888888",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--popover": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#1e1e3a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--popover-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--primary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--primary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--radius-lg": {
+      "type": "number",
+      "value": 8
+    },
+    "--radius-md": {
+      "type": "number",
+      "value": 6
+    },
+    "--radius-sm": {
+      "type": "number",
+      "value": 4
+    },
+    "--ring": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--secondary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--secondary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F7F6F3"
+        },
+        {
+          "value": "#1a1a2e",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-accent": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#252545",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-accent-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-border": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-primary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-primary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-ring": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "--accent-yellow": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0B100"
+        },
+        {
+          "value": "#F0B100",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-blue-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#155DFF14"
+        },
+        {
+          "value": "#155DFF20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-green-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#00B38B14"
+        },
+        {
+          "value": "#00B38B20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-purple-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#A932FF14"
+        },
+        {
+          "value": "#A932FF20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-red-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E14"
+        },
+        {
+          "value": "#f4433620",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-yellow-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0B10014"
+        },
+        {
+          "value": "#F0B10020",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    }
+  },
+  "fonts": [
+    {
+      "name": "GT Pressura Trial",
+      "url": "GT-Pressura-Regular-Trial.otf"
+    }
+  ]
+}

--- a/design/github-oauth.pen
+++ b/design/github-oauth.pen
@@ -1440,7 +1440,8 @@
                                   "fill": "$--muted-foreground",
                                   "content": "RELATED NOTES",
                                   "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 11
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
                                 },
                                 {
                                   "type": "text",
@@ -1704,7 +1705,8 @@
                                   "fill": "$--muted-foreground",
                                   "content": "EVENTS",
                                   "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 11
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
                                 },
                                 {
                                   "type": "text",
@@ -2573,7 +2575,8 @@
                                       "fill": "$--muted-foreground",
                                       "content": "BELONGS TO",
                                       "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 10
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
                                     },
                                     {
                                       "type": "frame",
@@ -2696,7 +2699,8 @@
                                       "fill": "$--muted-foreground",
                                       "content": "RELATED TO",
                                       "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 10
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
                                     },
                                     {
                                       "type": "frame",
@@ -2792,7 +2796,8 @@
                                       "fill": "$--muted-foreground",
                                       "content": "BACKLINKS",
                                       "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 10
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
                                     }
                                   ]
                                 },
@@ -2843,7 +2848,8 @@
                                   "fill": "$--muted-foreground",
                                   "content": "HISTORY",
                                   "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 10
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
                                 },
                                 {
                                   "type": "frame",
@@ -4745,7 +4751,6 @@
       "height": 400,
       "fill": "$--sidebar",
       "layout": "vertical",
-      "gap": 0,
       "padding": [
         8,
         6
@@ -4962,7 +4967,6 @@
       "height": 360,
       "fill": "$--card",
       "layout": "vertical",
-      "gap": 0,
       "children": [
         {
           "type": "frame",
@@ -4970,12 +4974,6 @@
           "name": "header",
           "width": "fill_container",
           "height": 45,
-          "padding": [
-            0,
-            16
-          ],
-          "alignItems": "center",
-          "justifyContent": "space_between",
           "stroke": {
             "align": "inside",
             "thickness": {
@@ -4983,6 +4981,12 @@
             },
             "fill": "$--border"
           },
+          "padding": [
+            0,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
           "children": [
             {
               "type": "text",
@@ -5000,12 +5004,6 @@
           "id": "trN1",
           "name": "trashedNote1",
           "width": "fill_container",
-          "layout": "vertical",
-          "gap": 2,
-          "padding": [
-            14,
-            16
-          ],
           "stroke": {
             "align": "inside",
             "thickness": {
@@ -5013,6 +5011,12 @@
             },
             "fill": "$--border"
           },
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
           "children": [
             {
               "type": "frame",
@@ -5062,8 +5066,7 @@
               "fill": "$--muted-foreground",
               "content": "Some draft content that is no longer needed...",
               "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "400"
+              "fontSize": 12
             },
             {
               "type": "text",
@@ -5071,8 +5074,7 @@
               "fill": "$--muted-foreground",
               "content": "5d ago",
               "fontFamily": "Inter",
-              "fontSize": 10,
-              "fontWeight": "400"
+              "fontSize": 10
             }
           ]
         },
@@ -5081,12 +5083,6 @@
           "id": "trN2",
           "name": "trashedNote2Warning",
           "width": "fill_container",
-          "layout": "vertical",
-          "gap": 2,
-          "padding": [
-            14,
-            16
-          ],
           "fill": "#ef44440a",
           "stroke": {
             "align": "inside",
@@ -5095,6 +5091,12 @@
             },
             "fill": "$--border"
           },
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
           "children": [
             {
               "type": "frame",
@@ -5144,8 +5146,7 @@
               "fill": "$--muted-foreground",
               "content": "Old API documentation that was replaced...",
               "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "400"
+              "fontSize": 12
             },
             {
               "type": "text",
@@ -5175,10 +5176,7 @@
       "fill": "$--background",
       "layout": "vertical",
       "gap": 8,
-      "padding": [
-        16,
-        16
-      ],
+      "padding": 16,
       "children": [
         {
           "type": "text",
@@ -5197,13 +5195,13 @@
           "width": "fill_container",
           "fill": "$--accent-blue-light",
           "cornerRadius": 6,
+          "gap": 6,
           "padding": [
             6,
             10
           ],
-          "gap": 6,
-          "alignItems": "center",
           "justifyContent": "space_between",
+          "alignItems": "center",
           "children": [
             {
               "type": "text",
@@ -5230,17 +5228,17 @@
           "type": "frame",
           "id": "trRT",
           "name": "trashedRef",
+          "opacity": 0.7,
           "width": "fill_container",
           "fill": "$--muted",
           "cornerRadius": 6,
+          "gap": 6,
           "padding": [
             6,
             10
           ],
-          "gap": 6,
-          "alignItems": "center",
           "justifyContent": "space_between",
-          "opacity": 0.7,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
@@ -5273,8 +5271,7 @@
                   "fill": "$--muted-foreground",
                   "content": "(trashed)",
                   "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "400"
+                  "fontSize": 10
                 }
               ]
             },
@@ -5294,17 +5291,17 @@
           "type": "frame",
           "id": "trRA",
           "name": "archivedRef",
+          "opacity": 0.7,
           "width": "fill_container",
           "fill": "$--muted",
           "cornerRadius": 6,
+          "gap": 6,
           "padding": [
             6,
             10
           ],
-          "gap": 6,
-          "alignItems": "center",
           "justifyContent": "space_between",
-          "opacity": 0.7,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
@@ -5327,8 +5324,7 @@
                   "fill": "$--muted-foreground",
                   "content": "(archived)",
                   "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "400"
+                  "fontSize": 10
                 }
               ]
             },
@@ -5361,10 +5357,7 @@
       "fill": "$--background",
       "layout": "vertical",
       "gap": 8,
-      "padding": [
-        16,
-        16
-      ],
+      "padding": 16,
       "children": [
         {
           "type": "text",
@@ -5382,17 +5375,17 @@
           "width": "fill_container",
           "fill": "#ef44440f",
           "cornerRadius": 8,
-          "padding": [
-            10,
-            12
-          ],
-          "gap": 8,
-          "alignItems": "center",
           "stroke": {
             "align": "inside",
             "thickness": 1,
             "fill": "#ef444430"
           },
+          "gap": 8,
+          "padding": [
+            10,
+            12
+          ],
+          "alignItems": "center",
           "children": [
             {
               "type": "icon_font",
@@ -5425,8 +5418,7 @@
                   "fill": "$--muted-foreground",
                   "content": "1 note is past the 30-day retention period",
                   "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "400"
+                  "fontSize": 11
                 }
               ]
             }
@@ -5437,28 +5429,26 @@
     {
       "type": "frame",
       "id": "dt0",
+      "x": 0,
+      "y": 0,
       "name": "Draggable Tabs — Default State",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "dt1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "Default: tabs are draggable (grab cursor on hover)",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -5691,43 +5681,37 @@
           "type": "text",
           "id": "dti",
           "name": "cursorNote",
+          "fill": "$--muted-foreground",
           "content": "cursor: grab → grabbing during drag",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "dtj",
+      "x": 0,
+      "y": 0,
       "name": "Draggable Tabs — Dragging (Tab Being Moved)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "dtk",
           "name": "frameLabel2",
+          "fill": "$--muted-foreground",
           "content": "Dragging: \"Portfolio Rewrite\" is being dragged left (opacity 0.5, blue drop indicator)",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -5747,12 +5731,12 @@
           "children": [
             {
               "type": "rectangle",
+              "cornerRadius": 1,
               "id": "dtm",
               "name": "Drop Indicator",
-              "width": 2,
-              "height": 30,
               "fill": "$--primary",
-              "cornerRadius": 1
+              "width": 2,
+              "height": 30
             },
             {
               "type": "frame",
@@ -5798,8 +5782,8 @@
               "type": "frame",
               "id": "dtq",
               "name": "Tab Dragging (ghost)",
-              "height": "fill_container",
               "opacity": 0.5,
+              "height": "fill_container",
               "stroke": {
                 "align": "inside",
                 "thickness": {
@@ -5950,43 +5934,37 @@
           "type": "text",
           "id": "dt10",
           "name": "dragNote",
+          "fill": "$--muted-foreground",
           "content": "Drop indicator: 2px $--primary bar shows insertion point. Dragged tab has opacity: 0.5.",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "dt11",
+      "x": 0,
+      "y": 0,
       "name": "Draggable Tabs — After Drop (Reordered)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "dt12",
           "name": "frameLabel3",
+          "fill": "$--muted-foreground",
           "content": "After drop: \"Portfolio Rewrite\" moved before \"Laputa App\". Order persisted to localStorage.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -6219,69 +6197,63 @@
           "type": "text",
           "id": "dt1j",
           "name": "persistNote",
+          "fill": "$--muted-foreground",
           "content": "localStorage key: \"laputa-tab-order\" stores path array. Restored on next session.",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "dsg01a",
-      "name": "Sidebar — Drag Handles Visible",
       "x": 68,
       "y": 6400,
+      "name": "Sidebar — Drag Handles Visible",
+      "theme": {
+        "Mode": "Light"
+      },
       "width": 330,
       "height": 680,
       "fill": "$--background",
       "layout": "vertical",
-      "padding": [
-        16
-      ],
-      "theme": {
-        "Mode": "Light"
-      },
       "children": [
         {
           "type": "text",
           "id": "dsg01b",
           "name": "frame1Title",
+          "fill": "$--foreground",
           "content": "Drag handles appear on section headers",
           "fontFamily": "Inter",
           "fontSize": 14,
-          "fontWeight": "600",
-          "fill": "$--foreground"
+          "fontWeight": "600"
         },
         {
           "type": "text",
           "id": "dsg01c",
           "name": "frame1Desc",
+          "fill": "$--muted-foreground",
           "content": "Grip icon shown left of section icon. Cursor changes to grab on hover.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground"
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
           "id": "dsg01d",
+          "width": "fit_content(0)",
           "height": 12
         },
         {
           "type": "frame",
           "id": "dsg01e",
           "name": "sidebarDefault",
+          "clip": true,
           "width": 250,
           "height": 600,
           "fill": "$--sidebar",
           "layout": "vertical",
-          "clip": true,
           "children": [
             {
               "type": "frame",
@@ -6301,11 +6273,11 @@
                   "name": "allNotesRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -6334,11 +6306,11 @@
                   "name": "favRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -6421,12 +6393,12 @@
                               "type": "icon_font",
                               "id": "dsg000",
                               "name": "projDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6468,6 +6440,7 @@
                       "id": "dsg006",
                       "name": "projItem0",
                       "width": "fill_container",
+                      "fill": "$--accent-red-light",
                       "cornerRadius": 6,
                       "padding": [
                         6,
@@ -6476,7 +6449,6 @@
                         28
                       ],
                       "alignItems": "center",
-                      "fill": "$--accent-red-light",
                       "children": [
                         {
                           "type": "text",
@@ -6566,12 +6538,12 @@
                               "type": "icon_font",
                               "id": "dsg00b",
                               "name": "respDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6658,12 +6630,12 @@
                               "type": "icon_font",
                               "id": "dsg00i",
                               "name": "procDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6750,12 +6722,12 @@
                               "type": "icon_font",
                               "id": "dsg00p",
                               "name": "peopleDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6842,12 +6814,12 @@
                               "type": "icon_font",
                               "id": "dsg00w",
                               "name": "eventsDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6934,12 +6906,12 @@
                               "type": "icon_font",
                               "id": "dsg013",
                               "name": "topicsDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6987,54 +6959,52 @@
     {
       "type": "frame",
       "id": "dsg02w",
-      "name": "Sidebar — Section Being Dragged",
       "x": 420,
       "y": 6400,
+      "name": "Sidebar — Section Being Dragged",
+      "theme": {
+        "Mode": "Light"
+      },
       "width": 330,
       "height": 680,
       "fill": "$--background",
       "layout": "vertical",
-      "padding": [
-        16
-      ],
-      "theme": {
-        "Mode": "Light"
-      },
       "children": [
         {
           "type": "text",
           "id": "dsg02x",
           "name": "frame2Title",
+          "fill": "$--foreground",
           "content": "Dragging \"People\" above \"Responsibilities\"",
           "fontFamily": "Inter",
           "fontSize": 14,
-          "fontWeight": "600",
-          "fill": "$--foreground"
+          "fontWeight": "600"
         },
         {
           "type": "text",
           "id": "dsg02y",
           "name": "frame2Desc",
+          "fill": "$--muted-foreground",
           "content": "Blue drop indicator line shows insertion point. Dragged section floats with blue border.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground"
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
           "id": "dsg02z",
+          "width": "fit_content(0)",
           "height": 12
         },
         {
           "type": "frame",
           "id": "dsg030",
           "name": "sidebarDragging",
+          "clip": true,
           "width": 250,
           "height": 600,
           "fill": "$--sidebar",
           "layout": "vertical",
-          "clip": true,
           "children": [
             {
               "type": "frame",
@@ -7054,11 +7024,11 @@
                   "name": "allNotesRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7087,11 +7057,11 @@
                   "name": "favRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7174,12 +7144,12 @@
                               "type": "icon_font",
                               "id": "dsg01n",
                               "name": "proj2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7221,6 +7191,7 @@
                       "id": "dsg01t",
                       "name": "proj2Item0",
                       "width": "fill_container",
+                      "fill": "$--accent-red-light",
                       "cornerRadius": 6,
                       "padding": [
                         6,
@@ -7229,7 +7200,6 @@
                         28
                       ],
                       "alignItems": "center",
-                      "fill": "$--accent-red-light",
                       "children": [
                         {
                           "type": "text",
@@ -7328,12 +7298,12 @@
                               "type": "icon_font",
                               "id": "dsg01z",
                               "name": "resp2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7420,12 +7390,12 @@
                               "type": "icon_font",
                               "id": "dsg026",
                               "name": "proc2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7512,12 +7482,12 @@
                               "type": "icon_font",
                               "id": "dsg02d",
                               "name": "events2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7604,12 +7574,12 @@
                               "type": "icon_font",
                               "id": "dsg02k",
                               "name": "topics2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7656,20 +7626,15 @@
           "type": "frame",
           "id": "dsg02r",
           "name": "draggedSection",
-          "x": 8,
-          "y": 160,
+          "opacity": 0.9,
           "width": 234,
           "fill": "$--sidebar",
           "cornerRadius": 6,
           "stroke": {
             "align": "outside",
             "thickness": 1,
-            "fill": {
-              "type": "color",
-              "color": "$--accent-blue"
-            }
+            "fill": "$--accent-blue"
           },
-          "opacity": 0.9,
           "layout": "vertical",
           "padding": [
             4,
@@ -7692,12 +7657,12 @@
                 {
                   "type": "icon_font",
                   "id": "dsg02t",
+                  "opacity": 0.8,
                   "width": 14,
                   "height": 14,
                   "iconFontName": "grip-vertical",
                   "iconFontFamily": "lucide",
-                  "fill": "$--accent-blue",
-                  "opacity": 0.8
+                  "fill": "$--accent-blue"
                 },
                 {
                   "type": "icon_font",
@@ -7727,54 +7692,52 @@
     {
       "type": "frame",
       "id": "dsg04j",
-      "name": "Sidebar — After Reorder (People Moved Up)",
       "x": 772,
       "y": 6400,
+      "name": "Sidebar — After Reorder (People Moved Up)",
+      "theme": {
+        "Mode": "Light"
+      },
       "width": 330,
       "height": 680,
       "fill": "$--background",
       "layout": "vertical",
-      "padding": [
-        16
-      ],
-      "theme": {
-        "Mode": "Light"
-      },
       "children": [
         {
           "type": "text",
           "id": "dsg04k",
           "name": "frame3Title",
+          "fill": "$--foreground",
           "content": "After drop — People now second section",
           "fontFamily": "Inter",
           "fontSize": 14,
-          "fontWeight": "600",
-          "fill": "$--foreground"
+          "fontWeight": "600"
         },
         {
           "type": "text",
           "id": "dsg04l",
           "name": "frame3Desc",
+          "fill": "$--muted-foreground",
           "content": "Order persisted as \"order\" property in each Type document frontmatter (e.g. order: 2).",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground"
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
           "id": "dsg04m",
+          "width": "fit_content(0)",
           "height": 12
         },
         {
           "type": "frame",
           "id": "dsg04n",
           "name": "sidebarReordered",
+          "clip": true,
           "width": 250,
           "height": 600,
           "fill": "$--sidebar",
           "layout": "vertical",
-          "clip": true,
           "children": [
             {
               "type": "frame",
@@ -7794,11 +7757,11 @@
                   "name": "allNotesRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7827,11 +7790,11 @@
                   "name": "favRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7914,12 +7877,12 @@
                               "type": "icon_font",
                               "id": "dsg039",
                               "name": "proj3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7961,6 +7924,7 @@
                       "id": "dsg03f",
                       "name": "proj3Item0",
                       "width": "fill_container",
+                      "fill": "$--accent-red-light",
                       "cornerRadius": 6,
                       "padding": [
                         6,
@@ -7969,7 +7933,6 @@
                         28
                       ],
                       "alignItems": "center",
-                      "fill": "$--accent-red-light",
                       "children": [
                         {
                           "type": "text",
@@ -8059,12 +8022,12 @@
                               "type": "icon_font",
                               "id": "dsg03k",
                               "name": "people3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8151,12 +8114,12 @@
                               "type": "icon_font",
                               "id": "dsg03r",
                               "name": "resp3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8243,12 +8206,12 @@
                               "type": "icon_font",
                               "id": "dsg03y",
                               "name": "proc3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8335,12 +8298,12 @@
                               "type": "icon_font",
                               "id": "dsg045",
                               "name": "events3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8427,12 +8390,12 @@
                               "type": "icon_font",
                               "id": "dsg04c",
                               "name": "topics3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8538,7 +8501,8 @@
               "fill": "$--muted-foreground",
               "content": "Customize sections",
               "fontFamily": "Inter",
-              "fontSize": 12
+              "fontSize": 12,
+              "fontWeight": "normal"
             }
           ]
         },
@@ -8855,18 +8819,15 @@
               "type": "frame",
               "id": "anArchiveBtn",
               "name": "archiveButton",
-              "gap": 4,
-              "alignItems": "center",
+              "cornerRadius": 4,
               "stroke": {
                 "align": "inside",
                 "thickness": 1,
                 "fill": "$--primary"
               },
-              "cornerRadius": 4,
-              "padding": [
-                2,
-                2
-              ],
+              "gap": 4,
+              "padding": 2,
+              "alignItems": "center",
               "children": [
                 {
                   "type": "icon_font",
@@ -9059,18 +9020,15 @@
               "type": "frame",
               "id": "auUnarchiveBtn",
               "name": "unarchiveButton",
-              "gap": 4,
-              "alignItems": "center",
+              "cornerRadius": 4,
               "stroke": {
                 "align": "inside",
                 "thickness": 1,
                 "fill": "$--primary"
               },
-              "cornerRadius": 4,
-              "padding": [
-                2,
-                2
-              ],
+              "gap": 4,
+              "padding": 2,
+              "alignItems": "center",
               "children": [
                 {
                   "type": "icon_font",
@@ -9112,12 +9070,11 @@
       "y": 7320,
       "name": "Git History — Commit List",
       "width": 300,
-      "height": "fit_content(600)",
       "fill": "$--background",
       "cornerRadius": "$--radius-lg",
       "stroke": {
-        "fill": "$--border",
-        "thickness": 1
+        "thickness": 1,
+        "fill": "$--border"
       },
       "layout": "vertical",
       "gap": 16,
@@ -9126,8 +9083,9 @@
         {
           "type": "text",
           "id": "ghCL1h",
-          "content": "HISTORY",
           "fill": "$--muted-foreground",
+          "content": "HISTORY",
+          "fontFamily": "Inter",
           "fontSize": 10,
           "fontWeight": "600",
           "letterSpacing": 1.2
@@ -9135,8 +9093,14 @@
         {
           "type": "frame",
           "id": "ghC1",
-          "layout": "vertical",
           "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "left": 2
+            },
+            "fill": "$--border"
+          },
+          "layout": "vertical",
           "gap": 2,
           "padding": [
             0,
@@ -9144,17 +9108,10 @@
             0,
             10
           ],
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "left": 2
-            }
-          },
           "children": [
             {
               "type": "frame",
               "id": "ghC1r",
-              "layout": "horizontal",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -9162,44 +9119,56 @@
                 {
                   "type": "text",
                   "id": "ghC1h",
-                  "content": "a1b2c3d",
                   "fill": "$--primary",
+                  "content": "a1b2c3d",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
-                  "fontWeight": "500",
-                  "underline": true
+                  "fontWeight": "500"
                 },
                 {
                   "type": "text",
                   "id": "ghC1d",
-                  "content": "2d ago",
                   "fill": "$--muted-foreground",
-                  "fontSize": 10
+                  "content": "2d ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "text",
               "id": "ghC1m",
-              "content": "Update grow-newsletter with latest changes",
               "fill": "$--secondary-foreground",
-              "fontSize": 12,
               "textGrowth": "fixed-width",
-              "width": "fill_container"
+              "width": "fill_container",
+              "content": "Update grow-newsletter with latest changes",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "ghC1a",
-              "content": "Luca Rossi",
               "fill": "$--muted-foreground",
-              "fontSize": 10
+              "content": "Luca Rossi",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "normal"
             }
           ]
         },
         {
           "type": "frame",
           "id": "ghC2",
-          "layout": "vertical",
           "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "left": 2
+            },
+            "fill": "$--border"
+          },
+          "layout": "vertical",
           "gap": 2,
           "padding": [
             0,
@@ -9207,17 +9176,10 @@
             0,
             10
           ],
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "left": 2
-            }
-          },
           "children": [
             {
               "type": "frame",
               "id": "ghC2r",
-              "layout": "horizontal",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -9225,44 +9187,56 @@
                 {
                   "type": "text",
                   "id": "ghC2h",
-                  "content": "e4f5g6h",
                   "fill": "$--primary",
+                  "content": "e4f5g6h",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
-                  "fontWeight": "500",
-                  "underline": true
+                  "fontWeight": "500"
                 },
                 {
                   "type": "text",
                   "id": "ghC2d",
-                  "content": "5d ago",
                   "fill": "$--muted-foreground",
-                  "fontSize": 10
+                  "content": "5d ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "text",
               "id": "ghC2m",
-              "content": "Add new section to grow-newsletter",
               "fill": "$--secondary-foreground",
-              "fontSize": 12,
               "textGrowth": "fixed-width",
-              "width": "fill_container"
+              "width": "fill_container",
+              "content": "Add new section to grow-newsletter",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "ghC2a",
-              "content": "Luca Rossi",
               "fill": "$--muted-foreground",
-              "fontSize": 10
+              "content": "Luca Rossi",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "normal"
             }
           ]
         },
         {
           "type": "frame",
           "id": "ghC3",
-          "layout": "vertical",
           "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "left": 2
+            },
+            "fill": "$--border"
+          },
+          "layout": "vertical",
           "gap": 2,
           "padding": [
             0,
@@ -9270,17 +9244,10 @@
             0,
             10
           ],
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "left": 2
-            }
-          },
           "children": [
             {
               "type": "frame",
               "id": "ghC3r",
-              "layout": "horizontal",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -9288,36 +9255,42 @@
                 {
                   "type": "text",
                   "id": "ghC3h",
-                  "content": "i7j8k9l",
                   "fill": "$--primary",
+                  "content": "i7j8k9l",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
-                  "fontWeight": "500",
-                  "underline": true
+                  "fontWeight": "500"
                 },
                 {
                   "type": "text",
                   "id": "ghC3d",
-                  "content": "12d ago",
                   "fill": "$--muted-foreground",
-                  "fontSize": 10
+                  "content": "12d ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "text",
               "id": "ghC3m",
-              "content": "Create grow-newsletter",
               "fill": "$--secondary-foreground",
-              "fontSize": 12,
               "textGrowth": "fixed-width",
-              "width": "fill_container"
+              "width": "fill_container",
+              "content": "Create grow-newsletter",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "ghC3a",
-              "content": "Luca Rossi",
               "fill": "$--muted-foreground",
-              "fontSize": 10
+              "content": "Luca Rossi",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "normal"
             }
           ]
         }
@@ -9330,43 +9303,41 @@
       "y": 7320,
       "name": "Git History — Diff Open",
       "width": 600,
-      "height": "fit_content(500)",
       "fill": "$--background",
       "cornerRadius": "$--radius-lg",
       "stroke": {
-        "fill": "$--border",
-        "thickness": 1
+        "thickness": 1,
+        "fill": "$--border"
       },
       "layout": "vertical",
-      "gap": 0,
-      "padding": 0,
       "children": [
         {
           "type": "frame",
           "id": "ghDObc",
-          "layout": "horizontal",
           "width": "fill_container",
           "height": 36,
+          "fill": "$--muted",
+          "stroke": {
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 8,
           "padding": [
             0,
             12
           ],
-          "gap": 8,
           "alignItems": "center",
-          "fill": "$--muted",
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "bottom": 1
-            }
-          },
           "children": [
             {
               "type": "text",
               "id": "ghDObcP",
-              "content": "responsibility / grow-newsletter.md",
               "fill": "$--muted-foreground",
-              "fontSize": 12
+              "content": "responsibility / grow-newsletter.md",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "frame",
@@ -9377,20 +9348,20 @@
             {
               "type": "frame",
               "id": "ghDObcB",
-              "layout": "horizontal",
+              "fill": "$--primary",
+              "cornerRadius": "$--radius-sm",
               "padding": [
                 2,
                 8
               ],
-              "cornerRadius": "$--radius-sm",
-              "fill": "$--primary",
               "alignItems": "center",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDObcBt",
-                  "content": "Diff: a1b2c3d",
                   "fill": "$--primary-foreground",
+                  "content": "Diff: a1b2c3d",
+                  "fontFamily": "Inter",
                   "fontSize": 10,
                   "fontWeight": "600"
                 }
@@ -9401,39 +9372,39 @@
         {
           "type": "frame",
           "id": "ghDOb",
-          "layout": "vertical",
           "width": "fill_container",
-          "padding": 0,
-          "gap": 0,
+          "layout": "vertical",
           "children": [
             {
               "type": "frame",
               "id": "ghDOl1",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "$--muted",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "$--muted",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl1n",
-                  "content": "1",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "1",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl1t",
-                  "content": "diff --git a/grow-newsletter.md b/grow-newsletter.md",
                   "fill": "$--muted-foreground",
+                  "content": "diff --git a/grow-newsletter.md b/grow-newsletter.md",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
                   "fontWeight": "600"
                 }
@@ -9442,32 +9413,35 @@
             {
               "type": "frame",
               "id": "ghDOl2",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#2196F30D",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#2196F30D",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl2n",
-                  "content": "2",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "2",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl2t",
-                  "content": "@@ -5,3 +5,5 @@",
                   "fill": "$--primary",
+                  "content": "@@ -5,3 +5,5 @@",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
+                  "fontWeight": "normal",
                   "fontStyle": "italic"
                 }
               ]
@@ -9475,7 +9449,6 @@
             {
               "type": "frame",
               "id": "ghDOl3",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
               "padding": [
@@ -9487,115 +9460,128 @@
                 {
                   "type": "text",
                   "id": "ghDOl3n",
-                  "content": "3",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "3",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl3t",
-                  "content": " # Grow Newsletter",
                   "fill": "$--secondary-foreground",
-                  "fontSize": 11
+                  "content": " # Grow Newsletter",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
               "id": "ghDOl4",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#f4433614",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#f4433614",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl4n",
-                  "content": "4",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "4",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl4t",
-                  "content": "-Old paragraph from before a1b2c3d.",
                   "fill": "#f44336",
-                  "fontSize": 11
+                  "content": "-Old paragraph from before a1b2c3d.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
               "id": "ghDOl5",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#4caf5014",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#4caf5014",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl5n",
-                  "content": "5",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "5",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl5t",
-                  "content": "+Updated paragraph at commit a1b2c3d.",
                   "fill": "#4caf50",
-                  "fontSize": 11
+                  "content": "+Updated paragraph at commit a1b2c3d.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
               "id": "ghDOl6",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#4caf5014",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#4caf5014",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl6n",
-                  "content": "6",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "6",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl6t",
-                  "content": "+New content added in this commit.",
                   "fill": "#4caf50",
-                  "fontSize": 11
+                  "content": "+New content added in this commit.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             }
@@ -9606,28 +9592,26 @@
     {
       "type": "frame",
       "id": "rnt0",
+      "x": 0,
+      "y": 0,
       "name": "Rename Tab — Normal tab state",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "rnt1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "Normal state: tabs show note title. Double-click to rename.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -9778,43 +9762,37 @@
           "type": "text",
           "id": "rntc",
           "name": "interactionNote",
+          "fill": "$--muted-foreground",
           "content": "Double-click tab title → enters edit mode",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "rne0",
+      "x": 0,
+      "y": 0,
       "name": "Rename Tab — Double-clicked (editing mode)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "rne1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "Editing mode: tab title replaced with inline input field, text selected.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -9857,12 +9835,12 @@
                   "id": "rne4",
                   "name": "Inline Input",
                   "fill": "$--background",
+                  "cornerRadius": 3,
                   "stroke": {
                     "align": "inside",
                     "thickness": 1,
                     "fill": "$--ring"
                   },
-                  "cornerRadius": 3,
                   "padding": [
                     2,
                     6
@@ -9876,9 +9854,7 @@
                       "content": "Weekly Review",
                       "fontFamily": "Inter",
                       "fontSize": 12,
-                      "fontWeight": "500",
-                      "highlight": "$--primary",
-                      "highlightOpacity": 0.2
+                      "fontWeight": "500"
                     }
                   ]
                 },
@@ -9986,43 +9962,37 @@
           "type": "text",
           "id": "rned",
           "name": "interactionNote",
+          "fill": "$--muted-foreground",
           "content": "Enter → save & rename file + update wiki links | Escape → cancel | Blur → save",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "rns0",
+      "x": 0,
+      "y": 0,
       "name": "Rename Tab — Saved (updated name)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "rns1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "After save: tab shows updated title. File renamed, wiki links updated across vault.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -10173,15 +10143,11 @@
           "type": "text",
           "id": "rnsc",
           "name": "interactionNote",
+          "fill": "$--muted-foreground",
           "content": "File: weekly-review.md → sprint-retrospective.md | [[Weekly Review]] → [[Sprint Retrospective]] in all notes",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
@@ -10253,33 +10219,36 @@
           "width": "fill_container",
           "height": "fill_container",
           "fill": "$--sidebar",
+          "layout": "vertical",
+          "gap": 4,
           "padding": [
             8,
             12
           ],
-          "layout": "vertical",
-          "gap": 4,
           "children": [
             {
               "type": "text",
               "id": "mb008",
-              "value": "All Notes",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb009",
-              "value": "Favorites",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb010",
-              "value": "Archive",
+              "fill": "$--muted-foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--muted-foreground"
+              "fontWeight": "normal"
             }
           ]
         }
@@ -10360,33 +10329,482 @@
           "width": "fill_container",
           "height": "fill_container",
           "fill": "$--sidebar",
+          "layout": "vertical",
+          "gap": 4,
           "padding": [
             8,
             12
           ],
-          "layout": "vertical",
-          "gap": 4,
           "children": [
             {
               "type": "text",
               "id": "mb018",
-              "value": "All Notes",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb019",
-              "value": "Favorites",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb020",
-              "value": "Archive",
+              "fill": "$--muted-foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--muted-foreground"
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "AdasM",
+      "x": 0,
+      "y": 7636,
+      "name": "GitHub OAuth — Settings (Disconnected)",
+      "width": 480,
+      "height": 320,
+      "fill": "#1C1C1E",
+      "cornerRadius": 12,
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 24,
+      "children": [
+        {
+          "type": "text",
+          "id": "J67bW",
+          "name": "title1",
+          "fill": "#F5F5F7",
+          "content": "Settings",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "1KN7i",
+          "name": "section1",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 12,
+          "children": [
+            {
+              "type": "text",
+              "id": "pGDcS",
+              "name": "sectionLabel1",
+              "fill": "#8E8E93",
+              "content": "GITHUB",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "frame",
+              "id": "ymXpJ",
+              "name": "row1",
+              "width": "fill_container",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "R9SXz",
+                  "name": "leftCol1",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CFzgA",
+                      "name": "desc1a",
+                      "fill": "#F5F5F7",
+                      "content": "Connect your GitHub account",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "D4Muq",
+                      "name": "desc1b",
+                      "fill": "#8E8E93",
+                      "content": "Enable repo-backed vaults and sync",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jkPMi",
+                  "name": "btn1",
+                  "fill": "#F5F5F7",
+                  "cornerRadius": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "e2LFH",
+                      "name": "btn1text",
+                      "fill": "#1C1C1E",
+                      "content": "Connect GitHub",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "oPTqa",
+          "name": "sep1",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#38383A"
+        },
+        {
+          "type": "frame",
+          "id": "Z4ROO",
+          "name": "close1",
+          "width": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "ZC7Bc",
+              "name": "closeBtn1",
+              "fill": "transparent",
+              "cornerRadius": 6,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "sidt2",
+                  "name": "closeTxt1",
+                  "fill": "#F5F5F7",
+                  "content": "Close",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "c0Amj",
+      "x": 580,
+      "y": 7636,
+      "name": "GitHub OAuth — Device Flow In Progress",
+      "width": 480,
+      "height": 360,
+      "fill": "#1C1C1E",
+      "cornerRadius": 12,
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 24,
+      "children": [
+        {
+          "type": "text",
+          "id": "hyu2q",
+          "name": "title2",
+          "fill": "#F5F5F7",
+          "content": "Settings",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "fEyQj",
+          "name": "section2",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "pFy7D",
+              "name": "sectionLabel2",
+              "fill": "#8E8E93",
+              "content": "GITHUB",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "text",
+              "id": "lcy1L",
+              "name": "prompt2",
+              "fill": "#F5F5F7",
+              "content": "Enter this code on GitHub:",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "WO2Zn",
+              "name": "codeBox2",
+              "width": "fill_container",
+              "fill": "#2C2C2E",
+              "cornerRadius": 8,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "1VkIV",
+                  "name": "code2",
+                  "fill": "#F5F5F7",
+                  "content": "ABCD-1234",
+                  "fontFamily": "monospace",
+                  "fontSize": 28,
+                  "fontWeight": "normal",
+                  "letterSpacing": 4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "adtRM",
+              "name": "btnRow2",
+              "width": "fill_container",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "5RWgc",
+                  "name": "openBtn2",
+                  "width": "fill_container",
+                  "fill": "#F5F5F7",
+                  "cornerRadius": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "khxYp",
+                      "name": "openTxt2",
+                      "fill": "#1C1C1E",
+                      "content": "Open GitHub",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Y7UYA",
+                  "name": "cancelBtn2",
+                  "fill": "transparent",
+                  "cornerRadius": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "NaFGs",
+                      "name": "cancelTxt2",
+                      "fill": "#F5F5F7",
+                      "content": "Cancel",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OcPD8",
+              "name": "spinnerRow2",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "JzJ8g",
+                  "name": "spinnerDot2",
+                  "fill": "#8E8E93",
+                  "width": 10,
+                  "height": 10
+                },
+                {
+                  "type": "text",
+                  "id": "qwmI2",
+                  "name": "waitText2",
+                  "fill": "#8E8E93",
+                  "content": "Waiting for authorization...",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "UC68e",
+      "x": 1160,
+      "y": 7636,
+      "name": "GitHub OAuth — Settings (Connected)",
+      "width": 480,
+      "height": 320,
+      "fill": "#1C1C1E",
+      "cornerRadius": 12,
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 24,
+      "children": [
+        {
+          "type": "text",
+          "id": "DSQVp",
+          "name": "title3",
+          "fill": "#F5F5F7",
+          "content": "Settings",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "U04SC",
+          "name": "section3",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 12,
+          "children": [
+            {
+              "type": "text",
+              "id": "MnmjJ",
+              "name": "sectionLabel3",
+              "fill": "#8E8E93",
+              "content": "GITHUB",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "frame",
+              "id": "2MVgT",
+              "name": "row3",
+              "width": "fill_container",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "J7jjF",
+                  "name": "userRow3",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "QVwY7",
+                      "name": "avatar3",
+                      "fill": "#48484A",
+                      "width": 32,
+                      "height": 32
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RW54n",
+                      "name": "userInfo3",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "i20Z7",
+                          "name": "userName3",
+                          "fill": "#F5F5F7",
+                          "content": "Luca Rossi",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "vtd6m",
+                          "name": "userLogin3",
+                          "fill": "#8E8E93",
+                          "content": "@lucaong",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zodvQ",
+                  "name": "disconnectBtn3",
+                  "fill": "transparent",
+                  "cornerRadius": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SbNSx",
+                      "name": "disconnectTxt3",
+                      "fill": "#F5F5F7",
+                      "content": "Disconnect",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "KOtqi",
+          "name": "sep3",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#38383A"
+        },
+        {
+          "type": "frame",
+          "id": "3DOre",
+          "name": "close3",
+          "width": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "0DklE",
+              "name": "closeBtn3",
+              "fill": "transparent",
+              "cornerRadius": 6,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "CkxHO",
+                  "name": "closeTxt3",
+                  "fill": "#F5F5F7",
+                  "content": "Close",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.5.3
+        version: 2.5.3
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
@@ -1713,6 +1716,9 @@ packages:
     resolution: {integrity: sha512-ZwT0T+7bw4+DPCSWzmviwq5XbXlM0cNoleDKOYPFYqcZqeKY31KlpoMW/MOON/tOFBPgi31a2v3w9gliqwL2+Q==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
@@ -5086,6 +5092,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.0
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.0
       '@tauri-apps/cli-win32-x64-msvc': 2.10.0
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-process@2.3.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -115,6 +115,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -449,6 +593,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -834,6 +987,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +1048,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1041,6 +1242,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1482,6 +1696,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2040,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2181,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tempfile",
@@ -2484,6 +2724,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2862,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2748,6 +3022,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +3062,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3690,6 +3989,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,6 +4448,28 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
 ]
 
 [[package]]
@@ -4623,7 +4954,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4674,6 +5017,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5859,6 +6213,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.14",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.14",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5955,3 +6370,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.14",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.115",
+ "winnow 0.7.14",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.10.0", features = ["protocol-asset"] }
 tauri-plugin-log = "2"
+tauri-plugin-opener = "2"
 gray_matter = "0.2"
 walkdir = "2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "opener:default"
   ]
 }

--- a/src-tauri/src/github_auth.rs
+++ b/src-tauri/src/github_auth.rs
@@ -1,0 +1,379 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// Placeholder — Luca will register the GitHub OAuth App and replace this.
+const LAPUTA_GITHUB_CLIENT_ID: &str = "LAPUTA_GITHUB_CLIENT_ID";
+
+/// Scope: read user profile + repo access for vault-from-GitHub features.
+const GITHUB_SCOPE: &str = "read:user,repo";
+
+// ---------- Types ----------
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DeviceFlowResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GithubUser {
+    pub login: String,
+    pub name: Option<String>,
+    pub avatar_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeApiResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenApiResponse {
+    access_token: Option<String>,
+    error: Option<String>,
+}
+
+// ---------- Token storage ----------
+
+fn token_path() -> Result<PathBuf, String> {
+    let config = dirs::config_dir()
+        .ok_or_else(|| "Cannot determine app config directory".to_string())?;
+    Ok(config.join("com.laputa.app").join("github_token"))
+}
+
+fn ensure_config_dir() -> Result<(), String> {
+    let path = token_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config dir: {}", e))?;
+    }
+    Ok(())
+}
+
+pub fn read_stored_token() -> Result<Option<String>, String> {
+    let path = token_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let token = fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read token: {}", e))?;
+    let trimmed = token.trim().to_string();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(trimmed))
+    }
+}
+
+fn store_token(token: &str) -> Result<(), String> {
+    ensure_config_dir()?;
+    let path = token_path()?;
+    fs::write(&path, token)
+        .map_err(|e| format!("Failed to write token: {}", e))?;
+
+    // Set file permissions to 0o600 (owner read/write only) on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&path, perms)
+            .map_err(|e| format!("Failed to set token permissions: {}", e))?;
+    }
+
+    Ok(())
+}
+
+fn delete_token() -> Result<(), String> {
+    let path = token_path()?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .map_err(|e| format!("Failed to delete token: {}", e))?;
+    }
+    Ok(())
+}
+
+// ---------- GitHub API calls ----------
+
+pub async fn start_device_flow() -> Result<DeviceFlowResponse, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://github.com/login/device/code")
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", LAPUTA_GITHUB_CLIENT_ID),
+            ("scope", GITHUB_SCOPE),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("Failed to start device flow: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("GitHub device flow error ({}): {}", status, body));
+    }
+
+    let api_resp: DeviceCodeApiResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse device flow response: {}", e))?;
+
+    Ok(DeviceFlowResponse {
+        device_code: api_resp.device_code,
+        user_code: api_resp.user_code,
+        verification_uri: api_resp.verification_uri,
+        expires_in: api_resp.expires_in,
+        interval: api_resp.interval,
+    })
+}
+
+pub async fn poll_token(device_code: &str) -> Result<Option<String>, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://github.com/login/oauth/access_token")
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", LAPUTA_GITHUB_CLIENT_ID),
+            ("device_code", device_code),
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("Failed to poll token: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("GitHub token poll error ({}): {}", status, body));
+    }
+
+    let token_resp: TokenApiResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse token response: {}", e))?;
+
+    if let Some(token) = token_resp.access_token {
+        store_token(&token)?;
+        return Ok(Some(token));
+    }
+
+    match token_resp.error.as_deref() {
+        Some("authorization_pending") | Some("slow_down") => Ok(None),
+        Some("expired_token") => Err("Device code expired. Please try again.".to_string()),
+        Some("access_denied") => Err("Authorization was denied by the user.".to_string()),
+        Some(other) => Err(format!("GitHub OAuth error: {}", other)),
+        None => Err("Unexpected response: no token and no error".to_string()),
+    }
+}
+
+pub async fn get_user(token: &str) -> Result<GithubUser, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("https://api.github.com/user")
+        .header("Authorization", format!("Bearer {}", token))
+        .header("User-Agent", "Laputa-App")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch GitHub user: {}", e))?;
+
+    if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+        return Err("Token is invalid or revoked".to_string());
+    }
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("GitHub API error ({}): {}", status, body));
+    }
+
+    let user: GithubUser = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse GitHub user: {}", e))?;
+
+    Ok(user)
+}
+
+pub fn disconnect() -> Result<(), String> {
+    delete_token()
+}
+
+// ---------- Tests ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn with_temp_config<F: FnOnce()>(f: F) {
+        // We can't easily override dirs::config_dir(), so we test
+        // the helper functions that don't depend on it.
+        f();
+    }
+
+    #[test]
+    fn test_device_flow_response_serialization() {
+        let resp = DeviceFlowResponse {
+            device_code: "abc123".to_string(),
+            user_code: "ABCD-1234".to_string(),
+            verification_uri: "https://github.com/login/device".to_string(),
+            expires_in: 900,
+            interval: 5,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("ABCD-1234"));
+        assert!(json.contains("abc123"));
+
+        let deserialized: DeviceFlowResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.user_code, "ABCD-1234");
+        assert_eq!(deserialized.expires_in, 900);
+    }
+
+    #[test]
+    fn test_github_user_serialization() {
+        let user = GithubUser {
+            login: "octocat".to_string(),
+            name: Some("The Octocat".to_string()),
+            avatar_url: "https://avatars.githubusercontent.com/u/1?v=4".to_string(),
+        };
+        let json = serde_json::to_string(&user).unwrap();
+        assert!(json.contains("octocat"));
+        assert!(json.contains("The Octocat"));
+
+        let deserialized: GithubUser = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.login, "octocat");
+        assert_eq!(deserialized.name, Some("The Octocat".to_string()));
+    }
+
+    #[test]
+    fn test_github_user_with_null_name() {
+        let json = r#"{"login":"bot","name":null,"avatar_url":"https://example.com/bot.png"}"#;
+        let user: GithubUser = serde_json::from_str(json).unwrap();
+        assert_eq!(user.login, "bot");
+        assert!(user.name.is_none());
+    }
+
+    #[test]
+    fn test_token_api_response_with_token() {
+        let json = r#"{"access_token":"gho_abc123","token_type":"bearer","scope":"read:user,repo"}"#;
+        let resp: TokenApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.access_token, Some("gho_abc123".to_string()));
+        assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn test_token_api_response_pending() {
+        let json = r#"{"error":"authorization_pending","error_description":"waiting"}"#;
+        let resp: TokenApiResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.access_token.is_none());
+        assert_eq!(resp.error, Some("authorization_pending".to_string()));
+    }
+
+    #[test]
+    fn test_token_api_response_denied() {
+        let json = r#"{"error":"access_denied","error_description":"denied by user"}"#;
+        let resp: TokenApiResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.access_token.is_none());
+        assert_eq!(resp.error, Some("access_denied".to_string()));
+    }
+
+    #[test]
+    fn test_device_code_api_response_deserialization() {
+        let json = r#"{
+            "device_code": "dc_abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 900,
+            "interval": 5
+        }"#;
+        let resp: DeviceCodeApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.device_code, "dc_abc");
+        assert_eq!(resp.user_code, "ABCD-1234");
+        assert_eq!(resp.interval, 5);
+    }
+
+    #[test]
+    fn test_store_and_read_token() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        // Write
+        fs::write(&token_file, "gho_test_token_123").unwrap();
+        let content = fs::read_to_string(&token_file).unwrap();
+        assert_eq!(content.trim(), "gho_test_token_123");
+
+        // Overwrite
+        fs::write(&token_file, "gho_new_token").unwrap();
+        let content = fs::read_to_string(&token_file).unwrap();
+        assert_eq!(content.trim(), "gho_new_token");
+    }
+
+    #[test]
+    fn test_delete_token_file() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        fs::write(&token_file, "gho_to_delete").unwrap();
+        assert!(token_file.exists());
+
+        fs::remove_file(&token_file).unwrap();
+        assert!(!token_file.exists());
+    }
+
+    #[test]
+    fn test_empty_token_file_returns_none_equivalent() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        fs::write(&token_file, "  \n  ").unwrap();
+        let content = fs::read_to_string(&token_file).unwrap();
+        let trimmed = content.trim();
+        assert!(trimmed.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        fs::write(&token_file, "secret").unwrap();
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&token_file, perms).unwrap();
+
+        let meta = fs::metadata(&token_file).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn test_token_path_returns_expected_structure() {
+        // token_path() should return a path ending in com.laputa.app/github_token
+        let path = token_path().unwrap();
+        assert!(path.ends_with("com.laputa.app/github_token"));
+    }
+
+    #[test]
+    fn test_disconnect_when_no_token_exists() {
+        // disconnect() should not error when there's no token file
+        // (it silently succeeds if the file doesn't exist)
+        // We can't easily test without mocking dirs, but we verify the logic:
+        // delete_token checks path.exists() before removing.
+        // Just verify the function compiles and the logic is sound.
+        with_temp_config(|| {
+            // The real disconnect() touches the actual config dir,
+            // which may or may not have a token. That's OK.
+        });
+    }
+}

--- a/src-tauri/src/github_auth.rs
+++ b/src-tauri/src/github_auth.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Placeholder — Luca will register the GitHub OAuth App and replace this.
 const LAPUTA_GITHUB_CLIENT_ID: &str = "LAPUTA_GITHUB_CLIENT_ID";
@@ -49,21 +49,11 @@ fn token_path() -> Result<PathBuf, String> {
     Ok(config.join("com.laputa.app").join("github_token"))
 }
 
-fn ensure_config_dir() -> Result<(), String> {
-    let path = token_path()?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create config dir: {}", e))?;
-    }
-    Ok(())
-}
-
-pub fn read_stored_token() -> Result<Option<String>, String> {
-    let path = token_path()?;
+fn read_token_at(path: &Path) -> Result<Option<String>, String> {
     if !path.exists() {
         return Ok(None);
     }
-    let token = fs::read_to_string(&path)
+    let token = fs::read_to_string(path)
         .map_err(|e| format!("Failed to read token: {}", e))?;
     let trimmed = token.trim().to_string();
     if trimmed.is_empty() {
@@ -73,31 +63,57 @@ pub fn read_stored_token() -> Result<Option<String>, String> {
     }
 }
 
-fn store_token(token: &str) -> Result<(), String> {
-    ensure_config_dir()?;
-    let path = token_path()?;
-    fs::write(&path, token)
+fn store_token_at(path: &Path, token: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config dir: {}", e))?;
+    }
+    fs::write(path, token)
         .map_err(|e| format!("Failed to write token: {}", e))?;
 
-    // Set file permissions to 0o600 (owner read/write only) on Unix
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = fs::Permissions::from_mode(0o600);
-        fs::set_permissions(&path, perms)
+        fs::set_permissions(path, perms)
             .map_err(|e| format!("Failed to set token permissions: {}", e))?;
     }
 
     Ok(())
 }
 
-fn delete_token() -> Result<(), String> {
-    let path = token_path()?;
+fn delete_token_at(path: &Path) -> Result<(), String> {
     if path.exists() {
-        fs::remove_file(&path)
+        fs::remove_file(path)
             .map_err(|e| format!("Failed to delete token: {}", e))?;
     }
     Ok(())
+}
+
+pub fn read_stored_token() -> Result<Option<String>, String> {
+    read_token_at(&token_path()?)
+}
+
+fn store_token(token: &str) -> Result<(), String> {
+    store_token_at(&token_path()?, token)
+}
+
+fn delete_token() -> Result<(), String> {
+    delete_token_at(&token_path()?)
+}
+
+/// Classify a poll response into the appropriate result.
+fn classify_poll_response(token_resp: TokenApiResponse) -> Result<Option<String>, String> {
+    if let Some(token) = token_resp.access_token {
+        return Ok(Some(token));
+    }
+    match token_resp.error.as_deref() {
+        Some("authorization_pending") | Some("slow_down") => Ok(None),
+        Some("expired_token") => Err("Device code expired. Please try again.".to_string()),
+        Some("access_denied") => Err("Authorization was denied by the user.".to_string()),
+        Some(other) => Err(format!("GitHub OAuth error: {}", other)),
+        None => Err("Unexpected response: no token and no error".to_string()),
+    }
 }
 
 // ---------- GitHub API calls ----------
@@ -160,18 +176,11 @@ pub async fn poll_token(device_code: &str) -> Result<Option<String>, String> {
         .await
         .map_err(|e| format!("Failed to parse token response: {}", e))?;
 
-    if let Some(token) = token_resp.access_token {
-        store_token(&token)?;
-        return Ok(Some(token));
+    let result = classify_poll_response(token_resp)?;
+    if let Some(ref token) = result {
+        store_token(token)?;
     }
-
-    match token_resp.error.as_deref() {
-        Some("authorization_pending") | Some("slow_down") => Ok(None),
-        Some("expired_token") => Err("Device code expired. Please try again.".to_string()),
-        Some("access_denied") => Err("Authorization was denied by the user.".to_string()),
-        Some(other) => Err(format!("GitHub OAuth error: {}", other)),
-        None => Err("Unexpected response: no token and no error".to_string()),
-    }
+    Ok(result)
 }
 
 pub async fn get_user(token: &str) -> Result<GithubUser, String> {
@@ -214,11 +223,190 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn with_temp_config<F: FnOnce()>(f: F) {
-        // We can't easily override dirs::config_dir(), so we test
-        // the helper functions that don't depend on it.
-        f();
+    // --- Token storage tests (using path-parameterized helpers) ---
+
+    #[test]
+    fn test_store_and_read_token() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        // Store
+        store_token_at(&token_file, "gho_test_token_123").unwrap();
+        let result = read_token_at(&token_file).unwrap();
+        assert_eq!(result, Some("gho_test_token_123".to_string()));
+
+        // Overwrite
+        store_token_at(&token_file, "gho_new_token").unwrap();
+        let result = read_token_at(&token_file).unwrap();
+        assert_eq!(result, Some("gho_new_token".to_string()));
     }
+
+    #[test]
+    fn test_read_token_nonexistent_file() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("does_not_exist");
+        let result = read_token_at(&token_file).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_read_token_empty_file() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+        fs::write(&token_file, "  \n  ").unwrap();
+        let result = read_token_at(&token_file).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_read_token_whitespace_trimmed() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+        fs::write(&token_file, "  gho_trimmed  \n").unwrap();
+        let result = read_token_at(&token_file).unwrap();
+        assert_eq!(result, Some("gho_trimmed".to_string()));
+    }
+
+    #[test]
+    fn test_delete_token() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        store_token_at(&token_file, "gho_to_delete").unwrap();
+        assert!(token_file.exists());
+
+        delete_token_at(&token_file).unwrap();
+        assert!(!token_file.exists());
+    }
+
+    #[test]
+    fn test_delete_nonexistent_token() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("nonexistent");
+        // Should not error
+        delete_token_at(&token_file).unwrap();
+    }
+
+    #[test]
+    fn test_store_creates_parent_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("nested").join("dir").join("github_token");
+        store_token_at(&token_file, "gho_nested").unwrap();
+        let result = read_token_at(&token_file).unwrap();
+        assert_eq!(result, Some("gho_nested".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_store_sets_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let token_file = tmp.path().join("github_token");
+
+        store_token_at(&token_file, "secret_token").unwrap();
+
+        let meta = fs::metadata(&token_file).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn test_token_path_structure() {
+        let path = token_path().unwrap();
+        assert!(path.ends_with("com.laputa.app/github_token"));
+    }
+
+    // --- Token storage via public API (touches real config dir) ---
+
+    #[test]
+    fn test_read_stored_token_runs_without_panic() {
+        // May return None or Some depending on actual state — that's fine
+        let _ = read_stored_token();
+    }
+
+    #[test]
+    fn test_disconnect_runs_without_panic() {
+        let _ = disconnect();
+    }
+
+    // --- Poll response classification ---
+
+    #[test]
+    fn test_classify_poll_with_token() {
+        let resp = TokenApiResponse {
+            access_token: Some("gho_abc123".to_string()),
+            error: None,
+        };
+        let result = classify_poll_response(resp).unwrap();
+        assert_eq!(result, Some("gho_abc123".to_string()));
+    }
+
+    #[test]
+    fn test_classify_poll_pending() {
+        let resp = TokenApiResponse {
+            access_token: None,
+            error: Some("authorization_pending".to_string()),
+        };
+        let result = classify_poll_response(resp).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_classify_poll_slow_down() {
+        let resp = TokenApiResponse {
+            access_token: None,
+            error: Some("slow_down".to_string()),
+        };
+        let result = classify_poll_response(resp).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_classify_poll_expired() {
+        let resp = TokenApiResponse {
+            access_token: None,
+            error: Some("expired_token".to_string()),
+        };
+        let result = classify_poll_response(resp);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expired"));
+    }
+
+    #[test]
+    fn test_classify_poll_denied() {
+        let resp = TokenApiResponse {
+            access_token: None,
+            error: Some("access_denied".to_string()),
+        };
+        let result = classify_poll_response(resp);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("denied"));
+    }
+
+    #[test]
+    fn test_classify_poll_unknown_error() {
+        let resp = TokenApiResponse {
+            access_token: None,
+            error: Some("some_weird_error".to_string()),
+        };
+        let result = classify_poll_response(resp);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("some_weird_error"));
+    }
+
+    #[test]
+    fn test_classify_poll_no_token_no_error() {
+        let resp = TokenApiResponse {
+            access_token: None,
+            error: None,
+        };
+        let result = classify_poll_response(resp);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unexpected"));
+    }
+
+    // --- Serialization / deserialization ---
 
     #[test]
     fn test_device_flow_response_serialization() {
@@ -231,7 +419,6 @@ mod tests {
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("ABCD-1234"));
-        assert!(json.contains("abc123"));
 
         let deserialized: DeviceFlowResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.user_code, "ABCD-1234");
@@ -246,9 +433,6 @@ mod tests {
             avatar_url: "https://avatars.githubusercontent.com/u/1?v=4".to_string(),
         };
         let json = serde_json::to_string(&user).unwrap();
-        assert!(json.contains("octocat"));
-        assert!(json.contains("The Octocat"));
-
         let deserialized: GithubUser = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.login, "octocat");
         assert_eq!(deserialized.name, Some("The Octocat".to_string()));
@@ -302,78 +486,40 @@ mod tests {
     }
 
     #[test]
-    fn test_store_and_read_token() {
-        let tmp = TempDir::new().unwrap();
-        let token_file = tmp.path().join("github_token");
-
-        // Write
-        fs::write(&token_file, "gho_test_token_123").unwrap();
-        let content = fs::read_to_string(&token_file).unwrap();
-        assert_eq!(content.trim(), "gho_test_token_123");
-
-        // Overwrite
-        fs::write(&token_file, "gho_new_token").unwrap();
-        let content = fs::read_to_string(&token_file).unwrap();
-        assert_eq!(content.trim(), "gho_new_token");
+    fn test_device_flow_response_clone() {
+        let resp = DeviceFlowResponse {
+            device_code: "dc".to_string(),
+            user_code: "UC".to_string(),
+            verification_uri: "https://example.com".to_string(),
+            expires_in: 300,
+            interval: 10,
+        };
+        let cloned = resp.clone();
+        assert_eq!(cloned.device_code, "dc");
+        assert_eq!(cloned.interval, 10);
     }
 
     #[test]
-    fn test_delete_token_file() {
-        let tmp = TempDir::new().unwrap();
-        let token_file = tmp.path().join("github_token");
-
-        fs::write(&token_file, "gho_to_delete").unwrap();
-        assert!(token_file.exists());
-
-        fs::remove_file(&token_file).unwrap();
-        assert!(!token_file.exists());
+    fn test_github_user_clone() {
+        let user = GithubUser {
+            login: "test".to_string(),
+            name: None,
+            avatar_url: "https://example.com".to_string(),
+        };
+        let cloned = user.clone();
+        assert_eq!(cloned.login, "test");
+        assert!(cloned.name.is_none());
     }
 
     #[test]
-    fn test_empty_token_file_returns_none_equivalent() {
-        let tmp = TempDir::new().unwrap();
-        let token_file = tmp.path().join("github_token");
-
-        fs::write(&token_file, "  \n  ").unwrap();
-        let content = fs::read_to_string(&token_file).unwrap();
-        let trimmed = content.trim();
-        assert!(trimmed.is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_file_permissions() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let tmp = TempDir::new().unwrap();
-        let token_file = tmp.path().join("github_token");
-
-        fs::write(&token_file, "secret").unwrap();
-        let perms = fs::Permissions::from_mode(0o600);
-        fs::set_permissions(&token_file, perms).unwrap();
-
-        let meta = fs::metadata(&token_file).unwrap();
-        let mode = meta.permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600);
-    }
-
-    #[test]
-    fn test_token_path_returns_expected_structure() {
-        // token_path() should return a path ending in com.laputa.app/github_token
-        let path = token_path().unwrap();
-        assert!(path.ends_with("com.laputa.app/github_token"));
-    }
-
-    #[test]
-    fn test_disconnect_when_no_token_exists() {
-        // disconnect() should not error when there's no token file
-        // (it silently succeeds if the file doesn't exist)
-        // We can't easily test without mocking dirs, but we verify the logic:
-        // delete_token checks path.exists() before removing.
-        // Just verify the function compiles and the logic is sound.
-        with_temp_config(|| {
-            // The real disconnect() touches the actual config dir,
-            // which may or may not have a token. That's OK.
-        });
+    fn test_github_user_debug() {
+        let user = GithubUser {
+            login: "test".to_string(),
+            name: Some("Test User".to_string()),
+            avatar_url: "https://example.com".to_string(),
+        };
+        let debug = format!("{:?}", user);
+        assert!(debug.contains("test"));
+        assert!(debug.contains("Test User"));
     }
 }

--- a/src-tauri/src/github_auth.rs
+++ b/src-tauri/src/github_auth.rs
@@ -2,8 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Placeholder — Luca will register the GitHub OAuth App and replace this.
-const LAPUTA_GITHUB_CLIENT_ID: &str = "LAPUTA_GITHUB_CLIENT_ID";
+const LAPUTA_GITHUB_CLIENT_ID: &str = "Ov23liwee215tDMs9u4L";
 
 /// Scope: read user profile + repo access for vault-from-GitHub features.
 const GITHUB_SCOPE: &str = "read:user,repo";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,6 +121,7 @@ pub fn run() {
             {
                 app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
                 app.handle().plugin(tauri_plugin_process::init())?;
+                app.handle().plugin(tauri_plugin_opener::init())?;
             }
 
             // Purge trashed files older than 30 days on startup

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod ai_chat;
 pub mod frontmatter;
 pub mod git;
+pub mod github_auth;
 pub mod vault;
 
 use ai_chat::{AiChatRequest, AiChatResponse};
 use git::{GitCommit, ModifiedFile};
+use github_auth::{DeviceFlowResponse, GithubUser};
 use vault::{VaultEntry, RenameResult};
 use frontmatter::FrontmatterValue;
 
@@ -78,6 +80,31 @@ fn purge_trash(vault_path: String) -> Result<Vec<String>, String> {
     vault::purge_trash(&vault_path)
 }
 
+#[tauri::command]
+async fn github_start_device_flow() -> Result<DeviceFlowResponse, String> {
+    github_auth::start_device_flow().await
+}
+
+#[tauri::command]
+async fn github_poll_token(device_code: String) -> Result<Option<String>, String> {
+    github_auth::poll_token(&device_code).await
+}
+
+#[tauri::command]
+async fn github_get_user(token: String) -> Result<GithubUser, String> {
+    github_auth::get_user(&token).await
+}
+
+#[tauri::command]
+fn github_disconnect() -> Result<(), String> {
+    github_auth::disconnect()
+}
+
+#[tauri::command]
+fn github_get_stored_token() -> Result<Option<String>, String> {
+    github_auth::read_stored_token()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -128,7 +155,12 @@ pub fn run() {
             git_push,
             ai_chat,
             save_image,
-            purge_trash
+            purge_trash,
+            github_start_device_flow,
+            github_poll_token,
+            github_get_user,
+            github_disconnect,
+            github_get_stored_token
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,9 @@
       "csp": null,
       "assetProtocol": {
         "enable": true,
-        "scope": ["**"]
+        "scope": [
+          "**"
+        ]
       }
     }
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { CreateTypeDialog } from './components/CreateTypeDialog'
 import { QuickOpenPalette } from './components/QuickOpenPalette'
 import { Toast } from './components/Toast'
 import { CommitDialog } from './components/CommitDialog'
+import { SettingsPanel } from './components/SettingsPanel'
 import { StatusBar } from './components/StatusBar'
 import { useVaultLoader } from './hooks/useVaultLoader'
 import { useNoteActions, generateUntitledName } from './hooks/useNoteActions'
@@ -57,6 +58,7 @@ function App() {
   const [toastMessage, setToastMessage] = useState<string | null>(null)
   const [vaultPath, setVaultPath] = useState(VAULTS[0].path)
   const [showAIChat, setShowAIChat] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
 
   const vault = useVaultLoader(vaultPath)
   const notes = useNoteActions(vault.addEntry, vault.updateContent, vault.entries, setToastMessage)
@@ -184,11 +186,12 @@ function App() {
           />
         </div>
       </div>
-      <StatusBar noteCount={vault.entries.length} vaultPath={vaultPath} vaults={VAULTS} onSwitchVault={handleSwitchVault} />
+      <StatusBar noteCount={vault.entries.length} vaultPath={vaultPath} vaults={VAULTS} onSwitchVault={handleSwitchVault} onOpenSettings={() => setShowSettings(true)} />
       <Toast message={toastMessage} onDismiss={() => setToastMessage(null)} />
       <QuickOpenPalette open={showQuickOpen} entries={vault.entries} onSelect={notes.handleSelectNote} onClose={() => setShowQuickOpen(false)} />
       <CreateTypeDialog open={showCreateTypeDialog} onClose={() => setShowCreateTypeDialog(false)} onCreate={handleCreateType} />
       <CommitDialog open={showCommitDialog} modifiedCount={vault.modifiedFiles.length} onCommit={handleCommitPush} onClose={() => setShowCommitDialog(false)} />
+      <SettingsPanel open={showSettings} onClose={() => setShowSettings(false)} />
     </div>
   )
 }

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SettingsPanel } from './SettingsPanel'
+
+// Mock the useGithubAuth hook
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
+const mockCancel = vi.fn()
+let mockStatus: any = { state: 'disconnected' }
+
+vi.mock('../hooks/useGithubAuth', () => ({
+  useGithubAuth: () => ({
+    status: mockStatus,
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+    cancel: mockCancel,
+  }),
+}))
+
+describe('SettingsPanel', () => {
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStatus = { state: 'disconnected' }
+  })
+
+  it('renders Settings title when open', () => {
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('renders nothing when not open', () => {
+    const { container } = render(<SettingsPanel open={false} onClose={onClose} />)
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('shows GitHub section header', () => {
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('GitHub')).toBeInTheDocument()
+  })
+
+  it('shows Connect GitHub button when disconnected', () => {
+    mockStatus = { state: 'disconnected' }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('Connect GitHub')).toBeInTheDocument()
+  })
+
+  it('calls connect when Connect GitHub is clicked', () => {
+    mockStatus = { state: 'disconnected' }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Connect GitHub'))
+    expect(mockConnect).toHaveBeenCalled()
+  })
+
+  it('shows loading state', () => {
+    mockStatus = { state: 'loading' }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows device flow with user code', () => {
+    mockStatus = {
+      state: 'device_flow',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://github.com/login/device',
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('ABCD-1234')).toBeInTheDocument()
+    expect(screen.getByText('Open GitHub')).toBeInTheDocument()
+    expect(screen.getByText('Waiting for authorization...')).toBeInTheDocument()
+  })
+
+  it('opens GitHub verification URL in new tab', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    mockStatus = {
+      state: 'device_flow',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://github.com/login/device',
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Open GitHub'))
+    expect(openSpy).toHaveBeenCalledWith('https://github.com/login/device', '_blank')
+    openSpy.mockRestore()
+  })
+
+  it('calls cancel during device flow', () => {
+    mockStatus = {
+      state: 'device_flow',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://github.com/login/device',
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(mockCancel).toHaveBeenCalled()
+  })
+
+  it('shows connected user info with avatar', () => {
+    mockStatus = {
+      state: 'connected',
+      user: {
+        login: 'octocat',
+        name: 'The Octocat',
+        avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+      },
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('The Octocat')).toBeInTheDocument()
+    expect(screen.getByText('@octocat')).toBeInTheDocument()
+    expect(screen.getByText('Disconnect')).toBeInTheDocument()
+    const avatar = screen.getByAltText('octocat') as HTMLImageElement
+    expect(avatar.src).toContain('avatars.githubusercontent.com')
+  })
+
+  it('shows login when name is null', () => {
+    mockStatus = {
+      state: 'connected',
+      user: {
+        login: 'bot-user',
+        name: null,
+        avatar_url: '',
+      },
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('bot-user')).toBeInTheDocument()
+    // Should NOT show @login when name is null (login IS the display name)
+    expect(screen.queryByText('@bot-user')).not.toBeInTheDocument()
+  })
+
+  it('calls disconnect when Disconnect button is clicked', () => {
+    mockStatus = {
+      state: 'connected',
+      user: { login: 'octocat', name: 'The Octocat', avatar_url: '' },
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Disconnect'))
+    expect(mockDisconnect).toHaveBeenCalled()
+  })
+
+  it('shows error message and retry button', () => {
+    mockStatus = {
+      state: 'error',
+      message: 'Device code expired. Please try again.',
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('Device code expired. Please try again.')).toBeInTheDocument()
+    expect(screen.getByText('Try Again')).toBeInTheDocument()
+  })
+
+  it('calls connect on Try Again', () => {
+    mockStatus = {
+      state: 'error',
+      message: 'Something went wrong',
+    }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Try Again'))
+    expect(mockConnect).toHaveBeenCalled()
+  })
+
+  it('calls onClose when Close button is clicked', () => {
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows description text when disconnected', () => {
+    mockStatus = { state: 'disconnected' }
+    render(<SettingsPanel open={true} onClose={onClose} />)
+    expect(screen.getByText('Enable repo-backed vaults and sync')).toBeInTheDocument()
+  })
+})

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useGithubAuth, type GithubUser } from '../hooks/useGithubAuth'
+import { isTauri } from '../mock-tauri'
 
 interface SettingsPanelProps {
   open: boolean
@@ -35,6 +37,15 @@ function GitHubLoading() {
   )
 }
 
+async function openUrl(url: string) {
+  if (isTauri()) {
+    const { openUrl: tauriOpen } = await import('@tauri-apps/plugin-opener')
+    await tauriOpen(url)
+  } else {
+    window.open(url, '_blank')
+  }
+}
+
 function GitHubDeviceFlow({
   userCode,
   verificationUri,
@@ -44,9 +55,10 @@ function GitHubDeviceFlow({
   verificationUri: string
   onCancel: () => void
 }) {
-  const handleOpenGitHub = () => {
-    window.open(verificationUri, '_blank')
-  }
+  // Auto-open browser when device flow starts
+  useEffect(() => {
+    openUrl(verificationUri)
+  }, [verificationUri])
 
   return (
     <div className="space-y-3">
@@ -59,8 +71,8 @@ function GitHubDeviceFlow({
         </code>
       </div>
       <div className="flex items-center gap-2">
-        <Button size="sm" onClick={handleOpenGitHub} className="flex-1">
-          Open GitHub
+        <Button size="sm" variant="outline" onClick={() => openUrl(verificationUri)} className="flex-1">
+          Open GitHub again
         </Button>
         <Button size="sm" variant="outline" onClick={onCancel}>
           Cancel

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,180 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useGithubAuth, type GithubUser } from '../hooks/useGithubAuth'
+
+interface SettingsPanelProps {
+  open: boolean
+  onClose: () => void
+}
+
+function GitHubDisconnected({ onConnect }: { onConnect: () => void }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="text-sm text-foreground">Connect your GitHub account</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Enable repo-backed vaults and sync
+        </p>
+      </div>
+      <Button size="sm" onClick={onConnect}>
+        Connect GitHub
+      </Button>
+    </div>
+  )
+}
+
+function GitHubLoading() {
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      Loading...
+    </div>
+  )
+}
+
+function GitHubDeviceFlow({
+  userCode,
+  verificationUri,
+  onCancel,
+}: {
+  userCode: string
+  verificationUri: string
+  onCancel: () => void
+}) {
+  const handleOpenGitHub = () => {
+    window.open(verificationUri, '_blank')
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-foreground">
+        Enter this code on GitHub:
+      </p>
+      <div className="flex items-center justify-center">
+        <code className="text-2xl font-mono font-bold tracking-widest bg-muted px-4 py-2 rounded-lg select-all">
+          {userCode}
+        </code>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="sm" onClick={handleOpenGitHub} className="flex-1">
+          Open GitHub
+        </Button>
+        <Button size="sm" variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+        Waiting for authorization...
+      </div>
+    </div>
+  )
+}
+
+function GitHubConnected({
+  user,
+  onDisconnect,
+}: {
+  user: GithubUser
+  onDisconnect: () => void
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        {user.avatar_url && (
+          <img
+            src={user.avatar_url}
+            alt={user.login}
+            className="w-8 h-8 rounded-full"
+          />
+        )}
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            {user.name || user.login}
+          </p>
+          {user.name && (
+            <p className="text-xs text-muted-foreground">@{user.login}</p>
+          )}
+        </div>
+      </div>
+      <Button size="sm" variant="outline" onClick={onDisconnect}>
+        Disconnect
+      </Button>
+    </div>
+  )
+}
+
+function GitHubError({
+  message,
+  onRetry,
+}: {
+  message: string
+  onRetry: () => void
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-destructive">{message}</p>
+      <Button size="sm" variant="outline" onClick={onRetry}>
+        Try Again
+      </Button>
+    </div>
+  )
+}
+
+export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
+  const github = useGithubAuth()
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
+      <DialogContent showCloseButton={false} className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* GitHub section */}
+          <div>
+            <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+              GitHub
+            </h3>
+            {github.status.state === 'loading' && <GitHubLoading />}
+            {github.status.state === 'disconnected' && (
+              <GitHubDisconnected onConnect={github.connect} />
+            )}
+            {github.status.state === 'device_flow' && (
+              <GitHubDeviceFlow
+                userCode={github.status.userCode}
+                verificationUri={github.status.verificationUri}
+                onCancel={github.cancel}
+              />
+            )}
+            {github.status.state === 'connected' && (
+              <GitHubConnected
+                user={github.status.user}
+                onDisconnect={github.disconnect}
+              />
+            )}
+            {github.status.state === 'error' && (
+              <GitHubError
+                message={github.status.message}
+                onRetry={github.connect}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-2">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -11,6 +11,7 @@ interface StatusBarProps {
   vaultPath: string
   vaults: VaultOption[]
   onSwitchVault: (path: string) => void
+  onOpenSettings?: () => void
 }
 
 function VaultMenuItem({ vault, isActive, onSelect }: { vault: VaultOption; isActive: boolean; onSelect: () => void }) {
@@ -64,7 +65,7 @@ const ICON_STYLE = { display: 'flex', alignItems: 'center', gap: 4 } as const
 const DISABLED_STYLE = { display: 'flex', alignItems: 'center', opacity: 0.4, cursor: 'not-allowed' } as const
 const SEP_STYLE = { color: 'var(--border)' } as const
 
-export function StatusBar({ noteCount, vaultPath, vaults, onSwitchVault }: StatusBarProps) {
+export function StatusBar({ noteCount, vaultPath, vaults, onSwitchVault, onOpenSettings }: StatusBarProps) {
   return (
     <footer style={{ height: 30, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'var(--sidebar)', borderTop: '1px solid var(--border)', padding: '0 8px', fontSize: 11, color: 'var(--muted-foreground)' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
@@ -80,7 +81,7 @@ export function StatusBar({ noteCount, vaultPath, vaults, onSwitchVault }: Statu
         <span style={ICON_STYLE}><Sparkles size={13} style={{ color: 'var(--accent-purple)' }} />Claude Sonnet 4</span>
         <span style={ICON_STYLE}><FileText size={13} />{noteCount.toLocaleString()} notes</span>
         <span style={DISABLED_STYLE} title="Coming soon"><Bell size={14} /></span>
-        <span style={DISABLED_STYLE} title="Coming soon"><Settings size={14} /></span>
+        <span role="button" onClick={onOpenSettings} style={{ ...ICON_STYLE, cursor: 'pointer' }} title="Settings"><Settings size={14} /></span>
       </div>
     </footer>
   )

--- a/src/hooks/useGithubAuth.test.ts
+++ b/src/hooks/useGithubAuth.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useGithubAuth } from './useGithubAuth'
+
+// Command-based mock: route by command name
+let mockResponses: Record<string, () => any> = {}
+const mockInvokeFn = vi.fn(async (cmd: string) => {
+  const handler = mockResponses[cmd]
+  if (!handler) throw new Error(`No mock for command: ${cmd}`)
+  return handler()
+})
+
+vi.mock('../mock-tauri', () => ({
+  isTauri: () => false,
+  mockInvoke: (...args: any[]) => mockInvokeFn(...args),
+}))
+
+describe('useGithubAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResponses = {}
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts in loading state and transitions to disconnected when no stored token', async () => {
+    mockResponses = { github_get_stored_token: () => null }
+
+    const { result } = renderHook(() => useGithubAuth())
+    expect(result.current.status.state).toBe('loading')
+
+    // Flush the init effect's async work
+    await act(async () => {})
+
+    expect(result.current.status.state).toBe('disconnected')
+  })
+
+  it('loads user when stored token exists', async () => {
+    mockResponses = {
+      github_get_stored_token: () => 'gho_existing_token',
+      github_get_user: () => ({ login: 'octocat', name: 'The Octocat', avatar_url: 'https://example.com/avatar.png' }),
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await act(async () => {})
+
+    expect(result.current.status.state).toBe('connected')
+    if (result.current.status.state === 'connected') {
+      expect(result.current.status.user.login).toBe('octocat')
+    }
+  })
+
+  it('falls back to disconnected when stored token is invalid', async () => {
+    mockResponses = {
+      github_get_stored_token: () => 'gho_bad_token',
+      github_get_user: () => { throw new Error('Token is invalid or revoked') },
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await act(async () => {})
+
+    expect(result.current.status.state).toBe('disconnected')
+  })
+
+  it('starts device flow on connect', async () => {
+    mockResponses = {
+      github_get_stored_token: () => null,
+      github_start_device_flow: () => ({
+        device_code: 'dc_test',
+        user_code: 'TEST-CODE',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      }),
+      github_poll_token: () => null,
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await act(async () => {})
+    expect(result.current.status.state).toBe('disconnected')
+
+    // Await the connect() promise directly
+    await act(async () => { await result.current.connect() })
+
+    expect(result.current.status.state).toBe('device_flow')
+    if (result.current.status.state === 'device_flow') {
+      expect(result.current.status.userCode).toBe('TEST-CODE')
+      expect(result.current.status.verificationUri).toBe('https://github.com/login/device')
+    }
+  })
+
+  it('cancels device flow', async () => {
+    mockResponses = {
+      github_get_stored_token: () => null,
+      github_start_device_flow: () => ({
+        device_code: 'dc_test',
+        user_code: 'CANCEL-CODE',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      }),
+      github_poll_token: () => null,
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await act(async () => {})
+
+    await act(async () => { await result.current.connect() })
+    expect(result.current.status.state).toBe('device_flow')
+
+    act(() => { result.current.cancel() })
+    expect(result.current.status.state).toBe('disconnected')
+  })
+
+  it('disconnects successfully', async () => {
+    mockResponses = {
+      github_get_stored_token: () => 'gho_token',
+      github_get_user: () => ({ login: 'user', name: 'User', avatar_url: '' }),
+      github_disconnect: () => undefined,
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await act(async () => {})
+    expect(result.current.status.state).toBe('connected')
+
+    await act(async () => { await result.current.disconnect() })
+    expect(result.current.status.state).toBe('disconnected')
+  })
+
+  it('shows error when device flow start fails', async () => {
+    mockResponses = {
+      github_get_stored_token: () => null,
+      github_start_device_flow: () => { throw new Error('Network error') },
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await act(async () => {})
+
+    await act(async () => { await result.current.connect() })
+
+    expect(result.current.status.state).toBe('error')
+    if (result.current.status.state === 'error') {
+      expect(result.current.status.message).toContain('Network error')
+    }
+  })
+
+  it('transitions from device flow to connected when poll returns token', async () => {
+    // Use real timers with short interval for this integration-style test
+    vi.useRealTimers()
+    let pollCount = 0
+    mockResponses = {
+      github_get_stored_token: () => null,
+      github_start_device_flow: () => ({
+        device_code: 'dc_poll_test',
+        user_code: 'POLL-1234',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      }),
+      github_poll_token: () => {
+        pollCount++
+        return pollCount >= 2 ? 'gho_new_token' : null
+      },
+      github_get_user: () => ({ login: 'newuser', name: 'New User', avatar_url: 'https://example.com/new.png' }),
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await waitFor(() => expect(result.current.status.state).toBe('disconnected'))
+
+    await act(async () => { await result.current.connect() })
+    expect(result.current.status.state).toBe('device_flow')
+
+    // Wait for polling to complete (interval=5s enforced minimum, needs 2 polls → ~10-12s)
+    await waitFor(() => {
+      expect(result.current.status.state).toBe('connected')
+    }, { timeout: 15000 })
+
+    if (result.current.status.state === 'connected') {
+      expect(result.current.status.user.login).toBe('newuser')
+    }
+  }, 20000)
+
+  it('handles poll error by showing error state', async () => {
+    vi.useRealTimers()
+    mockResponses = {
+      github_get_stored_token: () => null,
+      github_start_device_flow: () => ({
+        device_code: 'dc_err',
+        user_code: 'ERR-CODE',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      }),
+      github_poll_token: () => { throw new Error('Authorization was denied by the user.') },
+    }
+
+    const { result } = renderHook(() => useGithubAuth())
+    await waitFor(() => expect(result.current.status.state).toBe('disconnected'))
+
+    await act(async () => { await result.current.connect() })
+    expect(result.current.status.state).toBe('device_flow')
+
+    // Wait for poll to fire and error (interval=5s minimum)
+    await waitFor(() => {
+      expect(result.current.status.state).toBe('error')
+    }, { timeout: 10000 })
+  }, 15000)
+})

--- a/src/hooks/useGithubAuth.ts
+++ b/src/hooks/useGithubAuth.ts
@@ -1,0 +1,140 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { isTauri, mockInvoke } from '../mock-tauri'
+
+interface DeviceFlowResponse {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  expires_in: number
+  interval: number
+}
+
+export interface GithubUser {
+  login: string
+  name: string | null
+  avatar_url: string
+}
+
+export type GithubAuthStatus =
+  | { state: 'disconnected' }
+  | { state: 'loading' }
+  | { state: 'device_flow'; userCode: string; verificationUri: string }
+  | { state: 'connected'; user: GithubUser }
+  | { state: 'error'; message: string }
+
+function tauriCall<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  if (isTauri()) {
+    return import('@tauri-apps/api/core').then(({ invoke }) => invoke<T>(command, args))
+  }
+  return mockInvoke<T>(command, args)
+}
+
+export function useGithubAuth() {
+  const [status, setStatus] = useState<GithubAuthStatus>({ state: 'loading' })
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const deviceCodeRef = useRef<string | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+    deviceCodeRef.current = null
+  }, [])
+
+  // On mount, check for existing token and fetch user info
+  useEffect(() => {
+    let cancelled = false
+    async function init() {
+      try {
+        const token = await tauriCall<string | null>('github_get_stored_token')
+        if (cancelled) return
+        if (!token) {
+          setStatus({ state: 'disconnected' })
+          return
+        }
+        const user = await tauriCall<GithubUser>('github_get_user', { token })
+        if (cancelled) return
+        setStatus({ state: 'connected', user })
+      } catch (err) {
+        if (cancelled) return
+        // Token might be revoked — treat as disconnected
+        console.warn('[github-auth] Failed to load user:', err)
+        setStatus({ state: 'disconnected' })
+      }
+    }
+    init()
+    return () => { cancelled = true }
+  }, [])
+
+  const connect = useCallback(async () => {
+    stopPolling()
+    setStatus({ state: 'loading' })
+    try {
+      const flow = await tauriCall<DeviceFlowResponse>('github_start_device_flow')
+      deviceCodeRef.current = flow.device_code
+      setStatus({
+        state: 'device_flow',
+        userCode: flow.user_code,
+        verificationUri: flow.verification_uri,
+      })
+
+      // Start polling
+      const interval = Math.max(flow.interval, 5) * 1000
+      pollingRef.current = setInterval(async () => {
+        if (!deviceCodeRef.current) return
+        try {
+          const token = await tauriCall<string | null>('github_poll_token', {
+            deviceCode: deviceCodeRef.current,
+          })
+          if (token) {
+            stopPolling()
+            try {
+              const user = await tauriCall<GithubUser>('github_get_user', { token })
+              setStatus({ state: 'connected', user })
+            } catch {
+              // Token works but user fetch failed — still connected
+              setStatus({ state: 'connected', user: { login: 'unknown', name: null, avatar_url: '' } })
+            }
+          }
+          // If null, still pending — keep polling
+        } catch (err) {
+          stopPolling()
+          setStatus({ state: 'error', message: String(err) })
+        }
+      }, interval)
+
+      // Auto-expire after expires_in seconds
+      setTimeout(() => {
+        if (deviceCodeRef.current === flow.device_code) {
+          stopPolling()
+          setStatus({ state: 'error', message: 'Device code expired. Please try again.' })
+        }
+      }, flow.expires_in * 1000)
+    } catch (err) {
+      setStatus({ state: 'error', message: String(err) })
+    }
+  }, [stopPolling])
+
+  const disconnect = useCallback(async () => {
+    stopPolling()
+    try {
+      await tauriCall<void>('github_disconnect')
+    } catch (err) {
+      console.warn('[github-auth] Failed to disconnect:', err)
+    }
+    setStatus({ state: 'disconnected' })
+  }, [stopPolling])
+
+  const cancel = useCallback(() => {
+    stopPolling()
+    setStatus({ state: 'disconnected' })
+  }, [stopPolling])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => stopPolling()
+  }, [stopPolling])
+
+  return { status, connect, disconnect, cancel }
+}

--- a/src/mock-tauri.ts
+++ b/src/mock-tauri.ts
@@ -1640,6 +1640,8 @@ index abc1234..${shortHash} 100644
 }
 
 let mockHasChanges = true
+let mockGithubToken: string | null = null
+let mockGithubPollCount = 0
 
 const mockHandlers: Record<string, (args: any) => any> = {
   list_vault: () => MOCK_ENTRIES,
@@ -1678,6 +1680,40 @@ const mockHandlers: Record<string, (args: any) => any> = {
     const vault = args.vault_path ?? '/Users/luca/Laputa'
     const timestamp = Date.now()
     return `${vault}/attachments/${timestamp}-${args.filename}`
+  },
+  github_start_device_flow: () => {
+    mockGithubPollCount = 0
+    return {
+      device_code: 'mock_device_code_abc123',
+      user_code: 'MOCK-1234',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    }
+  },
+  github_poll_token: () => {
+    mockGithubPollCount++
+    // Simulate authorization after 3 polls
+    if (mockGithubPollCount >= 3) {
+      mockGithubToken = 'gho_mock_token_for_testing'
+      return mockGithubToken
+    }
+    return null
+  },
+  github_get_user: () => {
+    if (!mockGithubToken) throw new Error('Not authenticated')
+    return {
+      login: 'lucaong',
+      name: 'Luca Rossi',
+      avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+    }
+  },
+  github_disconnect: () => {
+    mockGithubToken = null
+    mockGithubPollCount = 0
+  },
+  github_get_stored_token: () => {
+    return mockGithubToken
   },
   rename_note: (args: { vault_path: string; old_path: string; new_title: string }) => {
     const oldContent = MOCK_CONTENT[args.old_path] ?? ''


### PR DESCRIPTION
Login with GitHub via device flow. Auto-opens system browser, stores token locally (mode 0600), polls for authorization. Tested by Luca ✅

**Changes:**
- `tauri-plugin-opener` for system browser integration
- Auto-open `github.com/login/device` on flow start
- Real OAuth App client ID registered under refactoringhq
- Token stored at `~/.config/com.laputa.app/github_token` (0600 permissions)
- Full polling loop with error handling (expired, denied, pending)