### PR TITLE
feat: dynamic vault management — remove hardcoded paths, add vault picker

### DIFF
--- a/.claude-done
+++ b/.claude-done
@@ -1,35 +1,49 @@
-# Rename Note Tab — Done Summary
+# Dynamic Vault Management — Done
 
 ## What was built
-Double-click a tab title to rename the note. The tab shows an inline text input (Enter saves, Escape cancels). Renaming updates the note's title, filename, H1 heading, frontmatter `title:` field, and all wiki links (`[[OldName]]` → `[[NewName]]`) across the entire vault.
 
-## Commits on `task/rename-note-tab`
-1. `caa26b6` — design: rename-note-tab wireframes (`design/rename-note-tab.pen`)
-2. `68dfab4` — feat: add `rename_note` Tauri command with wiki link updates (Rust backend)
-3. `5a8eb6a` — feat: rename note via double-click on tab — frontend wiring
-4. `ee00c2c` — test: Playwright e2e tests for rename tab feature
+Removed all hardcoded vault paths from source code. Users can now add, switch, and create vaults from within the app. First launch shows a welcome screen when no vaults are configured.
 
-## Architecture decisions
-- **Slug generation**: title → lowercase, non-alphanumeric chars replaced with hyphens, leading/trailing hyphens stripped. Same logic in Rust backend and TypeScript mock.
-- **Wiki link matching**: regex matches both title-based (`[[Old Title]]`) and path-stem-based (`[[note/old-title]]`) references, preserving pipe aliases (`[[Old Title|display]]` → `[[New Title|display]]`).
-- **State flow**: `onRenameTab` flows from TabBar → Editor → App → `useNoteActions.handleRenameNote` → Tauri backend → `useVaultLoader.replaceEntry` (updates entries + allContent atomically).
-- **H1 + frontmatter**: The rename updates both the first `# Heading` line and the `title:` frontmatter field if present.
-- **Toast feedback**: Shows "Renamed" or "Renamed — updated N wiki links" on success, "Failed to rename note" on error.
+## Changes
 
-## Code health
-- **TabBar.tsx**: Improved from CC 23→18 by extracting `TabItem` component and `tabStyle` helper.
-- **Rust `vault.rs`**: Passed code health after extracting helpers (`build_wikilink_pattern`, `WikilinkReplacement` struct, `collect_md_files`, etc.) to keep CC under thresholds.
-- **useNoteActions.ts**: Pre-existing CC=37 (threshold 9) increased to 42. Extracted `performRename` and `buildRenamedEntry` as module-level functions. Proper fix requires splitting the monolithic hook (separate concern).
-- **App.tsx / useVaultLoader.ts**: Minor LOC/CC increases on already-above-threshold functions.
+### Rust backend (`src-tauri/`)
+- **`src/settings.rs`** (new): Vault config management — `load_settings`, `save_settings`, `get_vaults`, `add_vault`, `remove_vault`, `init_vault`. Settings stored in `<app_config_dir>/settings.json` as `{vaults: [{label, path}]}`.
+- **`src/lib.rs`**: Added 4 new Tauri commands (`get_vaults`, `add_vault`, `remove_vault`, `init_vault`), registered `tauri-plugin-dialog`, updated startup trash purge to iterate configured vaults instead of hardcoded `~/Laputa`.
+- **`Cargo.toml`**: Added `tauri-plugin-dialog` dependency.
+- **`capabilities/default.json`**: Added `dialog:default` permission.
 
-## Test results
-- `pnpm test` — 119/119 passed
-- `cargo test` — 147/147 passed (including 7 new rename tests)
-- `npx vite build` — success
-- Playwright e2e — 2/2 rename-tab tests pass
+### Frontend (`src/`)
+- **`components/WelcomeScreen.tsx`** (new): Full-screen welcome shown when vault list is empty. Two buttons: "Open Existing Folder" and "Create New Vault".
+- **`hooks/useVaultConfig.ts`** (new): React hook wrapping the Rust vault config commands — load, add, remove, init, with error state management.
+- **`App.tsx`**: Replaced hardcoded `VAULTS` array with `useVaultConfig()`. Shows `WelcomeScreen` on empty state. Wires up folder picker via `@tauri-apps/plugin-dialog` (Tauri) or `window.prompt` (browser mock).
+- **`components/StatusBar.tsx`**: Vault dropdown now has "Add vault..." option at bottom and per-vault remove buttons (trash icon, only shown when multiple vaults exist).
+- **`mock-tauri.ts`**: Added mock handlers for `get_vaults`, `add_vault`, `remove_vault`, `init_vault`.
 
-## Visual verification
-Tested on `localhost:5173` via Playwright:
-- Double-click → inline input appears with current title selected
-- Type new name → Enter → tab title updates, note list updates, breadcrumb updates, toast shows "Renamed"
-- Double-click → type → Escape → title reverts, no changes made
+### Edge cases handled
+- Selected folder doesn't exist → error surfaced to user
+- Folder already a git repo → opened as-is, git init skipped
+- Duplicate vault path → deduplicated silently (canonical paths)
+- All vaults removed → WelcomeScreen shown again
+- git init failure → error surfaced to user
+- New empty vault → `.gitkeep` created automatically
+
+### Tests
+- **`WelcomeScreen.test.tsx`**: 6 tests (render, buttons, error display)
+- **`useVaultConfig.test.ts`**: 8 tests (load, add, remove, deduplicate, error, clear)
+- **`StatusBar.test.tsx`**: 5 new tests for add/remove vault UI
+- **`settings.rs`**: 6 Rust tests (roundtrip, init_vault, edge cases)
+- **`App.test.tsx`**: Updated mock to include vault config commands
+- Total: 387 frontend tests pass, 156 Rust tests pass
+
+### Design
+- **`design/dynamic-vault-management.pen`**: Two new frames — Welcome Screen and Vault Picker Menu wireframes.
+
+## Coverage
+- Frontend: 80.47% lines (threshold: 70%)
+- Rust: 86.25% lines (threshold: 85%)
+
+## Product decisions
+- Label for new vaults: derived from folder name (e.g. `/Users/luca/Laputa` → "Laputa")
+- Remove vault only removes from the config list — does not delete any files
+- Single-vault state hides the remove button to prevent accidental removal to empty state
+- Browser mock returns a single "Demo v2" vault so the app works in `pnpm dev` mode

--- a/design/dynamic-vault-management.pen
+++ b/design/dynamic-vault-management.pen
@@ -1,0 +1,11042 @@
+{
+  "version": "2.8",
+  "children": [
+    {
+      "type": "frame",
+      "id": "qHhaj",
+      "x": 68,
+      "y": 3385,
+      "name": "Laputa App — Full Layout (Light)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "yVQFF",
+          "name": "macOS Title Bar",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "0MCME",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "c2AU6",
+                  "name": "closeBtn",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "h0zbh",
+                  "name": "minimizeBtn",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "tcqbu",
+                  "name": "maximizeBtn",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "oHDfa",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "ZTOSJ",
+              "name": "Panel: Sidebar",
+              "clip": true,
+              "width": 250,
+              "height": "fill_container",
+              "fill": "$--sidebar",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--sidebar-border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "4wMva",
+                  "name": "Filters",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "gap": 1,
+                  "padding": [
+                    8,
+                    8,
+                    16,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Q78hg",
+                      "name": "filterAll",
+                      "width": "fill_container",
+                      "fill": "#4a9eff18",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5ip58",
+                          "name": "leftAll",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "PXpWi",
+                              "name": "iconAll",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tray-fill",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "NWprl",
+                              "name": "fAllTxt",
+                              "fill": "$--primary",
+                              "content": "Untagged",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NZ9Dv",
+                          "name": "countAll",
+                          "height": 20,
+                          "fill": "$--primary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mPlUV",
+                              "name": "badgeAllTxt",
+                              "fill": "$--primary-foreground",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YLWsY",
+                      "name": "filterUntagged",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "k7LIr",
+                          "name": "leftUntagged",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "FMVlh",
+                              "name": "untaggedIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "5XllD",
+                              "name": "untaggedTxt",
+                              "fill": "$--foreground",
+                              "content": "All Notes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "aSpGv",
+                          "name": "countUntagged",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "qZUFt",
+                              "name": "untaggedBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "6",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Jahon",
+                      "name": "filterTrash",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IOiBI",
+                          "name": "leftTrash",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "X6F74",
+                              "name": "trashIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "trash",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vRMH9",
+                              "name": "trashTxt",
+                              "fill": "$--foreground",
+                              "content": "Archive",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JMpkq",
+                          "name": "countTrash",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "0cKm4",
+                              "name": "trashBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6RMbq",
+                      "name": "filterChanges",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DpdBu",
+                          "name": "leftChanges",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "VTusA",
+                              "name": "iconChanges",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "git-branch",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qvq5O",
+                              "name": "fChangesTxt",
+                              "fill": "$--foreground",
+                              "content": "Changes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qAMES",
+                          "name": "countChanges",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "nkzVk",
+                              "name": "badgeChangesTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SSEUP",
+                  "name": "Sections",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    8,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nM2Cn",
+                      "name": "projGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6,
+                        8,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ouIl9",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Rx1Cp",
+                              "name": "leftProj",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "t5WJJ",
+                                  "name": "projIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "wrench",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-red"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "S3sGC",
+                                  "name": "projLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Projects",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "FKwSS",
+                              "name": "projChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "IHzFh",
+                          "name": "projItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "iiFcl",
+                              "name": "proj1Txt",
+                              "fill": "$--accent-red",
+                              "content": "Laputa App",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LdaU9",
+                          "name": "projItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XRll4",
+                              "name": "proj2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Portfolio Rewrite",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Vmykd",
+                          "name": "projItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "0PqQQ",
+                              "name": "proj3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "AI Habit Tracker",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WAQtn",
+                      "name": "respGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "aSi3l",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "lov6B",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Em4ns",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "medal",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "WPRCo",
+                                  "name": "respLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Responsibilities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "6hDdQ",
+                              "name": "respChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FmUu0",
+                      "name": "procGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Dat6o",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "iJlgx",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "I2J1R",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "AToF0",
+                                  "name": "Procedures",
+                                  "fill": "$--foreground",
+                                  "content": "Procedures",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "meEIL",
+                              "name": "procChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "T4NG2",
+                      "name": "peopleGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Q01iL",
+                          "name": "peopleHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "eE6Ca",
+                              "name": "leftPeople",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "jOmVa",
+                                  "name": "peopleIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "users",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "caelD",
+                                  "name": "peopleLbl",
+                                  "fill": "$--foreground",
+                                  "content": "People",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "TkuS1",
+                              "name": "peopleChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BY1Qx",
+                      "name": "eventsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "v28d8",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "TPyOc",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "ELRMi",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "OlI6Q",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Events",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "TZwK8",
+                              "name": "eventsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "trKNW",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qdbZ3",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "JP83M",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Q57kF",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "tag",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DeVxP",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Topics",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "nzAcm",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZWXuk",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CQaLg",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "2SMcN",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "0N8UH",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6XB2H",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Notes",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "NmBSB",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2cQBp",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "0f10v",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                0
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "xBv1X",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "viWPL",
+                                  "name": "eventsLbl",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Create new type",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "8lLHp",
+                  "name": "Commit Area",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "YYjuy",
+                      "name": "commitBtn",
+                      "width": "fill_container",
+                      "fill": "$--primary",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "YF44G",
+                          "name": "commitIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "git-commit-horizontal",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary-foreground"
+                        },
+                        {
+                          "type": "text",
+                          "id": "vpzJm",
+                          "name": "commitTxt",
+                          "fill": "$--primary-foreground",
+                          "content": "Commit & Push",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vhU5z",
+                          "name": "commitBadge",
+                          "height": 18,
+                          "fill": "#ffffff40",
+                          "cornerRadius": 9,
+                          "padding": [
+                            0,
+                            5
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "sdvYT",
+                              "name": "commitBadgeTxt",
+                              "fill": "$--white",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "IIvWr",
+              "name": "Resize Handle",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "zFIJv",
+              "name": "Panel: NoteList",
+              "clip": true,
+              "width": 300,
+              "height": "fill_container",
+              "fill": "$--card",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "uZJVN",
+                  "name": "NoteList Header",
+                  "width": "fill_container",
+                  "height": 45,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hmbdb",
+                      "name": "nlTitle",
+                      "fill": "$--foreground",
+                      "content": "Laputa App",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m6AeW",
+                      "name": "nlActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "8gMXE",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "magnifying-glass",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "YqvSN",
+                          "name": "plusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "0aJUm",
+                  "name": "Note Items",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "y9y05",
+                      "name": "Backlinks Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tMsM4",
+                          "name": "Note Item Selected",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E9E9E7"
+                          },
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "id": "npYuc",
+                              "name": "leftAccent",
+                              "fill": "$--accent-red",
+                              "width": 3,
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "a33Wx",
+                              "name": "noteSelContent",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "AZkyx",
+                                  "name": "noteSelRow",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "j7GDJ",
+                                      "name": "titleGroup",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "j7o2Q",
+                                          "name": "noteSelTitle",
+                                          "fill": "$--foreground",
+                                          "content": "Laputa App",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "BnkTG",
+                                          "name": "ico",
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "wrench",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Ac5Ds",
+                                  "name": "noteSelSnip",
+                                  "fill": "$--foreground",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Personal knowledge and life management desktop app...",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "9ASsT",
+                                  "name": "noteSelTime",
+                                  "fill": "$--accent-red",
+                                  "content": "2m ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7G8pN",
+                      "name": "Related Notes Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fDxtF",
+                          "name": "Related Notes Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "UBRdO",
+                              "name": "rnLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8Z4Wq",
+                                  "name": "rnLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "RELATED NOTES",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "vpnZr",
+                                  "name": "rnCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "X9LIR",
+                              "name": "rnRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "fzVWu",
+                                  "name": "rnFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "wuqsO",
+                                  "name": "rnPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "SbjLq",
+                                  "name": "rnChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AsAKG",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "QX5A1",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "rYdta",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "PC9XN",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Portfolio Rewrite",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "oI64Y",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "S9JPj",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Redesigning portfolio site with modern stack and updated visual language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "lU75x",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "u6E6Z",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ZjCz3",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "mxCzu",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "INenY",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Sample note 2",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "gz6qS",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "s141z",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Lorem ipsum dolor sit amet consequetur with modern stack and updated language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "SvGnt",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1GwHB",
+                      "name": "Events Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fp4xI",
+                          "name": "Events Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "MNNuU",
+                              "name": "evLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "BNxZp",
+                                  "name": "evLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "EVENTS",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qcEvw",
+                                  "name": "evCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WCyfc",
+                              "name": "evRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SpCoO",
+                                  "name": "evFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "G1DCl",
+                                  "name": "evPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "sAalN",
+                                  "name": "evChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "k7CjA",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "og5Gz",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "ttBdk",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "KI8Bf",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Grant",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "LdRjU",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "FfPXa",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "BHh4Z",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AQ51u",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "SHgK3",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "3rIet",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "dCwzu",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Matteo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "l8O2I",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "1L4oo",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "3oBam",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "MeqjO",
+              "name": "Resize Handle 2",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "zAbPt",
+              "name": "Panel: Editor",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$--background",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NdYcO",
+                  "name": "Tab Bar",
+                  "width": "fill_container",
+                  "height": 45,
+                  "fill": "$--sidebar",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--sidebar-border"
+                  },
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nVUGr",
+                      "name": "Tab Active",
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kBpGX",
+                          "name": "tab1Txt",
+                          "fill": "$--foreground",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "Bb2AE",
+                          "name": "tab1Close",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GYeyL",
+                      "name": "Tab Inactive",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1,
+                          "bottom": 1
+                        },
+                        "fill": "$--sidebar-border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kZ1bn",
+                          "name": "tab2Txt",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "RwyYI",
+                          "name": "tab2Close",
+                          "opacity": 0,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sbpmq",
+                      "name": "tabSpacer",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "$--border"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WF97k",
+                      "name": "tabControls",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1,
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_around",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "rfSoS",
+                          "name": "iconPlus",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "t0u6z",
+                          "name": "iconSplit",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "columns",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "kbe1P",
+                          "name": "iconExpand",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrows-out-simple",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rTdKS",
+                  "name": "Editor Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "NfyTF",
+                      "name": "Editor Left",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hvoFh",
+                          "name": "Info Bar",
+                          "width": "fill_container",
+                          "height": 45,
+                          "fill": "$--background",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "bTP0I",
+                              "name": "infoLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Msj7v",
+                                  "name": "breadcrumbType",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Project",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wqdMG",
+                                  "name": "breadcrumbSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "›",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "FzENd",
+                                  "name": "breadcrumbName",
+                                  "fill": "$--foreground",
+                                  "content": "Laputa App",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "pvTmc",
+                                  "name": "dotSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "9ga1R",
+                                  "name": "modifiedTxt",
+                                  "fill": "$--accent-yellow",
+                                  "content": "M",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "3bzDp",
+                              "name": "infoRight",
+                              "gap": 12,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "9Ctb0",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "magnifying-glass",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "csHzz",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "git-branch",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "2s6Of",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cursor-text",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "JVSlj",
+                                  "name": "iconAI",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sparkle",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "k3AiV",
+                                  "name": "iconMore",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "dots-three",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vvETz",
+                          "name": "Editor Content",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": [
+                            32,
+                            64
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "b6up3",
+                              "name": "editorP1",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Personal knowledge and life management desktop app, built with Tauri v2 + React + TypeScript + CodeMirror 6. It reads a vault of markdown files with YAML frontmatter and presents them in a four-panel UI inspired by Bear Notes.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "a2S43",
+                              "name": "editorH2",
+                              "fill": "$--foreground",
+                              "content": "Architecture",
+                              "lineHeight": 1.3,
+                              "fontFamily": "Inter",
+                              "fontSize": 24,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "wgvQa",
+                              "name": "editorP2",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The app uses a four-panel layout: Sidebar for navigation, NoteList for browsing, Editor for content, and Inspector for metadata. All data lives in markdown files with YAML frontmatter, git-versioned.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GGP97",
+                      "name": "Inspector",
+                      "clip": true,
+                      "width": 260,
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FbHy7",
+                          "name": "Inspector Header",
+                          "width": "fill_container",
+                          "height": 45,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "sA7Dx",
+                              "name": "leftGroup",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "0ccF1",
+                                  "name": "propIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sliders-horizontal",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "T2vTZ",
+                                  "name": "inspTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Properties",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "NQOhZ",
+                              "name": "sidebarIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "x",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LYFki",
+                          "name": "Inspector Body",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "8g61y",
+                              "name": "Properties Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "VhH4P",
+                                  "name": "addPropBtn",
+                                  "width": "fill_container",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$--border"
+                                  },
+                                  "padding": [
+                                    6,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Q9z8F",
+                                      "name": "addPropTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "+ Add property",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "6PwTH",
+                                  "name": "propType",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Vt2BC",
+                                      "name": "propTypeLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TYPE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "uvBiY",
+                                      "name": "propTypeVal",
+                                      "fill": "$--foreground",
+                                      "content": "Project",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "FDbay",
+                                  "name": "propStatus",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "e426F",
+                                      "name": "propStatusLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "STATUS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "o2rZM",
+                                      "name": "propStatusBadge",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 16,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "transparent"
+                                      },
+                                      "gap": 8,
+                                      "padding": [
+                                        1,
+                                        6
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "QM7L3",
+                                          "name": "Badge Text",
+                                          "fill": "$--accent-green",
+                                          "content": "ACTIVE",
+                                          "lineHeight": 1.33,
+                                          "textAlign": "center",
+                                          "textAlignVertical": "middle",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 1.2
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "NmRLv",
+                              "name": "Relationships Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 16,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "WFVAr",
+                                  "name": "relGroup1",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "0N729",
+                                      "name": "relGrp1Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "BELONGS TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "zLl8F",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "kw9vC",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Laputa",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "RFvoz",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ybi8Q",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "VNcmt",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Building",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "UVPwc",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "L6knW",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "jwU3Z",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "laPFL",
+                                  "name": "relGroup2",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "LOXUL",
+                                      "name": "relGrp2Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "RELATED TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "qLTYD",
+                                      "name": "relMigrationBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-red-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "GBk2u",
+                                          "name": "migrationTxt",
+                                          "fill": "$--accent-red",
+                                          "content": "Shadcn Migration",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "Sy14T",
+                                          "name": "expIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "flask",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "u8ijV",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "PUXx5",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "6PUnO",
+                              "name": "Backlinks Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "PllIu",
+                                  "name": "blTitle",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ZbgbI",
+                                      "name": "blTitleTxt",
+                                      "rotation": -0.5285936385085725,
+                                      "fill": "$--muted-foreground",
+                                      "content": "BACKLINKS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "eRoDO",
+                                  "name": "blItem1",
+                                  "fill": "$--primary",
+                                  "content": "Portfolio Rewrite",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "u1olR",
+                                  "name": "blItem2",
+                                  "fill": "$--primary",
+                                  "content": "Meeting with Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "oUd9s",
+                                  "name": "blItem3",
+                                  "fill": "$--primary",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yf0wj",
+                              "name": "History Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "dG7rj",
+                                  "name": "histTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "HISTORY",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "z2Mdy",
+                                  "name": "histItem1",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "AsiWz",
+                                      "name": "histItem1Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "a089f44 · feat: migrate to shadcn/ui",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "BdVhi",
+                                      "name": "histItem1Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 16, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "piJNC",
+                                  "name": "histItem2",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "0PWoX",
+                                      "name": "histItem2Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "5a4b4ac · feat: emoji favicon",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "xySNW",
+                                      "name": "histItem2Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 15, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "x1AHT",
+          "name": "lightStatusBar",
+          "width": "fill_container",
+          "height": 30,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            8
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "e2UzJ",
+              "name": "Status Left",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "mlD58",
+                  "name": "versionIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "box",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "hRBRa",
+                  "name": "versionText",
+                  "fill": "$--muted-foreground",
+                  "content": "v0.4.2",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "bFwrw",
+                  "name": "sep1",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "ey3Gr",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "Kz0sS",
+                  "name": "branchText",
+                  "fill": "$--muted-foreground",
+                  "content": "main",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "6IY1E",
+                  "name": "sep2",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "IjEG1",
+                  "name": "syncIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-green"
+                },
+                {
+                  "type": "text",
+                  "id": "srxkr",
+                  "name": "syncText",
+                  "fill": "$--muted-foreground",
+                  "content": "Synced 2m ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4jgQF",
+              "name": "Status Right",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "3RPmA",
+                  "name": "aiIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-purple"
+                },
+                {
+                  "type": "text",
+                  "id": "t0NOA",
+                  "name": "aiText",
+                  "fill": "$--muted-foreground",
+                  "content": "Claude Sonnet 4",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "16V7i",
+                  "name": "sep3",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "PXVrd",
+                  "name": "notesCount",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "2FxCi",
+                  "name": "notesText",
+                  "fill": "$--muted-foreground",
+                  "content": "1,247 notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "pB6ds",
+                  "name": "sep4",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "fRHKs",
+                  "name": "bellIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "bell",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "2sEBS",
+                  "name": "settingsIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mOf4J",
+      "x": 0,
+      "y": 4457,
+      "name": "Color Palette — shadcn/ui Theme (Light)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "width": 1440,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 32,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "rmJdn",
+          "name": "cTitle",
+          "fill": "$--foreground",
+          "content": "Color Palette — shadcn/ui Theme Variables (Light)",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "text",
+          "id": "V79Zu",
+          "name": "cSub",
+          "fill": "$--muted-foreground",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "All colors from src/index.css. Variables support light/dark mode via .dark class.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "Xbdzq",
+          "name": "primLbl",
+          "fill": "$--foreground",
+          "content": "Primary Colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "NyoC7",
+          "name": "primRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "Inb1x",
+              "name": "sw1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "HRsVC",
+                  "name": "sw1b",
+                  "fill": "$--background",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "jV89s",
+                  "name": "sw1n",
+                  "fill": "$--foreground",
+                  "content": "--background",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "qOUUY",
+                  "name": "sw1v",
+                  "fill": "$--muted-foreground",
+                  "content": "L: #FFFFFF / D: #0f0f1a",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QytAQ",
+              "name": "sw2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "TMuHH",
+                  "name": "sw2b",
+                  "fill": "$--foreground",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "k9qK4",
+                  "name": "sw2n",
+                  "fill": "$--foreground",
+                  "content": "--foreground",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "BfEn7",
+                  "name": "sw2v",
+                  "fill": "$--muted-foreground",
+                  "content": "L: #37352F / D: #e0e0e0",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gJZtB",
+              "name": "sw3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "RRsQg",
+                  "name": "sw3b",
+                  "fill": "$--primary",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "CtJe4",
+                  "name": "sw3n",
+                  "fill": "$--foreground",
+                  "content": "--primary",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "1iFr6",
+                  "name": "sw3v",
+                  "fill": "$--muted-foreground",
+                  "content": "#155DFF",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mbvua",
+              "name": "sw4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "fajNZ",
+                  "name": "sw4b",
+                  "fill": "$--primary-foreground",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "wVJ7z",
+                  "name": "sw4n",
+                  "fill": "$--foreground",
+                  "content": "--primary-foreground",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "Oum5Q",
+                  "name": "sw4v",
+                  "fill": "$--muted-foreground",
+                  "content": "L: #FFFFFF / D: #ffffff",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "UvI4d",
+          "name": "accLbl",
+          "fill": "$--foreground",
+          "content": "Accent & Semantic Colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "jOmo7",
+          "name": "accRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "uFXJ3",
+              "name": "a1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "NRr0w",
+                  "name": "a1b",
+                  "fill": "$--accent-blue",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "ECVqk",
+                  "name": "a1n",
+                  "fill": "$--foreground",
+                  "content": "--accent-blue",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "csKEt",
+              "name": "a2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "5IiT2",
+                  "name": "a2b",
+                  "fill": "$--accent-green",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "aCPba",
+                  "name": "a2n",
+                  "fill": "$--foreground",
+                  "content": "--accent-green",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "XbY7C",
+              "name": "a3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "I9qCz",
+                  "name": "a3b",
+                  "fill": "$--accent-yellow",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "DfZVh",
+                  "name": "a3n",
+                  "fill": "$--foreground",
+                  "content": "--accent-yellow",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nROw3",
+              "name": "a4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "IcIoP",
+                  "name": "a4b",
+                  "fill": "$--accent-red",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "eGgz6",
+                  "name": "a4n",
+                  "fill": "$--foreground",
+                  "content": "--destructive",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "J95fv",
+              "name": "a5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "o03fQ",
+                  "name": "a5b",
+                  "fill": "$--accent-purple",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "H9VWy",
+                  "name": "a5n",
+                  "fill": "$--foreground",
+                  "content": "--accent-purple",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "GcYle",
+          "name": "lightLightLbl",
+          "fill": "$--foreground",
+          "content": "Accent Light Backgrounds",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "Ju2xp",
+          "name": "accLightRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "5dnn5",
+              "name": "al1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "7kcqW",
+                  "name": "ll1b",
+                  "fill": "$--accent-blue-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "dBCbF",
+                  "name": "ll1n",
+                  "fill": "$--foreground",
+                  "content": "--accent-blue-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "W0t0j",
+              "name": "al2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "1vepp",
+                  "name": "ll2b",
+                  "fill": "$--accent-green-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "6kUyf",
+                  "name": "ll2n",
+                  "fill": "$--foreground",
+                  "content": "--accent-green-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zyV1j",
+              "name": "al3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "yUDBN",
+                  "name": "ll3b",
+                  "fill": "$--accent-yellow-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "dmfZ4",
+                  "name": "ll3n",
+                  "fill": "$--foreground",
+                  "content": "--accent-yellow-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yGmmo",
+              "name": "al4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "eLu8o",
+                  "name": "ll4b",
+                  "fill": "$--accent-red-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "PVLwR",
+                  "name": "ll4n",
+                  "fill": "$--foreground",
+                  "content": "--accent-red-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0BO2b",
+              "name": "al5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "6FBws",
+                  "name": "ll5b",
+                  "fill": "$--accent-purple-light",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "i2DfV",
+                  "name": "ll5n",
+                  "fill": "$--foreground",
+                  "content": "--accent-purple-light",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "JFocf",
+          "name": "surfLbl",
+          "fill": "$--foreground",
+          "content": "Surface & Border Colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "YAJLW",
+          "name": "surfRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "JHS3j",
+              "name": "s1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "9Bj41",
+                  "name": "s1b",
+                  "fill": "$--card",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "wn4ua",
+                  "name": "s1n",
+                  "fill": "$--foreground",
+                  "content": "--card",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Fyvfd",
+              "name": "s2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "UFLw5",
+                  "name": "s2b",
+                  "fill": "$--sidebar",
+                  "width": "fill_container",
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--sidebar-border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "gngfL",
+                  "name": "s2n",
+                  "fill": "$--foreground",
+                  "content": "--sidebar",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zbyEJ",
+              "name": "s3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "WnmQD",
+                  "name": "s3b",
+                  "fill": "$--secondary",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "wnkxR",
+                  "name": "s3n",
+                  "fill": "$--foreground",
+                  "content": "--secondary",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Z2FuK",
+              "name": "s4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "lNPnc",
+                  "name": "s4b",
+                  "fill": "$--border",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "x9aeh",
+                  "name": "s4n",
+                  "fill": "$--foreground",
+                  "content": "--border / --input",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TDDQ0",
+              "name": "s5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "MwHOe",
+                  "name": "s5b",
+                  "fill": "$--muted-foreground",
+                  "width": "fill_container",
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "dHZj5",
+                  "name": "s5n",
+                  "fill": "$--foreground",
+                  "content": "--muted-foreground",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "HZonq",
+      "x": 0,
+      "y": 5252,
+      "name": "Typography & Spacing Specs (Light)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "width": 1440,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 32,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "nGLlU",
+          "name": "tTitle",
+          "fill": "$--foreground",
+          "content": "Typography Scale (Light)",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "text",
+          "id": "gkQqO",
+          "name": "tSub",
+          "fill": "$--muted-foreground",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "Fonts: Inter, IBM Plex Mono. Base: 14px. System fallback: -apple-system, BlinkMacSystemFont, sans-serif.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "QL9fK",
+          "name": "t1",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "px1l7",
+              "name": "t1s",
+              "fill": "$--foreground",
+              "content": "Heading 1",
+              "lineHeight": 1.2,
+              "fontFamily": "Inter",
+              "fontSize": 32,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "3UWKu",
+              "name": "t1d",
+              "fill": "$--muted-foreground",
+              "content": "32px / Bold / lh 1.2 — Editor H1",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Yjhit",
+          "name": "t2",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "iFzl0",
+              "name": "t2s",
+              "fill": "$--foreground",
+              "content": "Heading 2",
+              "lineHeight": 1.3,
+              "fontFamily": "Inter",
+              "fontSize": 24,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "cF55I",
+              "name": "t2d",
+              "fill": "$--muted-foreground",
+              "content": "24px / Semibold / lh 1.3 — Editor H2",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "bBHMa",
+          "name": "t3",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "kpSyr",
+              "name": "t3s",
+              "fill": "$--foreground",
+              "content": "App Title",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "700",
+              "letterSpacing": -0.3
+            },
+            {
+              "type": "text",
+              "id": "xUuNz",
+              "name": "t3d",
+              "fill": "$--muted-foreground",
+              "content": "17px / Bold / ls -0.3 — Sidebar header",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Lsh7F",
+          "name": "t4",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "vTRSs",
+              "name": "t4s",
+              "fill": "$--foreground",
+              "content": "Body Text",
+              "lineHeight": 1.6,
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "fKa3p",
+              "name": "t4d",
+              "fill": "$--muted-foreground",
+              "content": "16px / Regular / lh 1.6 — Editor paragraphs",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rpOTz",
+          "name": "t5",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "VXY3Z",
+              "name": "t5s",
+              "fill": "$--foreground",
+              "content": "UI Label / Button",
+              "lineHeight": 1.43,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "F6GQz",
+              "name": "t5d",
+              "fill": "$--muted-foreground",
+              "content": "14px / Medium / lh 1.43 — Buttons, NoteList header, Inspector labels",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "H6Rgt",
+          "name": "t6",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "xWvbj",
+              "name": "t6s",
+              "fill": "$--foreground",
+              "content": "Sidebar Item",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "bvBBm",
+              "name": "t6d",
+              "fill": "$--muted-foreground",
+              "content": "13px / Medium — Sidebar nav items, filter items, search",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GrFAq",
+          "name": "t7",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "vY8j4",
+              "name": "t7s",
+              "fill": "$--muted-foreground",
+              "content": "SECTION HEADER",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 0.5
+            },
+            {
+              "type": "text",
+              "id": "okws6",
+              "name": "t7d",
+              "fill": "$--muted-foreground",
+              "content": "11px / Semibold / ls 0.5 — Sidebar sections, type pills",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "awxls",
+          "name": "t8",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "mD3f5",
+              "name": "t8s",
+              "fill": "$--foreground",
+              "content": "ALL-CAPS LABEL",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "text",
+              "id": "jFpLw",
+              "name": "t8d",
+              "fill": "$--muted-foreground",
+              "content": "11px / Semibold / ls 1.2 / IBM Plex Mono — Section labels, metadata tags",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ToLzL",
+          "name": "t9",
+          "width": "fill_container",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "LEsxW",
+              "name": "t9s",
+              "fill": "$--muted-foreground",
+              "content": "OVERLINE TEXT",
+              "fontFamily": "IBM Plex Mono",
+              "fontSize": 10,
+              "fontWeight": "500",
+              "letterSpacing": 1.5
+            },
+            {
+              "type": "text",
+              "id": "HQ3Df",
+              "name": "t9d",
+              "fill": "$--muted-foreground",
+              "content": "10px / Medium / ls 1.5 / IBM Plex Mono — Overlines, category labels, timestamps",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "3tiJ7",
+          "name": "div1",
+          "fill": "$--border",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "text",
+          "id": "b2Mt9",
+          "name": "spTitle",
+          "fill": "$--foreground",
+          "content": "Spacing & Layout Reference",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "frame",
+          "id": "o6ETJ",
+          "name": "pnlRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "HhbOn",
+              "name": "p1",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "YBekR",
+                  "name": "p1t",
+                  "fill": "$--foreground",
+                  "content": "Sidebar: 250px",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "dT8Xe",
+                  "name": "p1d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --sidebar | padding: 8px container, 12px 16px header, 6px 16px items",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aYkMZ",
+              "name": "p2",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Eycne",
+                  "name": "p2t",
+                  "fill": "$--foreground",
+                  "content": "NoteList: 300px",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "lyTZN",
+                  "name": "p2d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --card | padding: 14px 16px header, 8px 12px search/pills, 10px 16px items",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "E6G3g",
+              "name": "p3",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Xy5Gl",
+                  "name": "p3t",
+                  "fill": "$--foreground",
+                  "content": "Editor: flexible",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "y4svr",
+                  "name": "p3d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --background | padding: 32px 64px content, 7px 14px tabs, gap: 16px",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RBPav",
+              "name": "p4",
+              "width": "fill_container",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xKUWC",
+                  "name": "p4t",
+                  "fill": "$--foreground",
+                  "content": "Inspector: 280px",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "u81W5",
+                  "name": "p4d",
+                  "fill": "$--muted-foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "bg: --sidebar | padding: 14px 12px header, 12px body, 16px section gap, 8px prop gap",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "VvZyF",
+          "name": "radLbl",
+          "fill": "$--foreground",
+          "content": "Border Radius",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "OwJH7",
+          "name": "radRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "DHrzV",
+              "name": "r1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 4,
+                  "id": "V35oi",
+                  "name": "r1b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "HVQpq",
+                  "name": "r1n",
+                  "fill": "$--foreground",
+                  "content": "4px (sm) — chips",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wp350",
+              "name": "r2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 6,
+                  "id": "E031z",
+                  "name": "r2b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "rDLff",
+                  "name": "r2n",
+                  "fill": "$--foreground",
+                  "content": "6px (md) — buttons, inputs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "d6tJt",
+              "name": "r3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 8,
+                  "id": "PNkS4",
+                  "name": "r3b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "rZGXb",
+                  "name": "r3n",
+                  "fill": "$--foreground",
+                  "content": "8px (lg) — cards, dialogs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UAZ8u",
+              "name": "r4",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 16,
+                  "id": "wgMVG",
+                  "name": "r4b",
+                  "fill": "$--secondary",
+                  "width": 80,
+                  "height": 60,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--border"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "zw3RY",
+                  "name": "r4n",
+                  "fill": "$--foreground",
+                  "content": "16px — badges",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "kIrXE",
+          "name": "div2",
+          "fill": "$--border",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "text",
+          "id": "FYw8k",
+          "name": "compTitle",
+          "fill": "$--foreground",
+          "content": "shadcn/ui Component Inventory",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "700",
+          "letterSpacing": -0.5
+        },
+        {
+          "type": "frame",
+          "id": "7Q1Fi",
+          "name": "compRow",
+          "width": "fill_container",
+          "gap": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "XfUwj",
+              "name": "cg1",
+              "width": "fill_container",
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ly7m0",
+                  "name": "cg1t",
+                  "fill": "$--accent-green",
+                  "content": "In Use",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "Re89a",
+                  "name": "cg1r1",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Button — 5 variants (Default, Secondary, Outline, Ghost, Destructive)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "ILbjW",
+                  "name": "cg1r2",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Input — Default text input with label group",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "eurqS",
+                  "name": "cg1r3",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Dialog — Modal overlay (CreateNote, Commit)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "AZyZP",
+                  "name": "cg1r4",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Badge — 4 variants (Default, Secondary, Outline, Destructive)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "WtehQ",
+              "name": "cg2",
+              "width": "fill_container",
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "KaMZ9",
+                  "name": "cg2t",
+                  "fill": "$--accent-yellow",
+                  "content": "Available (Not Yet Used)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "F8wam",
+                  "name": "cg2r1",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "DropdownMenu — Context / dropdown menus",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Nl1aV",
+                  "name": "cg2r2",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Tabs — Tab navigation component",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "0sBwH",
+                  "name": "cg2r3",
+                  "fill": "$--foreground",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Tooltip, Select, Card, Separator, ScrollArea",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trSB1",
+      "x": 1600,
+      "y": 3385,
+      "name": "Trash — Sidebar Filter",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 260,
+      "height": 400,
+      "fill": "$--sidebar",
+      "layout": "vertical",
+      "gap": 0,
+      "padding": [
+        8,
+        6
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "trFAll",
+          "name": "filterAll",
+          "width": "fill_container",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trIAll",
+              "name": "iconAll",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "file-text",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "trTAll",
+              "name": "txtAll",
+              "fill": "$--foreground",
+              "content": "All Notes",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trFFav",
+          "name": "filterFav",
+          "width": "fill_container",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trIFav",
+              "name": "iconFav",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "star",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "trTFav",
+              "name": "txtFav",
+              "fill": "$--foreground",
+              "content": "Favorites",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trFArc",
+          "name": "filterArchive",
+          "width": "fill_container",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trIArc",
+              "name": "iconArchive",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "archive",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "trTArc",
+              "name": "txtArchive",
+              "fill": "$--foreground",
+              "content": "Archive",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "frame",
+              "id": "trBArc",
+              "name": "badgeArc",
+              "height": 20,
+              "fill": "$--muted",
+              "cornerRadius": 9999,
+              "padding": [
+                0,
+                6
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trBTArc",
+                  "fill": "$--muted-foreground",
+                  "content": "2",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trFTr",
+          "name": "filterTrash",
+          "width": "fill_container",
+          "fill": "#ef444418",
+          "cornerRadius": 6,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trITr",
+              "name": "iconTrash",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "trash",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--destructive"
+            },
+            {
+              "type": "text",
+              "id": "trTTr",
+              "name": "txtTrash",
+              "fill": "$--destructive",
+              "content": "Trash",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "trBTr",
+              "name": "badgeTrash",
+              "height": 20,
+              "fill": "$--destructive",
+              "cornerRadius": 9999,
+              "padding": [
+                0,
+                6
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trBTTr",
+                  "fill": "#ffffff",
+                  "content": "3",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trNL1",
+      "x": 1600,
+      "y": 3815,
+      "name": "Trash — Note List View",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 340,
+      "height": 360,
+      "fill": "$--card",
+      "layout": "vertical",
+      "gap": 0,
+      "children": [
+        {
+          "type": "frame",
+          "id": "trNLH",
+          "name": "header",
+          "width": "fill_container",
+          "height": 45,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "children": [
+            {
+              "type": "text",
+              "id": "trNLT",
+              "fill": "$--foreground",
+              "content": "Trash",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trN1",
+          "name": "trashedNote1",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "trN1H",
+              "name": "titleRow",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trN1T",
+                  "fill": "$--foreground",
+                  "content": "Old Draft Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "trN1B",
+                  "name": "trashedBadge",
+                  "height": 16,
+                  "fill": "#ef444418",
+                  "cornerRadius": 4,
+                  "padding": [
+                    1,
+                    4
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "trN1BT",
+                      "fill": "$--destructive",
+                      "content": "TRASHED",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "trN1S",
+              "fill": "$--muted-foreground",
+              "content": "Some draft content that is no longer needed...",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "400"
+            },
+            {
+              "type": "text",
+              "id": "trN1D",
+              "fill": "$--muted-foreground",
+              "content": "5d ago",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "400"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trN2",
+          "name": "trashedNote2Warning",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
+          "fill": "#ef44440a",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "trN2H",
+              "name": "titleRow",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trN2T",
+                  "fill": "$--foreground",
+                  "content": "Deprecated API Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "trN2B",
+                  "name": "warningBadge",
+                  "height": 16,
+                  "fill": "$--destructive",
+                  "cornerRadius": 4,
+                  "padding": [
+                    1,
+                    4
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "trN2BT",
+                      "fill": "#ffffff",
+                      "content": "30+ DAYS",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "trN2S",
+              "fill": "$--muted-foreground",
+              "content": "Old API documentation that was replaced...",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "400"
+            },
+            {
+              "type": "text",
+              "id": "trN2D",
+              "fill": "$--destructive",
+              "content": "Trashed 35d ago — will be permanently deleted",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "500"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trRI1",
+      "x": 1970,
+      "y": 3385,
+      "name": "Trash — Relationship Indicator",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 300,
+      "height": 200,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        16
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "trRIL",
+          "fill": "$--muted-foreground",
+          "content": "BELONGS TO",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 0.5
+        },
+        {
+          "type": "frame",
+          "id": "trRN",
+          "name": "normalRef",
+          "width": "fill_container",
+          "fill": "$--accent-blue-light",
+          "cornerRadius": 6,
+          "padding": [
+            6,
+            10
+          ],
+          "gap": 6,
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "children": [
+            {
+              "type": "text",
+              "id": "trRNT",
+              "fill": "$--accent-blue",
+              "content": "Build Laputa App",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "500"
+            },
+            {
+              "type": "icon_font",
+              "id": "trRNI",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "wrench",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--accent-blue"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trRT",
+          "name": "trashedRef",
+          "width": "fill_container",
+          "fill": "$--muted",
+          "cornerRadius": 6,
+          "padding": [
+            6,
+            10
+          ],
+          "gap": 6,
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "opacity": 0.7,
+          "children": [
+            {
+              "type": "frame",
+              "id": "trRTL",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "trRTTI",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "trash",
+                  "iconFontFamily": "phosphor",
+                  "weight": 700,
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "trRTT",
+                  "fill": "$--muted-foreground",
+                  "content": "Old Draft Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "trRTTX",
+                  "fill": "$--muted-foreground",
+                  "content": "(trashed)",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "400"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "trRTI",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "file-text",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "trRA",
+          "name": "archivedRef",
+          "width": "fill_container",
+          "fill": "$--muted",
+          "cornerRadius": 6,
+          "padding": [
+            6,
+            10
+          ],
+          "gap": 6,
+          "alignItems": "center",
+          "justifyContent": "space_between",
+          "opacity": 0.7,
+          "children": [
+            {
+              "type": "frame",
+              "id": "trRAL",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trRAT",
+                  "fill": "$--muted-foreground",
+                  "content": "Website Redesign",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "trRATX",
+                  "fill": "$--muted-foreground",
+                  "content": "(archived)",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "400"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "trRAI",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "wrench",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "trW30",
+      "x": 1970,
+      "y": 3615,
+      "name": "Trash — 30-Day Auto-Delete Warning",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 340,
+      "height": 120,
+      "fill": "$--background",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        16
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "trW3L",
+          "fill": "$--muted-foreground",
+          "content": "Warning banner shown at top of trash view:",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "500"
+        },
+        {
+          "type": "frame",
+          "id": "trW3B",
+          "name": "warningBanner",
+          "width": "fill_container",
+          "fill": "#ef44440f",
+          "cornerRadius": 8,
+          "padding": [
+            10,
+            12
+          ],
+          "gap": 8,
+          "alignItems": "center",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#ef444430"
+          },
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "trW3I",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "warning",
+              "iconFontFamily": "phosphor",
+              "weight": 700,
+              "fill": "$--destructive"
+            },
+            {
+              "type": "frame",
+              "id": "trW3T",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "trW3T1",
+                  "fill": "$--destructive",
+                  "content": "Notes in trash for 30+ days will be permanently deleted",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "trW3T2",
+                  "fill": "$--muted-foreground",
+                  "content": "1 note is past the 30-day retention period",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "400"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dt0",
+      "name": "Draggable Tabs — Default State",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dt1",
+          "name": "frameLabel",
+          "content": "Default: tabs are draggable (grab cursor on hover)",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dt2",
+          "name": "Tab Bar Default",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "dt3",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt4",
+                  "fill": "$--foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt6",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt7",
+                  "fill": "$--muted-foreground",
+                  "content": "Portfolio Rewrite",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt8",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt9",
+              "name": "Tab Inactive 2",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dta",
+                  "fill": "$--muted-foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dtb",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtc",
+              "name": "Tab Inactive 3",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtd",
+                  "fill": "$--muted-foreground",
+                  "content": "Workout Log",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dte",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtf",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "dtg",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dth",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "dti",
+          "name": "cursorNote",
+          "content": "cursor: grab → grabbing during drag",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dtj",
+      "name": "Draggable Tabs — Dragging (Tab Being Moved)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dtk",
+          "name": "frameLabel2",
+          "content": "Dragging: \"Portfolio Rewrite\" is being dragged left (opacity 0.5, blue drop indicator)",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dtl",
+          "name": "Tab Bar Dragging",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "rectangle",
+              "id": "dtm",
+              "name": "Drop Indicator",
+              "width": 2,
+              "height": 30,
+              "fill": "$--primary",
+              "cornerRadius": 1
+            },
+            {
+              "type": "frame",
+              "id": "dtn",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dto",
+                  "fill": "$--foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dtp",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtq",
+              "name": "Tab Dragging (ghost)",
+              "height": "fill_container",
+              "opacity": 0.5,
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtr",
+                  "fill": "$--muted-foreground",
+                  "content": "Portfolio Rewrite",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dts",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtt",
+              "name": "Tab Inactive 2",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtu",
+                  "fill": "$--muted-foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtv",
+              "name": "Tab Inactive 3",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dtw",
+                  "fill": "$--muted-foreground",
+                  "content": "Workout Log",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dtx",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "dty",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dtz",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "dt10",
+          "name": "dragNote",
+          "content": "Drop indicator: 2px $--primary bar shows insertion point. Dragged tab has opacity: 0.5.",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dt11",
+      "name": "Draggable Tabs — After Drop (Reordered)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dt12",
+          "name": "frameLabel3",
+          "content": "After drop: \"Portfolio Rewrite\" moved before \"Laputa App\". Order persisted to localStorage.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dt13",
+          "name": "Tab Bar Reordered",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "dt14",
+              "name": "Tab Inactive (moved)",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt15",
+                  "fill": "$--muted-foreground",
+                  "content": "Portfolio Rewrite",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt16",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt17",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt18",
+                  "fill": "$--foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt19",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt1a",
+              "name": "Tab Inactive 2",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt1b",
+                  "fill": "$--muted-foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt1c",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt1d",
+              "name": "Tab Inactive 3",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dt1e",
+                  "fill": "$--muted-foreground",
+                  "content": "Workout Log",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dt1f",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dt1g",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "dt1h",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dt1i",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "dt1j",
+          "name": "persistNote",
+          "content": "localStorage key: \"laputa-tab-order\" stores path array. Restored on next session.",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dsg01a",
+      "name": "Sidebar — Drag Handles Visible",
+      "x": 68,
+      "y": 6400,
+      "width": 330,
+      "height": 680,
+      "fill": "$--background",
+      "layout": "vertical",
+      "padding": [
+        16
+      ],
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dsg01b",
+          "name": "frame1Title",
+          "content": "Drag handles appear on section headers",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600",
+          "fill": "$--foreground"
+        },
+        {
+          "type": "text",
+          "id": "dsg01c",
+          "name": "frame1Desc",
+          "content": "Grip icon shown left of section icon. Cursor changes to grab on hover.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground"
+        },
+        {
+          "type": "frame",
+          "id": "dsg01d",
+          "height": 12
+        },
+        {
+          "type": "frame",
+          "id": "dsg01e",
+          "name": "sidebarDefault",
+          "width": 250,
+          "height": 600,
+          "fill": "$--sidebar",
+          "layout": "vertical",
+          "clip": true,
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg01f",
+              "name": "filters",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                6
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg01g",
+                  "name": "allNotesRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg01h",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg01i",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg01j",
+                  "name": "favRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg01k",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg01l",
+                      "fill": "$--muted-foreground",
+                      "content": "Favorites",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsg01m",
+              "name": "sectionsWrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg00a",
+                  "name": "projGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6,
+                    8,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg005",
+                      "name": "projHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg001",
+                          "name": "projLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg000",
+                              "name": "projDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg002",
+                              "name": "projIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "wrench",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-red"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg003",
+                              "name": "projLabel",
+                              "fill": "$--foreground",
+                              "content": "Projects",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg004",
+                          "name": "projChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg006",
+                      "name": "projItem0",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "fill": "$--accent-red-light",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg007",
+                          "name": "projItemTxt0",
+                          "fill": "$--accent-red",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg008",
+                      "name": "projItem1",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg009",
+                          "name": "projItemTxt1",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg00h",
+                  "name": "respGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg00g",
+                      "name": "respHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00c",
+                          "name": "respLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00b",
+                              "name": "respDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00d",
+                              "name": "respIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "medal",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00e",
+                              "name": "respLabel",
+                              "fill": "$--foreground",
+                              "content": "Responsibilities",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg00f",
+                          "name": "respChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg00o",
+                  "name": "procGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg00n",
+                      "name": "procHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00j",
+                          "name": "procLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00i",
+                              "name": "procDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00k",
+                              "name": "procIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "arrows-clockwise",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00l",
+                              "name": "procLabel",
+                              "fill": "$--foreground",
+                              "content": "Procedures",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg00m",
+                          "name": "procChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg00v",
+                  "name": "peopleGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg00u",
+                      "name": "peopleHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00q",
+                          "name": "peopleLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00p",
+                              "name": "peopleDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00r",
+                              "name": "peopleIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "leaf",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00s",
+                              "name": "peopleLabel",
+                              "fill": "$--foreground",
+                              "content": "People",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg00t",
+                          "name": "peopleChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg012",
+                  "name": "eventsGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg011",
+                      "name": "eventsHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg00x",
+                          "name": "eventsLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00w",
+                              "name": "eventsDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg00y",
+                              "name": "eventsIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg00z",
+                              "name": "eventsLabel",
+                              "fill": "$--foreground",
+                              "content": "Events",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg010",
+                          "name": "eventsChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg019",
+                  "name": "topicsGroup",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg018",
+                      "name": "topicsHeader",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg014",
+                          "name": "topicsLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg013",
+                              "name": "topicsDrag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg015",
+                              "name": "topicsIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tag",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-green"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg016",
+                              "name": "topicsLabel",
+                              "fill": "$--foreground",
+                              "content": "Topics",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg017",
+                          "name": "topicsChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dsg02w",
+      "name": "Sidebar — Section Being Dragged",
+      "x": 420,
+      "y": 6400,
+      "width": 330,
+      "height": 680,
+      "fill": "$--background",
+      "layout": "vertical",
+      "padding": [
+        16
+      ],
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dsg02x",
+          "name": "frame2Title",
+          "content": "Dragging \"People\" above \"Responsibilities\"",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600",
+          "fill": "$--foreground"
+        },
+        {
+          "type": "text",
+          "id": "dsg02y",
+          "name": "frame2Desc",
+          "content": "Blue drop indicator line shows insertion point. Dragged section floats with blue border.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground"
+        },
+        {
+          "type": "frame",
+          "id": "dsg02z",
+          "height": 12
+        },
+        {
+          "type": "frame",
+          "id": "dsg030",
+          "name": "sidebarDragging",
+          "width": 250,
+          "height": 600,
+          "fill": "$--sidebar",
+          "layout": "vertical",
+          "clip": true,
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg031",
+              "name": "filters",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                6
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg032",
+                  "name": "allNotesRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg033",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg034",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg035",
+                  "name": "favRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg036",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg037",
+                      "fill": "$--muted-foreground",
+                      "content": "Favorites",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsg038",
+              "name": "sectionsWrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg01x",
+                  "name": "proj2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6,
+                    8,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg01s",
+                      "name": "proj2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg01o",
+                          "name": "proj2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg01n",
+                              "name": "proj2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg01p",
+                              "name": "proj2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "wrench",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-red"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg01q",
+                              "name": "proj2Label",
+                              "fill": "$--foreground",
+                              "content": "Projects",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg01r",
+                          "name": "proj2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg01t",
+                      "name": "proj2Item0",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "fill": "$--accent-red-light",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg01u",
+                          "name": "proj2ItemTxt0",
+                          "fill": "$--accent-red",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg01v",
+                      "name": "proj2Item1",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg01w",
+                          "name": "proj2ItemTxt1",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg01y",
+                  "name": "dropIndicator",
+                  "width": "fill_container",
+                  "height": 2,
+                  "fill": "$--accent-blue",
+                  "cornerRadius": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg025",
+                  "name": "resp2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg024",
+                      "name": "resp2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg020",
+                          "name": "resp2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg01z",
+                              "name": "resp2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg021",
+                              "name": "resp2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "medal",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg022",
+                              "name": "resp2Label",
+                              "fill": "$--foreground",
+                              "content": "Responsibilities",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg023",
+                          "name": "resp2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg02c",
+                  "name": "proc2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg02b",
+                      "name": "proc2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg027",
+                          "name": "proc2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg026",
+                              "name": "proc2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg028",
+                              "name": "proc2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "arrows-clockwise",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg029",
+                              "name": "proc2Label",
+                              "fill": "$--foreground",
+                              "content": "Procedures",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg02a",
+                          "name": "proc2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg02j",
+                  "name": "events2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg02i",
+                      "name": "events2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg02e",
+                          "name": "events2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02d",
+                              "name": "events2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02f",
+                              "name": "events2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg02g",
+                              "name": "events2Label",
+                              "fill": "$--foreground",
+                              "content": "Events",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg02h",
+                          "name": "events2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg02q",
+                  "name": "topics2Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg02p",
+                      "name": "topics2Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg02l",
+                          "name": "topics2Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02k",
+                              "name": "topics2Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg02m",
+                              "name": "topics2Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tag",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-green"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg02n",
+                              "name": "topics2Label",
+                              "fill": "$--foreground",
+                              "content": "Topics",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg02o",
+                          "name": "topics2Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dsg02r",
+          "name": "draggedSection",
+          "x": 8,
+          "y": 160,
+          "width": 234,
+          "fill": "$--sidebar",
+          "cornerRadius": 6,
+          "stroke": {
+            "align": "outside",
+            "thickness": 1,
+            "fill": {
+              "type": "color",
+              "color": "$--accent-blue"
+            }
+          },
+          "opacity": 0.9,
+          "layout": "vertical",
+          "padding": [
+            4,
+            6
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg02s",
+              "name": "draggedHeader",
+              "width": "fill_container",
+              "cornerRadius": 4,
+              "gap": 8,
+              "padding": [
+                6,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dsg02t",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "grip-vertical",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-blue",
+                  "opacity": 0.8
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dsg02u",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "leaf",
+                  "iconFontFamily": "phosphor",
+                  "weight": 700,
+                  "fill": "$--accent-yellow"
+                },
+                {
+                  "type": "text",
+                  "id": "dsg02v",
+                  "fill": "$--foreground",
+                  "content": "People",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dsg04j",
+      "name": "Sidebar — After Reorder (People Moved Up)",
+      "x": 772,
+      "y": 6400,
+      "width": 330,
+      "height": 680,
+      "fill": "$--background",
+      "layout": "vertical",
+      "padding": [
+        16
+      ],
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "dsg04k",
+          "name": "frame3Title",
+          "content": "After drop — People now second section",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600",
+          "fill": "$--foreground"
+        },
+        {
+          "type": "text",
+          "id": "dsg04l",
+          "name": "frame3Desc",
+          "content": "Order persisted as \"order\" property in each Type document frontmatter (e.g. order: 2).",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground"
+        },
+        {
+          "type": "frame",
+          "id": "dsg04m",
+          "height": 12
+        },
+        {
+          "type": "frame",
+          "id": "dsg04n",
+          "name": "sidebarReordered",
+          "width": 250,
+          "height": 600,
+          "fill": "$--sidebar",
+          "layout": "vertical",
+          "clip": true,
+          "children": [
+            {
+              "type": "frame",
+              "id": "dsg04o",
+              "name": "filters",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                6
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg04p",
+                  "name": "allNotesRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg04q",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg04r",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg04s",
+                  "name": "favRow",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "dsg04t",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dsg04u",
+                      "fill": "$--muted-foreground",
+                      "content": "Favorites",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsg04v",
+              "name": "sectionsWrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dsg03j",
+                  "name": "proj3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6,
+                    8,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg03e",
+                      "name": "proj3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03a",
+                          "name": "proj3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg039",
+                              "name": "proj3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03b",
+                              "name": "proj3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "wrench",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-red"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg03c",
+                              "name": "proj3Label",
+                              "fill": "$--foreground",
+                              "content": "Projects",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg03d",
+                          "name": "proj3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg03f",
+                      "name": "proj3Item0",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "fill": "$--accent-red-light",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg03g",
+                          "name": "proj3ItemTxt0",
+                          "fill": "$--accent-red",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dsg03h",
+                      "name": "proj3Item1",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "padding": [
+                        6,
+                        16,
+                        6,
+                        28
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dsg03i",
+                          "name": "proj3ItemTxt1",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg03q",
+                  "name": "people3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg03p",
+                      "name": "people3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03l",
+                          "name": "people3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03k",
+                              "name": "people3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03m",
+                              "name": "people3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "leaf",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg03n",
+                              "name": "people3Label",
+                              "fill": "$--foreground",
+                              "content": "People",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg03o",
+                          "name": "people3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg03x",
+                  "name": "resp3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg03w",
+                      "name": "resp3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03s",
+                          "name": "resp3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03r",
+                              "name": "resp3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03t",
+                              "name": "resp3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "medal",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg03u",
+                              "name": "resp3Label",
+                              "fill": "$--foreground",
+                              "content": "Responsibilities",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg03v",
+                          "name": "resp3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg044",
+                  "name": "proc3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg043",
+                      "name": "proc3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg03z",
+                          "name": "proc3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg03y",
+                              "name": "proc3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg040",
+                              "name": "proc3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "arrows-clockwise",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-purple"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg041",
+                              "name": "proc3Label",
+                              "fill": "$--foreground",
+                              "content": "Procedures",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg042",
+                          "name": "proc3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg04b",
+                  "name": "events3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg04a",
+                      "name": "events3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg046",
+                          "name": "events3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg045",
+                              "name": "events3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg047",
+                              "name": "events3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-yellow"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg048",
+                              "name": "events3Label",
+                              "fill": "$--foreground",
+                              "content": "Events",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg049",
+                          "name": "events3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dsg04i",
+                  "name": "topics3Group",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": {
+                      "type": "color",
+                      "color": "$--border",
+                      "enabled": false
+                    }
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": [
+                    4,
+                    6
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dsg04h",
+                      "name": "topics3Header",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsg04d",
+                          "name": "topics3Left",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dsg04c",
+                              "name": "topics3Drag",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground",
+                              "opacity": 0.5
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "dsg04e",
+                              "name": "topics3Icon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tag",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-green"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dsg04f",
+                              "name": "topics3Label",
+                              "fill": "$--foreground",
+                              "content": "Topics",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "dsg04g",
+                          "name": "topics3Chev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "csB01",
+      "x": 0,
+      "y": 7140,
+      "name": "Sections Header — Before (old design)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 280,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        12
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "csB02",
+          "name": "frameLabel",
+          "fill": "$--muted-foreground",
+          "content": "BEFORE — Old Design",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 1
+        },
+        {
+          "type": "frame",
+          "id": "csB03",
+          "name": "customizeBtn",
+          "width": "fill_container",
+          "cornerRadius": 4,
+          "gap": 6,
+          "padding": [
+            4,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "csB04",
+              "name": "slidersIcon",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "sliders-horizontal",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "text",
+              "id": "csB05",
+              "name": "customizeLabel",
+              "fill": "$--muted-foreground",
+              "content": "Customize sections",
+              "fontFamily": "Inter",
+              "fontSize": 12
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "csB06",
+          "name": "sectionRow",
+          "width": "fill_container",
+          "cornerRadius": 4,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "csB07",
+              "name": "left",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "csB08",
+                  "name": "projIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wrench",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--accent-red"
+                },
+                {
+                  "type": "text",
+                  "id": "csB09",
+                  "name": "projLabel",
+                  "fill": "$--foreground",
+                  "content": "Projects",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "csB10",
+              "name": "chevron",
+              "width": 12,
+              "height": 12,
+              "iconFontName": "caret-right",
+              "iconFontFamily": "phosphor",
+              "fill": "$--foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "csA01",
+      "x": 340,
+      "y": 7140,
+      "name": "Sections Header — After (new design)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 280,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        16,
+        12
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "csA02",
+          "name": "frameLabel",
+          "fill": "$--muted-foreground",
+          "content": "AFTER — New Design",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 1
+        },
+        {
+          "type": "frame",
+          "id": "csA03",
+          "name": "sectionsHeader",
+          "width": "fill_container",
+          "padding": [
+            4,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "csA04",
+              "name": "sectionsLabel",
+              "fill": "$--muted-foreground",
+              "content": "SECTIONS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1.2
+            },
+            {
+              "type": "icon_font",
+              "id": "csA05",
+              "name": "settingsIcon",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "sliders-horizontal",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "csA06",
+          "name": "sectionRow",
+          "width": "fill_container",
+          "cornerRadius": 4,
+          "gap": 8,
+          "padding": [
+            6,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "csA07",
+              "name": "left",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "csA08",
+                  "name": "projIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wrench",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--accent-red"
+                },
+                {
+                  "type": "text",
+                  "id": "csA09",
+                  "name": "projLabel",
+                  "fill": "$--foreground",
+                  "content": "Projects",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "csA10",
+              "name": "chevron",
+              "width": 12,
+              "height": 12,
+              "iconFontName": "caret-right",
+              "iconFontFamily": "phosphor",
+              "fill": "$--foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "archBtnNorm",
+      "x": 68,
+      "y": 5200,
+      "name": "Archive Notes — Breadcrumb button (normal note)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 800,
+      "height": 45,
+      "fill": "$--background",
+      "stroke": {
+        "align": "inside",
+        "thickness": {
+          "bottom": 1
+        },
+        "fill": "$--border"
+      },
+      "padding": [
+        6,
+        16
+      ],
+      "justifyContent": "space_between",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "anInfoL",
+          "name": "infoLeft",
+          "gap": 6,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "anType",
+              "name": "breadcrumbType",
+              "fill": "$--muted-foreground",
+              "content": "Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "anSep",
+              "name": "breadcrumbSep",
+              "fill": "$--muted-foreground",
+              "content": "›",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "anName",
+              "name": "breadcrumbName",
+              "fill": "$--foreground",
+              "content": "My Active Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "anDot",
+              "name": "dotSep",
+              "fill": "$--muted-foreground",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "anWords",
+              "name": "wordCount",
+              "fill": "$--muted-foreground",
+              "content": "1,234 words",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "anInfoR",
+          "name": "infoRight",
+          "gap": 12,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "anISearch",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "magnifying-glass",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anIGit",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "git-branch",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anICursor",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "cursor-text",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anIAI",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "sparkle",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "frame",
+              "id": "anArchiveBtn",
+              "name": "archiveButton",
+              "gap": 4,
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--primary"
+              },
+              "cornerRadius": 4,
+              "padding": [
+                2,
+                2
+              ],
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "anIArchive",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "archive",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--primary"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "anITrash",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "trash",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "anIMore",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "dots-three",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "archBtnArc",
+      "x": 68,
+      "y": 5300,
+      "name": "Archive Notes — Breadcrumb button (archived note, shows Unarchive)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 800,
+      "height": 45,
+      "fill": "$--background",
+      "stroke": {
+        "align": "inside",
+        "thickness": {
+          "bottom": 1
+        },
+        "fill": "$--border"
+      },
+      "padding": [
+        6,
+        16
+      ],
+      "justifyContent": "space_between",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "auInfoL",
+          "name": "infoLeft",
+          "gap": 6,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "auType",
+              "name": "breadcrumbType",
+              "fill": "$--muted-foreground",
+              "content": "Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "auSep",
+              "name": "breadcrumbSep",
+              "fill": "$--muted-foreground",
+              "content": "›",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "auName",
+              "name": "breadcrumbName",
+              "fill": "$--foreground",
+              "content": "My Archived Note",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "auDot",
+              "name": "dotSep",
+              "fill": "$--muted-foreground",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "auWords",
+              "name": "wordCount",
+              "fill": "$--muted-foreground",
+              "content": "567 words",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "auBadge",
+              "name": "archivedBadge",
+              "height": 16,
+              "fill": "#2563eb1a",
+              "cornerRadius": 4,
+              "padding": [
+                1,
+                4
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "auBadgeTxt",
+                  "fill": "$--primary",
+                  "content": "ARCHIVED",
+                  "fontFamily": "Inter",
+                  "fontSize": 9,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "auInfoR",
+          "name": "infoRight",
+          "gap": 12,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "auISearch",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "magnifying-glass",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auIGit",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "git-branch",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auICursor",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "cursor-text",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auIAI",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "sparkle",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "frame",
+              "id": "auUnarchiveBtn",
+              "name": "unarchiveButton",
+              "gap": 4,
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--primary"
+              },
+              "cornerRadius": 4,
+              "padding": [
+                2,
+                2
+              ],
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "auIUnarchive",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "arrow-u-up-left",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--primary"
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "auITrash",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "trash",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            },
+            {
+              "type": "icon_font",
+              "id": "auIMore",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "dots-three",
+              "iconFontFamily": "phosphor",
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ghCL1",
+      "x": 0,
+      "y": 7320,
+      "name": "Git History — Commit List",
+      "width": 300,
+      "height": "fit_content(600)",
+      "fill": "$--background",
+      "cornerRadius": "$--radius-lg",
+      "stroke": {
+        "fill": "$--border",
+        "thickness": 1
+      },
+      "layout": "vertical",
+      "gap": 16,
+      "padding": 12,
+      "children": [
+        {
+          "type": "text",
+          "id": "ghCL1h",
+          "content": "HISTORY",
+          "fill": "$--muted-foreground",
+          "fontSize": 10,
+          "fontWeight": "600",
+          "letterSpacing": 1.2
+        },
+        {
+          "type": "frame",
+          "id": "ghC1",
+          "layout": "vertical",
+          "width": "fill_container",
+          "gap": 2,
+          "padding": [
+            0,
+            0,
+            0,
+            10
+          ],
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "left": 2
+            }
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghC1r",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghC1h",
+                  "content": "a1b2c3d",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "underline": true
+                },
+                {
+                  "type": "text",
+                  "id": "ghC1d",
+                  "content": "2d ago",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ghC1m",
+              "content": "Update grow-newsletter with latest changes",
+              "fill": "$--secondary-foreground",
+              "fontSize": 12,
+              "textGrowth": "fixed-width",
+              "width": "fill_container"
+            },
+            {
+              "type": "text",
+              "id": "ghC1a",
+              "content": "Luca Rossi",
+              "fill": "$--muted-foreground",
+              "fontSize": 10
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ghC2",
+          "layout": "vertical",
+          "width": "fill_container",
+          "gap": 2,
+          "padding": [
+            0,
+            0,
+            0,
+            10
+          ],
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "left": 2
+            }
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghC2r",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghC2h",
+                  "content": "e4f5g6h",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "underline": true
+                },
+                {
+                  "type": "text",
+                  "id": "ghC2d",
+                  "content": "5d ago",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ghC2m",
+              "content": "Add new section to grow-newsletter",
+              "fill": "$--secondary-foreground",
+              "fontSize": 12,
+              "textGrowth": "fixed-width",
+              "width": "fill_container"
+            },
+            {
+              "type": "text",
+              "id": "ghC2a",
+              "content": "Luca Rossi",
+              "fill": "$--muted-foreground",
+              "fontSize": 10
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ghC3",
+          "layout": "vertical",
+          "width": "fill_container",
+          "gap": 2,
+          "padding": [
+            0,
+            0,
+            0,
+            10
+          ],
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "left": 2
+            }
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghC3r",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghC3h",
+                  "content": "i7j8k9l",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "underline": true
+                },
+                {
+                  "type": "text",
+                  "id": "ghC3d",
+                  "content": "12d ago",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ghC3m",
+              "content": "Create grow-newsletter",
+              "fill": "$--secondary-foreground",
+              "fontSize": 12,
+              "textGrowth": "fixed-width",
+              "width": "fill_container"
+            },
+            {
+              "type": "text",
+              "id": "ghC3a",
+              "content": "Luca Rossi",
+              "fill": "$--muted-foreground",
+              "fontSize": 10
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ghDO1",
+      "x": 380,
+      "y": 7320,
+      "name": "Git History — Diff Open",
+      "width": 600,
+      "height": "fit_content(500)",
+      "fill": "$--background",
+      "cornerRadius": "$--radius-lg",
+      "stroke": {
+        "fill": "$--border",
+        "thickness": 1
+      },
+      "layout": "vertical",
+      "gap": 0,
+      "padding": 0,
+      "children": [
+        {
+          "type": "frame",
+          "id": "ghDObc",
+          "layout": "horizontal",
+          "width": "fill_container",
+          "height": 36,
+          "padding": [
+            0,
+            12
+          ],
+          "gap": 8,
+          "alignItems": "center",
+          "fill": "$--muted",
+          "stroke": {
+            "fill": "$--border",
+            "thickness": {
+              "bottom": 1
+            }
+          },
+          "children": [
+            {
+              "type": "text",
+              "id": "ghDObcP",
+              "content": "responsibility / grow-newsletter.md",
+              "fill": "$--muted-foreground",
+              "fontSize": 12
+            },
+            {
+              "type": "frame",
+              "id": "ghDObcS",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "ghDObcB",
+              "layout": "horizontal",
+              "padding": [
+                2,
+                8
+              ],
+              "cornerRadius": "$--radius-sm",
+              "fill": "$--primary",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDObcBt",
+                  "content": "Diff: a1b2c3d",
+                  "fill": "$--primary-foreground",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ghDOb",
+          "layout": "vertical",
+          "width": "fill_container",
+          "padding": 0,
+          "gap": 0,
+          "children": [
+            {
+              "type": "frame",
+              "id": "ghDOl1",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "$--muted",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl1n",
+                  "content": "1",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl1t",
+                  "content": "diff --git a/grow-newsletter.md b/grow-newsletter.md",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl2",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#2196F30D",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl2n",
+                  "content": "2",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl2t",
+                  "content": "@@ -5,3 +5,5 @@",
+                  "fill": "$--primary",
+                  "fontSize": 11,
+                  "fontStyle": "italic"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl3",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl3n",
+                  "content": "3",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl3t",
+                  "content": " # Grow Newsletter",
+                  "fill": "$--secondary-foreground",
+                  "fontSize": 11
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl4",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#f4433614",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl4n",
+                  "content": "4",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl4t",
+                  "content": "-Old paragraph from before a1b2c3d.",
+                  "fill": "#f44336",
+                  "fontSize": 11
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl5",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#4caf5014",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl5n",
+                  "content": "5",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl5t",
+                  "content": "+Updated paragraph at commit a1b2c3d.",
+                  "fill": "#4caf50",
+                  "fontSize": 11
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ghDOl6",
+              "layout": "horizontal",
+              "width": "fill_container",
+              "height": 22,
+              "padding": [
+                0,
+                8
+              ],
+              "alignItems": "center",
+              "fill": "#4caf5014",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ghDOl6n",
+                  "content": "6",
+                  "fill": "$--muted-foreground",
+                  "fontSize": 11,
+                  "textGrowth": "fixed-width",
+                  "width": 30,
+                  "textAlign": "right"
+                },
+                {
+                  "type": "text",
+                  "id": "ghDOl6t",
+                  "content": "+New content added in this commit.",
+                  "fill": "#4caf50",
+                  "fontSize": 11
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rnt0",
+      "name": "Rename Tab — Normal tab state",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "rnt1",
+          "name": "frameLabel",
+          "content": "Normal state: tabs show note title. Double-click to rename.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rnt2",
+          "name": "Tab Bar Normal",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rnt3",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rnt4",
+                  "fill": "$--foreground",
+                  "content": "Weekly Review",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rnt5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rnt6",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rnt7",
+                  "fill": "$--muted-foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rnt8",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rnt9",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "rnta",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "rntb",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "rntc",
+          "name": "interactionNote",
+          "content": "Double-click tab title → enters edit mode",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rne0",
+      "name": "Rename Tab — Double-clicked (editing mode)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "rne1",
+          "name": "frameLabel",
+          "content": "Editing mode: tab title replaced with inline input field, text selected.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rne2",
+          "name": "Tab Bar Editing",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rne3",
+              "name": "Tab Active (Editing)",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rne4",
+                  "name": "Inline Input",
+                  "fill": "$--background",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$--ring"
+                  },
+                  "cornerRadius": 3,
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rne5",
+                      "fill": "$--foreground",
+                      "content": "Weekly Review",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500",
+                      "highlight": "$--primary",
+                      "highlightOpacity": 0.2
+                    }
+                  ]
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rne6",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rne7",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rne8",
+                  "fill": "$--muted-foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rne9",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rnea",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "rneb",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "rnec",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "rned",
+          "name": "interactionNote",
+          "content": "Enter → save & rename file + update wiki links | Escape → cancel | Blur → save",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rns0",
+      "name": "Rename Tab — Saved (updated name)",
+      "width": 800,
+      "height": 120,
+      "layout": "vertical",
+      "fill": "$--sidebar",
+      "theme": {
+        "Mode": "Light"
+      },
+      "children": [
+        {
+          "type": "text",
+          "id": "rns1",
+          "name": "frameLabel",
+          "content": "After save: tab shows updated title. File renamed, wiki links updated across vault.",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            8,
+            12
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rns2",
+          "name": "Tab Bar Saved",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--sidebar-border"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rns3",
+              "name": "Tab Active (Renamed)",
+              "height": "fill_container",
+              "fill": "$--background",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rns4",
+                  "fill": "$--foreground",
+                  "content": "Sprint Retrospective",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rns5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rns6",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "bottom": 1
+                },
+                "fill": "$--sidebar-border"
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rns7",
+                  "fill": "$--muted-foreground",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "rns8",
+                  "opacity": 0,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rns9",
+              "name": "tabSpacer",
+              "width": "fill_container",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              }
+            },
+            {
+              "type": "frame",
+              "id": "rnsa",
+              "name": "tabControls",
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1,
+                  "left": 1
+                },
+                "fill": "$--border"
+              },
+              "gap": 12,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_around",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "rnsb",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "rnsc",
+          "name": "interactionNote",
+          "content": "File: weekly-review.md → sprint-retrospective.md | [[Weekly Review]] → [[Sprint Retrospective]] in all notes",
+          "fontFamily": "Inter",
+          "fontSize": 10,
+          "fontWeight": "normal",
+          "fill": "$--muted-foreground",
+          "padding": [
+            4,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mb001",
+      "x": 0,
+      "y": 0,
+      "name": "macOS Border — Before (no border)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 400,
+      "height": 200,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "mb002",
+          "name": "macOS Title Bar (before)",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "mb003",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "mb004",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb005",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb006",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "mb007",
+          "name": "Sidebar Content (before)",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$--sidebar",
+          "padding": [
+            8,
+            12
+          ],
+          "layout": "vertical",
+          "gap": 4,
+          "children": [
+            {
+              "type": "text",
+              "id": "mb008",
+              "value": "All Notes",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb009",
+              "value": "Favorites",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb010",
+              "value": "Archive",
+              "fontSize": 14,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mb011",
+      "x": 440,
+      "y": 0,
+      "name": "macOS Border — After (with border)",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 400,
+      "height": 200,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "mb012",
+          "name": "macOS Title Bar (after)",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "mb013",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "mb014",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb015",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "mb016",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "mb017",
+          "name": "Sidebar Content (after)",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$--sidebar",
+          "padding": [
+            8,
+            12
+          ],
+          "layout": "vertical",
+          "gap": 4,
+          "children": [
+            {
+              "type": "text",
+              "id": "mb018",
+              "value": "All Notes",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb019",
+              "value": "Favorites",
+              "fontSize": 14,
+              "fill": "$--foreground"
+            },
+            {
+              "type": "text",
+              "id": "mb020",
+              "value": "Archive",
+              "fontSize": 14,
+              "fill": "$--muted-foreground"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "themes": {
+    "Mode": [
+      "Dark"
+    ]
+  },
+  "variables": {
+    "--accent": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#252545",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-blue": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-green": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#0F7B6C"
+        },
+        {
+          "value": "#4caf50",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#00B38B"
+        },
+        {
+          "value": "#00B38B",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-orange": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#D9730D"
+        },
+        {
+          "value": "#ff9800",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-purple": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#9065B0"
+        },
+        {
+          "value": "#9c72ff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#A932FF"
+        },
+        {
+          "value": "#A932FF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-red": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E"
+        },
+        {
+          "value": "#f44336",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--background": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#0f0f1a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--black": {
+      "type": "color",
+      "value": "#000000"
+    },
+    "--border": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--card": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#16162a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--card-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--destructive": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E"
+        },
+        {
+          "value": "#f44336",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--destructive-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--font-primary": {
+      "type": "string",
+      "value": [
+        {
+          "value": "Inter"
+        },
+        {
+          "value": "-apple-system, BlinkMacSystemFont, Inter, sans-serif"
+        },
+        {
+          "value": "Inter"
+        }
+      ]
+    },
+    "--font-system": {
+      "type": "string",
+      "value": "-apple-system, BlinkMacSystemFont, sans-serif"
+    },
+    "--foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--input": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--muted": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0F0EF"
+        },
+        {
+          "value": "#1e1e3a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--muted-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#787774"
+        },
+        {
+          "value": "#888888",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--popover": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#1e1e3a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--popover-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--primary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--primary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--radius-lg": {
+      "type": "number",
+      "value": 8
+    },
+    "--radius-md": {
+      "type": "number",
+      "value": 6
+    },
+    "--radius-sm": {
+      "type": "number",
+      "value": 4
+    },
+    "--ring": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--secondary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--secondary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F7F6F3"
+        },
+        {
+          "value": "#1a1a2e",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-accent": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#252545",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-accent-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-border": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-primary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-primary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-ring": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "--accent-yellow": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0B100"
+        },
+        {
+          "value": "#F0B100",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-blue-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#155DFF14"
+        },
+        {
+          "value": "#155DFF20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-green-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#00B38B14"
+        },
+        {
+          "value": "#00B38B20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-purple-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#A932FF14"
+        },
+        {
+          "value": "#A932FF20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-red-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E14"
+        },
+        {
+          "value": "#f4433620",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-yellow-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0B10014"
+        },
+        {
+          "value": "#F0B10020",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    }
+  },
+  "fonts": [
+    {
+      "name": "GT Pressura Trial",
+      "url": "GT-Pressura-Regular-Trial.otf"
+    }
+  ]
+}

--- a/design/dynamic-vault-management.pen
+++ b/design/dynamic-vault-management.pen
@@ -1440,7 +1440,8 @@
                                   "fill": "$--muted-foreground",
                                   "content": "RELATED NOTES",
                                   "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 11
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
                                 },
                                 {
                                   "type": "text",
@@ -1704,7 +1705,8 @@
                                   "fill": "$--muted-foreground",
                                   "content": "EVENTS",
                                   "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 11
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
                                 },
                                 {
                                   "type": "text",
@@ -2573,7 +2575,8 @@
                                       "fill": "$--muted-foreground",
                                       "content": "BELONGS TO",
                                       "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 10
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
                                     },
                                     {
                                       "type": "frame",
@@ -2696,7 +2699,8 @@
                                       "fill": "$--muted-foreground",
                                       "content": "RELATED TO",
                                       "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 10
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
                                     },
                                     {
                                       "type": "frame",
@@ -2792,7 +2796,8 @@
                                       "fill": "$--muted-foreground",
                                       "content": "BACKLINKS",
                                       "fontFamily": "IBM Plex Mono",
-                                      "fontSize": 10
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
                                     }
                                   ]
                                 },
@@ -2843,7 +2848,8 @@
                                   "fill": "$--muted-foreground",
                                   "content": "HISTORY",
                                   "fontFamily": "IBM Plex Mono",
-                                  "fontSize": 10
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
                                 },
                                 {
                                   "type": "frame",
@@ -4745,7 +4751,6 @@
       "height": 400,
       "fill": "$--sidebar",
       "layout": "vertical",
-      "gap": 0,
       "padding": [
         8,
         6
@@ -4962,7 +4967,6 @@
       "height": 360,
       "fill": "$--card",
       "layout": "vertical",
-      "gap": 0,
       "children": [
         {
           "type": "frame",
@@ -4970,12 +4974,6 @@
           "name": "header",
           "width": "fill_container",
           "height": 45,
-          "padding": [
-            0,
-            16
-          ],
-          "alignItems": "center",
-          "justifyContent": "space_between",
           "stroke": {
             "align": "inside",
             "thickness": {
@@ -4983,6 +4981,12 @@
             },
             "fill": "$--border"
           },
+          "padding": [
+            0,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
           "children": [
             {
               "type": "text",
@@ -5000,12 +5004,6 @@
           "id": "trN1",
           "name": "trashedNote1",
           "width": "fill_container",
-          "layout": "vertical",
-          "gap": 2,
-          "padding": [
-            14,
-            16
-          ],
           "stroke": {
             "align": "inside",
             "thickness": {
@@ -5013,6 +5011,12 @@
             },
             "fill": "$--border"
           },
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
           "children": [
             {
               "type": "frame",
@@ -5062,8 +5066,7 @@
               "fill": "$--muted-foreground",
               "content": "Some draft content that is no longer needed...",
               "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "400"
+              "fontSize": 12
             },
             {
               "type": "text",
@@ -5071,8 +5074,7 @@
               "fill": "$--muted-foreground",
               "content": "5d ago",
               "fontFamily": "Inter",
-              "fontSize": 10,
-              "fontWeight": "400"
+              "fontSize": 10
             }
           ]
         },
@@ -5081,12 +5083,6 @@
           "id": "trN2",
           "name": "trashedNote2Warning",
           "width": "fill_container",
-          "layout": "vertical",
-          "gap": 2,
-          "padding": [
-            14,
-            16
-          ],
           "fill": "#ef44440a",
           "stroke": {
             "align": "inside",
@@ -5095,6 +5091,12 @@
             },
             "fill": "$--border"
           },
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            14,
+            16
+          ],
           "children": [
             {
               "type": "frame",
@@ -5144,8 +5146,7 @@
               "fill": "$--muted-foreground",
               "content": "Old API documentation that was replaced...",
               "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "400"
+              "fontSize": 12
             },
             {
               "type": "text",
@@ -5175,10 +5176,7 @@
       "fill": "$--background",
       "layout": "vertical",
       "gap": 8,
-      "padding": [
-        16,
-        16
-      ],
+      "padding": 16,
       "children": [
         {
           "type": "text",
@@ -5197,13 +5195,13 @@
           "width": "fill_container",
           "fill": "$--accent-blue-light",
           "cornerRadius": 6,
+          "gap": 6,
           "padding": [
             6,
             10
           ],
-          "gap": 6,
-          "alignItems": "center",
           "justifyContent": "space_between",
+          "alignItems": "center",
           "children": [
             {
               "type": "text",
@@ -5230,17 +5228,17 @@
           "type": "frame",
           "id": "trRT",
           "name": "trashedRef",
+          "opacity": 0.7,
           "width": "fill_container",
           "fill": "$--muted",
           "cornerRadius": 6,
+          "gap": 6,
           "padding": [
             6,
             10
           ],
-          "gap": 6,
-          "alignItems": "center",
           "justifyContent": "space_between",
-          "opacity": 0.7,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
@@ -5273,8 +5271,7 @@
                   "fill": "$--muted-foreground",
                   "content": "(trashed)",
                   "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "400"
+                  "fontSize": 10
                 }
               ]
             },
@@ -5294,17 +5291,17 @@
           "type": "frame",
           "id": "trRA",
           "name": "archivedRef",
+          "opacity": 0.7,
           "width": "fill_container",
           "fill": "$--muted",
           "cornerRadius": 6,
+          "gap": 6,
           "padding": [
             6,
             10
           ],
-          "gap": 6,
-          "alignItems": "center",
           "justifyContent": "space_between",
-          "opacity": 0.7,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
@@ -5327,8 +5324,7 @@
                   "fill": "$--muted-foreground",
                   "content": "(archived)",
                   "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "400"
+                  "fontSize": 10
                 }
               ]
             },
@@ -5361,10 +5357,7 @@
       "fill": "$--background",
       "layout": "vertical",
       "gap": 8,
-      "padding": [
-        16,
-        16
-      ],
+      "padding": 16,
       "children": [
         {
           "type": "text",
@@ -5382,17 +5375,17 @@
           "width": "fill_container",
           "fill": "#ef44440f",
           "cornerRadius": 8,
-          "padding": [
-            10,
-            12
-          ],
-          "gap": 8,
-          "alignItems": "center",
           "stroke": {
             "align": "inside",
             "thickness": 1,
             "fill": "#ef444430"
           },
+          "gap": 8,
+          "padding": [
+            10,
+            12
+          ],
+          "alignItems": "center",
           "children": [
             {
               "type": "icon_font",
@@ -5425,8 +5418,7 @@
                   "fill": "$--muted-foreground",
                   "content": "1 note is past the 30-day retention period",
                   "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "400"
+                  "fontSize": 11
                 }
               ]
             }
@@ -5437,28 +5429,26 @@
     {
       "type": "frame",
       "id": "dt0",
+      "x": 0,
+      "y": 0,
       "name": "Draggable Tabs — Default State",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "dt1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "Default: tabs are draggable (grab cursor on hover)",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -5691,43 +5681,37 @@
           "type": "text",
           "id": "dti",
           "name": "cursorNote",
+          "fill": "$--muted-foreground",
           "content": "cursor: grab → grabbing during drag",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "dtj",
+      "x": 0,
+      "y": 0,
       "name": "Draggable Tabs — Dragging (Tab Being Moved)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "dtk",
           "name": "frameLabel2",
+          "fill": "$--muted-foreground",
           "content": "Dragging: \"Portfolio Rewrite\" is being dragged left (opacity 0.5, blue drop indicator)",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -5747,12 +5731,12 @@
           "children": [
             {
               "type": "rectangle",
+              "cornerRadius": 1,
               "id": "dtm",
               "name": "Drop Indicator",
-              "width": 2,
-              "height": 30,
               "fill": "$--primary",
-              "cornerRadius": 1
+              "width": 2,
+              "height": 30
             },
             {
               "type": "frame",
@@ -5798,8 +5782,8 @@
               "type": "frame",
               "id": "dtq",
               "name": "Tab Dragging (ghost)",
-              "height": "fill_container",
               "opacity": 0.5,
+              "height": "fill_container",
               "stroke": {
                 "align": "inside",
                 "thickness": {
@@ -5950,43 +5934,37 @@
           "type": "text",
           "id": "dt10",
           "name": "dragNote",
+          "fill": "$--muted-foreground",
           "content": "Drop indicator: 2px $--primary bar shows insertion point. Dragged tab has opacity: 0.5.",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "dt11",
+      "x": 0,
+      "y": 0,
       "name": "Draggable Tabs — After Drop (Reordered)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "dt12",
           "name": "frameLabel3",
+          "fill": "$--muted-foreground",
           "content": "After drop: \"Portfolio Rewrite\" moved before \"Laputa App\". Order persisted to localStorage.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -6219,69 +6197,63 @@
           "type": "text",
           "id": "dt1j",
           "name": "persistNote",
+          "fill": "$--muted-foreground",
           "content": "localStorage key: \"laputa-tab-order\" stores path array. Restored on next session.",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "dsg01a",
-      "name": "Sidebar — Drag Handles Visible",
       "x": 68,
       "y": 6400,
+      "name": "Sidebar — Drag Handles Visible",
+      "theme": {
+        "Mode": "Light"
+      },
       "width": 330,
       "height": 680,
       "fill": "$--background",
       "layout": "vertical",
-      "padding": [
-        16
-      ],
-      "theme": {
-        "Mode": "Light"
-      },
       "children": [
         {
           "type": "text",
           "id": "dsg01b",
           "name": "frame1Title",
+          "fill": "$--foreground",
           "content": "Drag handles appear on section headers",
           "fontFamily": "Inter",
           "fontSize": 14,
-          "fontWeight": "600",
-          "fill": "$--foreground"
+          "fontWeight": "600"
         },
         {
           "type": "text",
           "id": "dsg01c",
           "name": "frame1Desc",
+          "fill": "$--muted-foreground",
           "content": "Grip icon shown left of section icon. Cursor changes to grab on hover.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground"
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
           "id": "dsg01d",
+          "width": "fit_content(0)",
           "height": 12
         },
         {
           "type": "frame",
           "id": "dsg01e",
           "name": "sidebarDefault",
+          "clip": true,
           "width": 250,
           "height": 600,
           "fill": "$--sidebar",
           "layout": "vertical",
-          "clip": true,
           "children": [
             {
               "type": "frame",
@@ -6301,11 +6273,11 @@
                   "name": "allNotesRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -6334,11 +6306,11 @@
                   "name": "favRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -6421,12 +6393,12 @@
                               "type": "icon_font",
                               "id": "dsg000",
                               "name": "projDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6468,6 +6440,7 @@
                       "id": "dsg006",
                       "name": "projItem0",
                       "width": "fill_container",
+                      "fill": "$--accent-red-light",
                       "cornerRadius": 6,
                       "padding": [
                         6,
@@ -6476,7 +6449,6 @@
                         28
                       ],
                       "alignItems": "center",
-                      "fill": "$--accent-red-light",
                       "children": [
                         {
                           "type": "text",
@@ -6566,12 +6538,12 @@
                               "type": "icon_font",
                               "id": "dsg00b",
                               "name": "respDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6658,12 +6630,12 @@
                               "type": "icon_font",
                               "id": "dsg00i",
                               "name": "procDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6750,12 +6722,12 @@
                               "type": "icon_font",
                               "id": "dsg00p",
                               "name": "peopleDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6842,12 +6814,12 @@
                               "type": "icon_font",
                               "id": "dsg00w",
                               "name": "eventsDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6934,12 +6906,12 @@
                               "type": "icon_font",
                               "id": "dsg013",
                               "name": "topicsDrag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -6987,54 +6959,52 @@
     {
       "type": "frame",
       "id": "dsg02w",
-      "name": "Sidebar — Section Being Dragged",
       "x": 420,
       "y": 6400,
+      "name": "Sidebar — Section Being Dragged",
+      "theme": {
+        "Mode": "Light"
+      },
       "width": 330,
       "height": 680,
       "fill": "$--background",
       "layout": "vertical",
-      "padding": [
-        16
-      ],
-      "theme": {
-        "Mode": "Light"
-      },
       "children": [
         {
           "type": "text",
           "id": "dsg02x",
           "name": "frame2Title",
+          "fill": "$--foreground",
           "content": "Dragging \"People\" above \"Responsibilities\"",
           "fontFamily": "Inter",
           "fontSize": 14,
-          "fontWeight": "600",
-          "fill": "$--foreground"
+          "fontWeight": "600"
         },
         {
           "type": "text",
           "id": "dsg02y",
           "name": "frame2Desc",
+          "fill": "$--muted-foreground",
           "content": "Blue drop indicator line shows insertion point. Dragged section floats with blue border.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground"
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
           "id": "dsg02z",
+          "width": "fit_content(0)",
           "height": 12
         },
         {
           "type": "frame",
           "id": "dsg030",
           "name": "sidebarDragging",
+          "clip": true,
           "width": 250,
           "height": 600,
           "fill": "$--sidebar",
           "layout": "vertical",
-          "clip": true,
           "children": [
             {
               "type": "frame",
@@ -7054,11 +7024,11 @@
                   "name": "allNotesRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7087,11 +7057,11 @@
                   "name": "favRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7174,12 +7144,12 @@
                               "type": "icon_font",
                               "id": "dsg01n",
                               "name": "proj2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7221,6 +7191,7 @@
                       "id": "dsg01t",
                       "name": "proj2Item0",
                       "width": "fill_container",
+                      "fill": "$--accent-red-light",
                       "cornerRadius": 6,
                       "padding": [
                         6,
@@ -7229,7 +7200,6 @@
                         28
                       ],
                       "alignItems": "center",
-                      "fill": "$--accent-red-light",
                       "children": [
                         {
                           "type": "text",
@@ -7328,12 +7298,12 @@
                               "type": "icon_font",
                               "id": "dsg01z",
                               "name": "resp2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7420,12 +7390,12 @@
                               "type": "icon_font",
                               "id": "dsg026",
                               "name": "proc2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7512,12 +7482,12 @@
                               "type": "icon_font",
                               "id": "dsg02d",
                               "name": "events2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7604,12 +7574,12 @@
                               "type": "icon_font",
                               "id": "dsg02k",
                               "name": "topics2Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7656,20 +7626,15 @@
           "type": "frame",
           "id": "dsg02r",
           "name": "draggedSection",
-          "x": 8,
-          "y": 160,
+          "opacity": 0.9,
           "width": 234,
           "fill": "$--sidebar",
           "cornerRadius": 6,
           "stroke": {
             "align": "outside",
             "thickness": 1,
-            "fill": {
-              "type": "color",
-              "color": "$--accent-blue"
-            }
+            "fill": "$--accent-blue"
           },
-          "opacity": 0.9,
           "layout": "vertical",
           "padding": [
             4,
@@ -7692,12 +7657,12 @@
                 {
                   "type": "icon_font",
                   "id": "dsg02t",
+                  "opacity": 0.8,
                   "width": 14,
                   "height": 14,
                   "iconFontName": "grip-vertical",
                   "iconFontFamily": "lucide",
-                  "fill": "$--accent-blue",
-                  "opacity": 0.8
+                  "fill": "$--accent-blue"
                 },
                 {
                   "type": "icon_font",
@@ -7727,54 +7692,52 @@
     {
       "type": "frame",
       "id": "dsg04j",
-      "name": "Sidebar — After Reorder (People Moved Up)",
       "x": 772,
       "y": 6400,
+      "name": "Sidebar — After Reorder (People Moved Up)",
+      "theme": {
+        "Mode": "Light"
+      },
       "width": 330,
       "height": 680,
       "fill": "$--background",
       "layout": "vertical",
-      "padding": [
-        16
-      ],
-      "theme": {
-        "Mode": "Light"
-      },
       "children": [
         {
           "type": "text",
           "id": "dsg04k",
           "name": "frame3Title",
+          "fill": "$--foreground",
           "content": "After drop — People now second section",
           "fontFamily": "Inter",
           "fontSize": 14,
-          "fontWeight": "600",
-          "fill": "$--foreground"
+          "fontWeight": "600"
         },
         {
           "type": "text",
           "id": "dsg04l",
           "name": "frame3Desc",
+          "fill": "$--muted-foreground",
           "content": "Order persisted as \"order\" property in each Type document frontmatter (e.g. order: 2).",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground"
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
           "id": "dsg04m",
+          "width": "fit_content(0)",
           "height": 12
         },
         {
           "type": "frame",
           "id": "dsg04n",
           "name": "sidebarReordered",
+          "clip": true,
           "width": 250,
           "height": 600,
           "fill": "$--sidebar",
           "layout": "vertical",
-          "clip": true,
           "children": [
             {
               "type": "frame",
@@ -7794,11 +7757,11 @@
                   "name": "allNotesRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7827,11 +7790,11 @@
                   "name": "favRow",
                   "width": "fill_container",
                   "cornerRadius": 4,
+                  "gap": 8,
                   "padding": [
                     6,
                     16
                   ],
-                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
@@ -7914,12 +7877,12 @@
                               "type": "icon_font",
                               "id": "dsg039",
                               "name": "proj3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -7961,6 +7924,7 @@
                       "id": "dsg03f",
                       "name": "proj3Item0",
                       "width": "fill_container",
+                      "fill": "$--accent-red-light",
                       "cornerRadius": 6,
                       "padding": [
                         6,
@@ -7969,7 +7933,6 @@
                         28
                       ],
                       "alignItems": "center",
-                      "fill": "$--accent-red-light",
                       "children": [
                         {
                           "type": "text",
@@ -8059,12 +8022,12 @@
                               "type": "icon_font",
                               "id": "dsg03k",
                               "name": "people3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8151,12 +8114,12 @@
                               "type": "icon_font",
                               "id": "dsg03r",
                               "name": "resp3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8243,12 +8206,12 @@
                               "type": "icon_font",
                               "id": "dsg03y",
                               "name": "proc3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8335,12 +8298,12 @@
                               "type": "icon_font",
                               "id": "dsg045",
                               "name": "events3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8427,12 +8390,12 @@
                               "type": "icon_font",
                               "id": "dsg04c",
                               "name": "topics3Drag",
+                              "opacity": 0.5,
                               "width": 14,
                               "height": 14,
                               "iconFontName": "grip-vertical",
                               "iconFontFamily": "lucide",
-                              "fill": "$--muted-foreground",
-                              "opacity": 0.5
+                              "fill": "$--muted-foreground"
                             },
                             {
                               "type": "icon_font",
@@ -8538,7 +8501,8 @@
               "fill": "$--muted-foreground",
               "content": "Customize sections",
               "fontFamily": "Inter",
-              "fontSize": 12
+              "fontSize": 12,
+              "fontWeight": "normal"
             }
           ]
         },
@@ -8855,18 +8819,15 @@
               "type": "frame",
               "id": "anArchiveBtn",
               "name": "archiveButton",
-              "gap": 4,
-              "alignItems": "center",
+              "cornerRadius": 4,
               "stroke": {
                 "align": "inside",
                 "thickness": 1,
                 "fill": "$--primary"
               },
-              "cornerRadius": 4,
-              "padding": [
-                2,
-                2
-              ],
+              "gap": 4,
+              "padding": 2,
+              "alignItems": "center",
               "children": [
                 {
                   "type": "icon_font",
@@ -9059,18 +9020,15 @@
               "type": "frame",
               "id": "auUnarchiveBtn",
               "name": "unarchiveButton",
-              "gap": 4,
-              "alignItems": "center",
+              "cornerRadius": 4,
               "stroke": {
                 "align": "inside",
                 "thickness": 1,
                 "fill": "$--primary"
               },
-              "cornerRadius": 4,
-              "padding": [
-                2,
-                2
-              ],
+              "gap": 4,
+              "padding": 2,
+              "alignItems": "center",
               "children": [
                 {
                   "type": "icon_font",
@@ -9112,12 +9070,11 @@
       "y": 7320,
       "name": "Git History — Commit List",
       "width": 300,
-      "height": "fit_content(600)",
       "fill": "$--background",
       "cornerRadius": "$--radius-lg",
       "stroke": {
-        "fill": "$--border",
-        "thickness": 1
+        "thickness": 1,
+        "fill": "$--border"
       },
       "layout": "vertical",
       "gap": 16,
@@ -9126,8 +9083,9 @@
         {
           "type": "text",
           "id": "ghCL1h",
-          "content": "HISTORY",
           "fill": "$--muted-foreground",
+          "content": "HISTORY",
+          "fontFamily": "Inter",
           "fontSize": 10,
           "fontWeight": "600",
           "letterSpacing": 1.2
@@ -9135,8 +9093,14 @@
         {
           "type": "frame",
           "id": "ghC1",
-          "layout": "vertical",
           "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "left": 2
+            },
+            "fill": "$--border"
+          },
+          "layout": "vertical",
           "gap": 2,
           "padding": [
             0,
@@ -9144,17 +9108,10 @@
             0,
             10
           ],
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "left": 2
-            }
-          },
           "children": [
             {
               "type": "frame",
               "id": "ghC1r",
-              "layout": "horizontal",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -9162,44 +9119,56 @@
                 {
                   "type": "text",
                   "id": "ghC1h",
-                  "content": "a1b2c3d",
                   "fill": "$--primary",
+                  "content": "a1b2c3d",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
-                  "fontWeight": "500",
-                  "underline": true
+                  "fontWeight": "500"
                 },
                 {
                   "type": "text",
                   "id": "ghC1d",
-                  "content": "2d ago",
                   "fill": "$--muted-foreground",
-                  "fontSize": 10
+                  "content": "2d ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "text",
               "id": "ghC1m",
-              "content": "Update grow-newsletter with latest changes",
               "fill": "$--secondary-foreground",
-              "fontSize": 12,
               "textGrowth": "fixed-width",
-              "width": "fill_container"
+              "width": "fill_container",
+              "content": "Update grow-newsletter with latest changes",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "ghC1a",
-              "content": "Luca Rossi",
               "fill": "$--muted-foreground",
-              "fontSize": 10
+              "content": "Luca Rossi",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "normal"
             }
           ]
         },
         {
           "type": "frame",
           "id": "ghC2",
-          "layout": "vertical",
           "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "left": 2
+            },
+            "fill": "$--border"
+          },
+          "layout": "vertical",
           "gap": 2,
           "padding": [
             0,
@@ -9207,17 +9176,10 @@
             0,
             10
           ],
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "left": 2
-            }
-          },
           "children": [
             {
               "type": "frame",
               "id": "ghC2r",
-              "layout": "horizontal",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -9225,44 +9187,56 @@
                 {
                   "type": "text",
                   "id": "ghC2h",
-                  "content": "e4f5g6h",
                   "fill": "$--primary",
+                  "content": "e4f5g6h",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
-                  "fontWeight": "500",
-                  "underline": true
+                  "fontWeight": "500"
                 },
                 {
                   "type": "text",
                   "id": "ghC2d",
-                  "content": "5d ago",
                   "fill": "$--muted-foreground",
-                  "fontSize": 10
+                  "content": "5d ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "text",
               "id": "ghC2m",
-              "content": "Add new section to grow-newsletter",
               "fill": "$--secondary-foreground",
-              "fontSize": 12,
               "textGrowth": "fixed-width",
-              "width": "fill_container"
+              "width": "fill_container",
+              "content": "Add new section to grow-newsletter",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "ghC2a",
-              "content": "Luca Rossi",
               "fill": "$--muted-foreground",
-              "fontSize": 10
+              "content": "Luca Rossi",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "normal"
             }
           ]
         },
         {
           "type": "frame",
           "id": "ghC3",
-          "layout": "vertical",
           "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "left": 2
+            },
+            "fill": "$--border"
+          },
+          "layout": "vertical",
           "gap": 2,
           "padding": [
             0,
@@ -9270,17 +9244,10 @@
             0,
             10
           ],
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "left": 2
-            }
-          },
           "children": [
             {
               "type": "frame",
               "id": "ghC3r",
-              "layout": "horizontal",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -9288,36 +9255,42 @@
                 {
                   "type": "text",
                   "id": "ghC3h",
-                  "content": "i7j8k9l",
                   "fill": "$--primary",
+                  "content": "i7j8k9l",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
-                  "fontWeight": "500",
-                  "underline": true
+                  "fontWeight": "500"
                 },
                 {
                   "type": "text",
                   "id": "ghC3d",
-                  "content": "12d ago",
                   "fill": "$--muted-foreground",
-                  "fontSize": 10
+                  "content": "12d ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "text",
               "id": "ghC3m",
-              "content": "Create grow-newsletter",
               "fill": "$--secondary-foreground",
-              "fontSize": 12,
               "textGrowth": "fixed-width",
-              "width": "fill_container"
+              "width": "fill_container",
+              "content": "Create grow-newsletter",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "ghC3a",
-              "content": "Luca Rossi",
               "fill": "$--muted-foreground",
-              "fontSize": 10
+              "content": "Luca Rossi",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "normal"
             }
           ]
         }
@@ -9330,43 +9303,41 @@
       "y": 7320,
       "name": "Git History — Diff Open",
       "width": 600,
-      "height": "fit_content(500)",
       "fill": "$--background",
       "cornerRadius": "$--radius-lg",
       "stroke": {
-        "fill": "$--border",
-        "thickness": 1
+        "thickness": 1,
+        "fill": "$--border"
       },
       "layout": "vertical",
-      "gap": 0,
-      "padding": 0,
       "children": [
         {
           "type": "frame",
           "id": "ghDObc",
-          "layout": "horizontal",
           "width": "fill_container",
           "height": 36,
+          "fill": "$--muted",
+          "stroke": {
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 8,
           "padding": [
             0,
             12
           ],
-          "gap": 8,
           "alignItems": "center",
-          "fill": "$--muted",
-          "stroke": {
-            "fill": "$--border",
-            "thickness": {
-              "bottom": 1
-            }
-          },
           "children": [
             {
               "type": "text",
               "id": "ghDObcP",
-              "content": "responsibility / grow-newsletter.md",
               "fill": "$--muted-foreground",
-              "fontSize": 12
+              "content": "responsibility / grow-newsletter.md",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "frame",
@@ -9377,20 +9348,20 @@
             {
               "type": "frame",
               "id": "ghDObcB",
-              "layout": "horizontal",
+              "fill": "$--primary",
+              "cornerRadius": "$--radius-sm",
               "padding": [
                 2,
                 8
               ],
-              "cornerRadius": "$--radius-sm",
-              "fill": "$--primary",
               "alignItems": "center",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDObcBt",
-                  "content": "Diff: a1b2c3d",
                   "fill": "$--primary-foreground",
+                  "content": "Diff: a1b2c3d",
+                  "fontFamily": "Inter",
                   "fontSize": 10,
                   "fontWeight": "600"
                 }
@@ -9401,39 +9372,39 @@
         {
           "type": "frame",
           "id": "ghDOb",
-          "layout": "vertical",
           "width": "fill_container",
-          "padding": 0,
-          "gap": 0,
+          "layout": "vertical",
           "children": [
             {
               "type": "frame",
               "id": "ghDOl1",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "$--muted",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "$--muted",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl1n",
-                  "content": "1",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "1",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl1t",
-                  "content": "diff --git a/grow-newsletter.md b/grow-newsletter.md",
                   "fill": "$--muted-foreground",
+                  "content": "diff --git a/grow-newsletter.md b/grow-newsletter.md",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
                   "fontWeight": "600"
                 }
@@ -9442,32 +9413,35 @@
             {
               "type": "frame",
               "id": "ghDOl2",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#2196F30D",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#2196F30D",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl2n",
-                  "content": "2",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "2",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl2t",
-                  "content": "@@ -5,3 +5,5 @@",
                   "fill": "$--primary",
+                  "content": "@@ -5,3 +5,5 @@",
+                  "fontFamily": "Inter",
                   "fontSize": 11,
+                  "fontWeight": "normal",
                   "fontStyle": "italic"
                 }
               ]
@@ -9475,7 +9449,6 @@
             {
               "type": "frame",
               "id": "ghDOl3",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
               "padding": [
@@ -9487,115 +9460,128 @@
                 {
                   "type": "text",
                   "id": "ghDOl3n",
-                  "content": "3",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "3",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl3t",
-                  "content": " # Grow Newsletter",
                   "fill": "$--secondary-foreground",
-                  "fontSize": 11
+                  "content": " # Grow Newsletter",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
               "id": "ghDOl4",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#f4433614",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#f4433614",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl4n",
-                  "content": "4",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "4",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl4t",
-                  "content": "-Old paragraph from before a1b2c3d.",
                   "fill": "#f44336",
-                  "fontSize": 11
+                  "content": "-Old paragraph from before a1b2c3d.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
               "id": "ghDOl5",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#4caf5014",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#4caf5014",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl5n",
-                  "content": "5",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "5",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl5t",
-                  "content": "+Updated paragraph at commit a1b2c3d.",
                   "fill": "#4caf50",
-                  "fontSize": 11
+                  "content": "+Updated paragraph at commit a1b2c3d.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
               "id": "ghDOl6",
-              "layout": "horizontal",
               "width": "fill_container",
               "height": 22,
+              "fill": "#4caf5014",
               "padding": [
                 0,
                 8
               ],
               "alignItems": "center",
-              "fill": "#4caf5014",
               "children": [
                 {
                   "type": "text",
                   "id": "ghDOl6n",
-                  "content": "6",
                   "fill": "$--muted-foreground",
-                  "fontSize": 11,
                   "textGrowth": "fixed-width",
                   "width": 30,
-                  "textAlign": "right"
+                  "content": "6",
+                  "textAlign": "right",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 },
                 {
                   "type": "text",
                   "id": "ghDOl6t",
-                  "content": "+New content added in this commit.",
                   "fill": "#4caf50",
-                  "fontSize": 11
+                  "content": "+New content added in this commit.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             }
@@ -9606,28 +9592,26 @@
     {
       "type": "frame",
       "id": "rnt0",
+      "x": 0,
+      "y": 0,
       "name": "Rename Tab — Normal tab state",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "rnt1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "Normal state: tabs show note title. Double-click to rename.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -9778,43 +9762,37 @@
           "type": "text",
           "id": "rntc",
           "name": "interactionNote",
+          "fill": "$--muted-foreground",
           "content": "Double-click tab title → enters edit mode",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "rne0",
+      "x": 0,
+      "y": 0,
       "name": "Rename Tab — Double-clicked (editing mode)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "rne1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "Editing mode: tab title replaced with inline input field, text selected.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -9857,12 +9835,12 @@
                   "id": "rne4",
                   "name": "Inline Input",
                   "fill": "$--background",
+                  "cornerRadius": 3,
                   "stroke": {
                     "align": "inside",
                     "thickness": 1,
                     "fill": "$--ring"
                   },
-                  "cornerRadius": 3,
                   "padding": [
                     2,
                     6
@@ -9876,9 +9854,7 @@
                       "content": "Weekly Review",
                       "fontFamily": "Inter",
                       "fontSize": 12,
-                      "fontWeight": "500",
-                      "highlight": "$--primary",
-                      "highlightOpacity": 0.2
+                      "fontWeight": "500"
                     }
                   ]
                 },
@@ -9986,43 +9962,37 @@
           "type": "text",
           "id": "rned",
           "name": "interactionNote",
+          "fill": "$--muted-foreground",
           "content": "Enter → save & rename file + update wiki links | Escape → cancel | Blur → save",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
     {
       "type": "frame",
       "id": "rns0",
+      "x": 0,
+      "y": 0,
       "name": "Rename Tab — Saved (updated name)",
-      "width": 800,
-      "height": 120,
-      "layout": "vertical",
-      "fill": "$--sidebar",
       "theme": {
         "Mode": "Light"
       },
+      "width": 800,
+      "height": 120,
+      "fill": "$--sidebar",
+      "layout": "vertical",
       "children": [
         {
           "type": "text",
           "id": "rns1",
           "name": "frameLabel",
+          "fill": "$--muted-foreground",
           "content": "After save: tab shows updated title. File renamed, wiki links updated across vault.",
           "fontFamily": "Inter",
           "fontSize": 11,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            8,
-            12
-          ]
+          "fontWeight": "normal"
         },
         {
           "type": "frame",
@@ -10173,15 +10143,11 @@
           "type": "text",
           "id": "rnsc",
           "name": "interactionNote",
+          "fill": "$--muted-foreground",
           "content": "File: weekly-review.md → sprint-retrospective.md | [[Weekly Review]] → [[Sprint Retrospective]] in all notes",
           "fontFamily": "Inter",
           "fontSize": 10,
-          "fontWeight": "normal",
-          "fill": "$--muted-foreground",
-          "padding": [
-            4,
-            12
-          ]
+          "fontWeight": "normal"
         }
       ]
     },
@@ -10253,33 +10219,36 @@
           "width": "fill_container",
           "height": "fill_container",
           "fill": "$--sidebar",
+          "layout": "vertical",
+          "gap": 4,
           "padding": [
             8,
             12
           ],
-          "layout": "vertical",
-          "gap": 4,
           "children": [
             {
               "type": "text",
               "id": "mb008",
-              "value": "All Notes",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb009",
-              "value": "Favorites",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb010",
-              "value": "Archive",
+              "fill": "$--muted-foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--muted-foreground"
+              "fontWeight": "normal"
             }
           ]
         }
@@ -10360,33 +10329,272 @@
           "width": "fill_container",
           "height": "fill_container",
           "fill": "$--sidebar",
+          "layout": "vertical",
+          "gap": 4,
           "padding": [
             8,
             12
           ],
-          "layout": "vertical",
-          "gap": 4,
           "children": [
             {
               "type": "text",
               "id": "mb018",
-              "value": "All Notes",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb019",
-              "value": "Favorites",
+              "fill": "$--foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--foreground"
+              "fontWeight": "normal"
             },
             {
               "type": "text",
               "id": "mb020",
-              "value": "Archive",
+              "fill": "$--muted-foreground",
+              "fontFamily": "Inter",
               "fontSize": 14,
-              "fill": "$--muted-foreground"
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "961O2",
+      "x": 0,
+      "y": 7636,
+      "name": "Welcome Screen",
+      "width": 1400,
+      "height": 900,
+      "fill": "#F7F6F3",
+      "layout": "vertical",
+      "gap": 32,
+      "padding": 64,
+      "children": [
+        {
+          "type": "text",
+          "id": "V2nfG",
+          "name": "title",
+          "fill": "#37352F",
+          "content": "Welcome to Laputa",
+          "fontFamily": "Inter",
+          "fontSize": 28,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "uTZL7",
+          "name": "subtitle",
+          "fill": "#787774",
+          "content": "Open a folder of markdown files to get started, or create a new vault.",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "8uejY",
+          "name": "Button Group",
+          "width": 300,
+          "layout": "vertical",
+          "gap": 12,
+          "children": [
+            {
+              "type": "frame",
+              "id": "3AEzd",
+              "name": "Open Existing Folder",
+              "width": "fill_container",
+              "height": 44,
+              "fill": "#155DFF",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HJDhK",
+                  "name": "openIcon",
+                  "content": "📂",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Aq2mE",
+                  "name": "openLabel",
+                  "fill": "#FFFFFF",
+                  "content": "Open Existing Folder",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KfErM",
+              "name": "Create New Vault",
+              "width": "fill_container",
+              "height": 44,
+              "fill": "#FFFFFF",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "nPuGn",
+                  "name": "createIcon",
+                  "content": "➕",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "zxBWk",
+                  "name": "createLabel",
+                  "fill": "#37352F",
+                  "content": "Create New Vault",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "JErHw",
+      "x": 1500,
+      "y": 7636,
+      "name": "Vault Picker Menu",
+      "width": 220,
+      "height": 260,
+      "fill": "#F7F6F3",
+      "cornerRadius": 8,
+      "layout": "vertical",
+      "padding": 4,
+      "children": [
+        {
+          "type": "frame",
+          "id": "FlVxV",
+          "name": "Vault Item Active",
+          "width": "fill_container",
+          "height": 32,
+          "fill": "#EBEBEA",
+          "cornerRadius": 4,
+          "gap": 6,
+          "padding": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "ibeqb",
+              "name": "check1",
+              "fill": "#37352F",
+              "content": "✓",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "UnNaB",
+              "name": "label1",
+              "fill": "#37352F",
+              "content": "Laputa",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Rw1gX",
+          "name": "Vault Item",
+          "width": "fill_container",
+          "height": 32,
+          "cornerRadius": 4,
+          "gap": 6,
+          "padding": 6,
+          "children": [
+            {
+              "type": "frame",
+              "id": "72MAj",
+              "name": "spacer2",
+              "width": 12,
+              "height": 12
+            },
+            {
+              "type": "text",
+              "id": "P1sRb",
+              "name": "label2",
+              "fill": "#787774",
+              "content": "Demo v2",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "DG8NZ",
+              "name": "trash2",
+              "fill": "#787774",
+              "content": "🗑",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "w9Gwr",
+          "name": "Divider",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#E9E9E7"
+        },
+        {
+          "type": "frame",
+          "id": "lgC8x",
+          "name": "Add Vault Item",
+          "width": "fill_container",
+          "height": 32,
+          "cornerRadius": 4,
+          "gap": 6,
+          "padding": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "i3Aff",
+              "name": "addIcon",
+              "fill": "#787774",
+              "content": "+",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "nE1ld",
+              "name": "addLabel",
+              "fill": "#787774",
+              "content": "Add vault...",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.6.0
+        version: 2.6.0
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
@@ -1713,6 +1716,9 @@ packages:
     resolution: {integrity: sha512-ZwT0T+7bw4+DPCSWzmviwq5XbXlM0cNoleDKOYPFYqcZqeKY31KlpoMW/MOON/tOFBPgi31a2v3w9gliqwL2+Q==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.6.0':
+    resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
@@ -5086,6 +5092,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.0
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.0
       '@tauri-apps/cli-win32-x64-msvc': 2.10.0
+
+  '@tauri-apps/plugin-dialog@2.6.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-process@2.3.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -731,6 +731,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -1941,6 +1943,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-process",
  "tauri-plugin-updater",
@@ -3205,6 +3208,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,6 +4144,46 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ regex = "1"
 dirs = "5"
 tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.1"
+tauri-plugin-dialog = "2.6.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "dialog:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ pub mod vault;
 use ai_chat::{AiChatRequest, AiChatResponse};
 use git::{GitCommit, ModifiedFile};
 use settings::VaultConfig;
-use vault::{VaultEntry, RenameResult};
+use vault::{VaultEntry, RenameResult, write_note as vault_write_note};
 use frontmatter::FrontmatterValue;
 
 #[tauri::command]
@@ -68,6 +68,11 @@ async fn ai_chat(request: AiChatRequest) -> Result<AiChatResponse, String> {
 #[tauri::command]
 fn save_image(vault_path: String, filename: String, data: String) -> Result<String, String> {
     vault::save_image(&vault_path, &filename, &data)
+}
+
+#[tauri::command]
+fn write_note(path: String, content: String) -> Result<(), String> {
+    vault_write_note(&path, &content)
 }
 
 #[tauri::command]
@@ -147,6 +152,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             list_vault,
             get_note_content,
+            write_note,
             update_frontmatter,
             delete_frontmatter_property,
             rename_note,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod ai_chat;
 pub mod frontmatter;
 pub mod git;
+pub mod settings;
 pub mod vault;
 
 use ai_chat::{AiChatRequest, AiChatResponse};
 use git::{GitCommit, ModifiedFile};
+use settings::VaultConfig;
 use vault::{VaultEntry, RenameResult};
 use frontmatter::FrontmatterValue;
 
@@ -78,9 +80,30 @@ fn purge_trash(vault_path: String) -> Result<Vec<String>, String> {
     vault::purge_trash(&vault_path)
 }
 
+#[tauri::command]
+fn get_vaults() -> Result<Vec<VaultConfig>, String> {
+    settings::get_vaults()
+}
+
+#[tauri::command]
+fn add_vault(path: String) -> Result<VaultConfig, String> {
+    settings::add_vault(&path)
+}
+
+#[tauri::command]
+fn remove_vault(path: String) -> Result<(), String> {
+    settings::remove_vault(&path)
+}
+
+#[tauri::command]
+fn init_vault(path: String) -> Result<(), String> {
+    settings::init_vault(&path)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -96,19 +119,26 @@ pub fn run() {
                 app.handle().plugin(tauri_plugin_process::init())?;
             }
 
-            // Purge trashed files older than 30 days on startup
-            let vault_path = dirs::home_dir()
-                .map(|h| h.join("Laputa"))
-                .unwrap_or_default();
-            if vault_path.is_dir() {
-                match vault::purge_trash(vault_path.to_str().unwrap_or_default()) {
-                    Ok(deleted) if !deleted.is_empty() => {
-                        log::info!("Purged {} trashed files on startup", deleted.len());
+            // Purge trashed files older than 30 days on startup — for all configured vaults
+            match settings::get_vaults() {
+                Ok(vaults) => {
+                    for v in &vaults {
+                        let vault_path = std::path::Path::new(&v.path);
+                        if vault_path.is_dir() {
+                            match vault::purge_trash(&v.path) {
+                                Ok(deleted) if !deleted.is_empty() => {
+                                    log::info!("Purged {} trashed files from {} on startup", deleted.len(), v.label);
+                                }
+                                Err(e) => {
+                                    log::warn!("Failed to purge trash in {}: {}", v.label, e);
+                                }
+                                _ => {}
+                            }
+                        }
                     }
-                    Err(e) => {
-                        log::warn!("Failed to purge trash on startup: {}", e);
-                    }
-                    _ => {}
+                }
+                Err(e) => {
+                    log::warn!("Failed to load vault settings for trash purge: {}", e);
                 }
             }
 
@@ -128,7 +158,11 @@ pub fn run() {
             git_push,
             ai_chat,
             save_image,
-            purge_trash
+            purge_trash,
+            get_vaults,
+            add_vault,
+            remove_vault,
+            init_vault
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,253 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct VaultConfig {
+    pub label: String,
+    pub path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AppSettings {
+    #[serde(default)]
+    pub vaults: Vec<VaultConfig>,
+}
+
+/// Return the settings file path: <app_config_dir>/settings.json
+fn settings_path() -> Result<PathBuf, String> {
+    // Use a consistent config directory: ~/.config/com.tauri.dev/ (matches app identifier)
+    let config_dir = dirs::config_dir()
+        .ok_or_else(|| "Cannot determine config directory".to_string())?;
+    let app_dir = config_dir.join("com.tauri.dev");
+    Ok(app_dir.join("settings.json"))
+}
+
+pub fn load_settings() -> Result<AppSettings, String> {
+    let path = settings_path()?;
+    if !path.exists() {
+        return Ok(AppSettings::default());
+    }
+    let data = fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read settings: {}", e))?;
+    serde_json::from_str(&data)
+        .map_err(|e| format!("Failed to parse settings: {}", e))
+}
+
+pub fn save_settings(settings: &AppSettings) -> Result<(), String> {
+    let path = settings_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config directory: {}", e))?;
+    }
+    let data = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+    fs::write(&path, data)
+        .map_err(|e| format!("Failed to write settings: {}", e))
+}
+
+pub fn get_vaults() -> Result<Vec<VaultConfig>, String> {
+    let settings = load_settings()?;
+    Ok(settings.vaults)
+}
+
+pub fn add_vault(path: &str) -> Result<VaultConfig, String> {
+    let abs_path = Path::new(path);
+
+    if !abs_path.exists() {
+        return Err(format!("Folder does not exist: {}", path));
+    }
+    if !abs_path.is_dir() {
+        return Err(format!("Path is not a directory: {}", path));
+    }
+
+    let canonical = abs_path.canonicalize()
+        .map_err(|e| format!("Failed to resolve path: {}", e))?;
+    let canonical_str = canonical.to_str()
+        .ok_or_else(|| "Invalid UTF-8 in path".to_string())?
+        .to_string();
+
+    // Derive label from folder name
+    let label = canonical.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("Vault")
+        .to_string();
+
+    let mut settings = load_settings()?;
+
+    // Deduplicate: skip if path already exists
+    if settings.vaults.iter().any(|v| v.path == canonical_str) {
+        // Return the existing vault config
+        return Ok(settings.vaults.iter().find(|v| v.path == canonical_str).unwrap().clone());
+    }
+
+    let vault = VaultConfig {
+        label,
+        path: canonical_str,
+    };
+    settings.vaults.push(vault.clone());
+    save_settings(&settings)?;
+
+    Ok(vault)
+}
+
+pub fn remove_vault(path: &str) -> Result<(), String> {
+    let mut settings = load_settings()?;
+    settings.vaults.retain(|v| v.path != path);
+    save_settings(&settings)
+}
+
+pub fn init_vault(path: &str) -> Result<(), String> {
+    let dir = Path::new(path);
+
+    if !dir.exists() {
+        // Create the directory for new vaults
+        fs::create_dir_all(dir)
+            .map_err(|e| format!("Failed to create directory: {}", e))?;
+    }
+
+    if !dir.is_dir() {
+        return Err(format!("Path is not a directory: {}", path));
+    }
+
+    // Check if already a git repo
+    let git_dir = dir.join(".git");
+    if git_dir.exists() {
+        return Ok(()); // Already initialized
+    }
+
+    // Run git init
+    let output = Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("Failed to run git init: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git init failed: {}", stderr));
+    }
+
+    // Create .gitkeep if directory is empty (no files besides .git)
+    let has_files = fs::read_dir(dir)
+        .map_err(|e| format!("Failed to read directory: {}", e))?
+        .any(|entry| {
+            entry
+                .ok()
+                .and_then(|e| e.file_name().into_string().ok())
+                .map(|name| name != ".git")
+                .unwrap_or(false)
+        });
+
+    if !has_files {
+        fs::write(dir.join(".gitkeep"), "")
+            .map_err(|e| format!("Failed to create .gitkeep: {}", e))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_default_settings() {
+        let settings = AppSettings::default();
+        assert!(settings.vaults.is_empty());
+    }
+
+    #[test]
+    fn test_settings_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let settings_file = dir.path().join("settings.json");
+
+        let settings = AppSettings {
+            vaults: vec![
+                VaultConfig {
+                    label: "Test".to_string(),
+                    path: "/tmp/test-vault".to_string(),
+                },
+            ],
+        };
+
+        let data = serde_json::to_string_pretty(&settings).unwrap();
+        fs::write(&settings_file, &data).unwrap();
+
+        let loaded: AppSettings = serde_json::from_str(&fs::read_to_string(&settings_file).unwrap()).unwrap();
+        assert_eq!(loaded.vaults.len(), 1);
+        assert_eq!(loaded.vaults[0].label, "Test");
+        assert_eq!(loaded.vaults[0].path, "/tmp/test-vault");
+    }
+
+    #[test]
+    fn test_init_vault_new_directory() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("new-vault");
+
+        init_vault(vault_path.to_str().unwrap()).unwrap();
+
+        assert!(vault_path.join(".git").exists());
+        assert!(vault_path.join(".gitkeep").exists());
+    }
+
+    #[test]
+    fn test_init_vault_existing_git_repo() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path();
+
+        // Initialize git repo first
+        Command::new("git")
+            .args(["init"])
+            .current_dir(vault_path)
+            .output()
+            .unwrap();
+
+        // Create a file so it's not empty
+        fs::write(vault_path.join("test.md"), "# Test").unwrap();
+
+        // init_vault should succeed without error (skip git init)
+        init_vault(vault_path.to_str().unwrap()).unwrap();
+
+        // .gitkeep should NOT be created since there are files
+        assert!(!vault_path.join(".gitkeep").exists());
+    }
+
+    #[test]
+    fn test_init_vault_existing_directory_with_files() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path();
+
+        fs::write(vault_path.join("notes.md"), "# Notes").unwrap();
+
+        init_vault(vault_path.to_str().unwrap()).unwrap();
+
+        assert!(vault_path.join(".git").exists());
+        // .gitkeep should not be created since directory has files
+        assert!(!vault_path.join(".gitkeep").exists());
+    }
+
+    #[test]
+    fn test_add_vault_nonexistent_path() {
+        let result = add_vault("/nonexistent/path/that/does/not/exist");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn test_vault_config_serialization() {
+        let vault = VaultConfig {
+            label: "My Vault".to_string(),
+            path: "/home/user/vault".to_string(),
+        };
+        let json = serde_json::to_string(&vault).unwrap();
+        assert!(json.contains("My Vault"));
+        assert!(json.contains("/home/user/vault"));
+
+        let deserialized: VaultConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.label, "My Vault");
+        assert_eq!(deserialized.path, "/home/user/vault");
+    }
+}

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -808,6 +808,17 @@ pub fn save_image(vault_path: &str, filename: &str, data: &str) -> Result<String
     Ok(target_path.to_string_lossy().to_string())
 }
 
+/// Write (or overwrite) a note file to disk, creating parent directories as needed.
+pub fn write_note(path: &str, content: &str) -> Result<(), String> {
+    let file_path = Path::new(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create directories for {}: {}", path, e))?;
+    }
+    fs::write(file_path, content)
+        .map_err(|e| format!("Failed to write note {}: {}", path, e))
+}
+
 /// Result of a rename operation
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RenameResult {
@@ -2117,5 +2128,43 @@ References:
         let content = fs::read_to_string(&result.new_path).unwrap();
         assert!(content.contains("title: New Name"));
         assert!(content.contains("# New Name"));
+    }
+
+    // --- write_note tests ---
+
+    #[test]
+    fn test_write_note_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("note/my-note.md");
+        let content = "---\ntitle: My Note\nis_a: Note\n---\n\n# My Note\n\n";
+
+        let result = write_note(file_path.to_str().unwrap(), content);
+        assert!(result.is_ok());
+        assert!(file_path.exists());
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), content);
+    }
+
+    #[test]
+    fn test_write_note_creates_parent_directories() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("deep/nested/dir/note.md");
+        let content = "# Nested Note\n";
+
+        let result = write_note(file_path.to_str().unwrap(), content);
+        assert!(result.is_ok());
+        assert!(file_path.exists());
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), content);
+    }
+
+    #[test]
+    fn test_write_note_overwrites_existing() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("note.md");
+        create_test_file(dir.path(), "note.md", "old content");
+
+        let new_content = "new content";
+        let result = write_note(file_path.to_str().unwrap(), new_content);
+        assert!(result.is_ok());
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), new_content);
     }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -53,6 +53,10 @@ vi.mock('./mock-tauri', () => ({
     if (cmd === 'get_modified_files') return []
     if (cmd === 'get_note_content') return mockAllContent['/vault/project/test.md'] || ''
     if (cmd === 'get_file_history') return []
+    if (cmd === 'get_vaults') return [{ label: 'Demo v2', path: '/vault' }]
+    if (cmd === 'add_vault') return { label: 'New', path: '/new' }
+    if (cmd === 'remove_vault') return null
+    if (cmd === 'init_vault') return null
     return null
   }),
   addMockEntry: vi.fn(),

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -79,9 +79,16 @@ vi.mock('@blocknote/react', () => ({
   useCreateBlockNote: () => ({
     tryParseMarkdownToBlocks: async () => [],
     replaceBlocks: () => {},
+    insertBlocks: () => {},
     document: [],
     insertInlineContent: () => {},
     onMount: (cb: () => void) => { cb(); return () => {} },
+    onChange: () => () => {},
+    prosemirrorView: {},
+    blocksToHTMLLossy: () => '',
+    blocksToMarkdownLossy: () => '',
+    _tiptapEditor: { commands: { setContent: () => {} } },
+    focus: () => {},
   }),
   SuggestionMenuController: () => null,
 }))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,12 @@ import { QuickOpenPalette } from './components/QuickOpenPalette'
 import { Toast } from './components/Toast'
 import { CommitDialog } from './components/CommitDialog'
 import { StatusBar } from './components/StatusBar'
+import { WelcomeScreen } from './components/WelcomeScreen'
 import { useVaultLoader } from './hooks/useVaultLoader'
 import { useNoteActions, generateUntitledName } from './hooks/useNoteActions'
 import { useAppKeyboard } from './hooks/useAppKeyboard'
 import { useEntryActions } from './hooks/useEntryActions'
+import { useVaultConfig } from './hooks/useVaultConfig'
 import { isTauri } from './mock-tauri'
 import { useKeyboardNavigation } from './hooks/useKeyboardNavigation'
 import { useUpdater } from './hooks/useUpdater'
@@ -27,14 +29,16 @@ declare global {
 
 const DEFAULT_SELECTION: SidebarSelection = { kind: 'filter', filter: 'all' }
 
-const VAULTS = isTauri()
-  ? [
-      { label: 'Demo v2', path: '/Users/luca/Workspace/laputa-app/demo-vault-v2' },
-      { label: 'Laputa', path: '/Users/luca/Laputa' },
-    ]
-  : [
-      { label: 'Demo v2', path: '/Users/luca/Workspace/laputa-app/demo-vault-v2' },
-    ]
+async function openFolderDialog(): Promise<string | null> {
+  if (isTauri()) {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const selected = await open({ directory: true, multiple: false, title: 'Choose vault folder' })
+    return selected ?? null
+  }
+  // In mock/browser mode, prompt the user
+  const path = window.prompt('Enter vault folder path:')
+  return path || null
+}
 
 function useLayoutPanels() {
   const [sidebarWidth, setSidebarWidth] = useState(250)
@@ -55,10 +59,22 @@ function App() {
   const [showQuickOpen, setShowQuickOpen] = useState(false)
   const [showCommitDialog, setShowCommitDialog] = useState(false)
   const [toastMessage, setToastMessage] = useState<string | null>(null)
-  const [vaultPath, setVaultPath] = useState(VAULTS[0].path)
+  const [vaultPath, setVaultPath] = useState<string | null>(null)
   const [showAIChat, setShowAIChat] = useState(false)
 
-  const vault = useVaultLoader(vaultPath)
+  const vaultConfig = useVaultConfig()
+
+  // Set initial vault path once config loads
+  useEffect(() => {
+    if (vaultConfig.loading) return
+    if (vaultPath) return // Already set
+    if (vaultConfig.vaults.length > 0) {
+      setVaultPath(vaultConfig.vaults[0].path)
+    }
+  }, [vaultConfig.loading, vaultConfig.vaults, vaultPath])
+
+  // Use a placeholder path for the vault loader when no vault is selected
+  const vault = useVaultLoader(vaultPath ?? '')
   const notes = useNoteActions(vault.addEntry, vault.updateContent, vault.entries, setToastMessage)
 
   const entryActions = useEntryActions({
@@ -83,6 +99,44 @@ function App() {
     notes.closeAllTabs()
   }, [notes])
 
+  const handleAddVaultFromDialog = useCallback(async () => {
+    try {
+      const selected = await openFolderDialog()
+      if (!selected) return
+      // Init git if needed, then add to config
+      await vaultConfig.initVault(selected)
+      const vault = await vaultConfig.addVault(selected)
+      handleSwitchVault(vault.path)
+    } catch (err) {
+      setToastMessage(String(err))
+    }
+  }, [vaultConfig, handleSwitchVault])
+
+  const handleCreateVault = useCallback(async () => {
+    try {
+      const selected = await openFolderDialog()
+      if (!selected) return
+      await vaultConfig.initVault(selected)
+      const vault = await vaultConfig.addVault(selected)
+      handleSwitchVault(vault.path)
+    } catch (err) {
+      setToastMessage(String(err))
+    }
+  }, [vaultConfig, handleSwitchVault])
+
+  const handleRemoveVault = useCallback(async (path: string) => {
+    await vaultConfig.removeVault(path)
+    // If the removed vault was active, switch to another or show welcome
+    if (vaultPath === path) {
+      const remaining = vaultConfig.vaults.filter((v) => v.path !== path)
+      if (remaining.length > 0) {
+        handleSwitchVault(remaining[0].path)
+      } else {
+        setVaultPath(null)
+      }
+    }
+  }, [vaultConfig, vaultPath, handleSwitchVault])
+
   useEffect(() => {
     if (!notes.activeTabPath) { setGitHistory([]); return }
     vault.loadGitHistory(notes.activeTabPath).then(setGitHistory)
@@ -98,7 +152,7 @@ function App() {
   }, [notes])
 
   const handleRenameTab = useCallback((path: string, newTitle: string) => {
-    notes.handleRenameNote(path, newTitle, vaultPath, vault.replaceEntry)
+    notes.handleRenameNote(path, newTitle, vaultPath ?? '', vault.replaceEntry)
   }, [notes, vaultPath, vault])
 
   useAppKeyboard({
@@ -137,6 +191,25 @@ function App() {
   }, [vault])
 
   const activeTab = notes.tabs.find((t) => t.entry.path === notes.activeTabPath) ?? null
+
+  // Show welcome screen when no vaults are configured
+  if (!vaultConfig.loading && vaultConfig.vaults.length === 0) {
+    return (
+      <>
+        <WelcomeScreen
+          onOpenFolder={handleAddVaultFromDialog}
+          onCreateVault={handleCreateVault}
+          error={vaultConfig.error}
+        />
+        <Toast message={toastMessage} onDismiss={() => setToastMessage(null)} />
+      </>
+    )
+  }
+
+  // Show nothing while loading config
+  if (vaultConfig.loading || !vaultPath) {
+    return null
+  }
 
   return (
     <div className="app-shell">
@@ -184,7 +257,14 @@ function App() {
           />
         </div>
       </div>
-      <StatusBar noteCount={vault.entries.length} vaultPath={vaultPath} vaults={VAULTS} onSwitchVault={handleSwitchVault} />
+      <StatusBar
+        noteCount={vault.entries.length}
+        vaultPath={vaultPath}
+        vaults={vaultConfig.vaults}
+        onSwitchVault={handleSwitchVault}
+        onAddVault={handleAddVaultFromDialog}
+        onRemoveVault={handleRemoveVault}
+      />
       <Toast message={toastMessage} onDismiss={() => setToastMessage(null)} />
       <QuickOpenPalette open={showQuickOpen} entries={vault.entries} onSelect={notes.handleSelectNote} onClose={() => setShowQuickOpen(false)} />
       <CreateTypeDialog open={showCreateTypeDialog} onClose={() => setShowCreateTypeDialog(false)} onCreate={handleCreateType} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
 
   // Use a placeholder path for the vault loader when no vault is selected
   const vault = useVaultLoader(vaultPath ?? '')
-  const notes = useNoteActions(vault.addEntry, vault.updateContent, vault.entries, setToastMessage)
+  const notes = useNoteActions(vault.addEntry, vault.updateContent, vault.entries, setToastMessage, vaultPath ?? '')
 
   const entryActions = useEntryActions({
     entries: vault.entries,
@@ -235,6 +235,7 @@ function App() {
             onLoadDiffAtCommit={vault.loadDiffAtCommit}
             isModified={vault.isFileModified}
             onCreateNote={handleCreateNoteImmediate}
+            onContentChange={vault.updateContent}
             inspectorCollapsed={layout.inspectorCollapsed}
             onToggleInspector={() => layout.setInspectorCollapsed((c) => !c)}
             inspectorWidth={layout.inspectorWidth}

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -10,9 +10,12 @@ const mockEditor = vi.hoisted(() => ({
   document: [{ id: '1', type: 'paragraph', content: [], props: {}, children: [] }],
   insertInlineContent: vi.fn(),
   onMount: vi.fn((cb: () => void) => { cb(); return () => {} }),
+  onChange: vi.fn(() => () => {}),
   prosemirrorView: {} as any,
   blocksToHTMLLossy: vi.fn(() => ''),
+  blocksToMarkdownLossy: vi.fn(() => ''),
   _tiptapEditor: { commands: { setContent: vi.fn() } },
+  focus: vi.fn(),
 }))
 
 // Mock BlockNote components

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -35,6 +35,7 @@ interface EditorProps {
   onLoadDiffAtCommit?: (path: string, commitHash: string) => Promise<string>
   isModified?: (path: string) => boolean
   onCreateNote?: () => void
+  onContentChange?: (path: string, content: string) => void
   // Inspector props
   inspectorCollapsed: boolean
   onToggleInspector: () => void
@@ -193,6 +194,7 @@ function SingleEditorView({ editor, entries, onNavigateWikilink }: { editor: Ret
 
 export const Editor = memo(function Editor({
   tabs, activeTabPath, entries, onSwitchTab, onCloseTab, onReorderTabs, onNavigateWikilink, onLoadDiff, onLoadDiffAtCommit, isModified, onCreateNote,
+  onContentChange,
   inspectorCollapsed, onToggleInspector, inspectorWidth, onInspectorResize,
   inspectorEntry, inspectorContent, allContent, gitHistory,
   onUpdateFrontmatter, onDeleteProperty, onAddProperty,
@@ -237,6 +239,28 @@ export const Editor = memo(function Editor({
       })
     },
   })
+  // --- Debounced autosave ---
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onContentChangeRef = useRef(onContentChange)
+  onContentChangeRef.current = onContentChange
+
+  const debouncedSave = useCallback((path: string, content: string) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    saveTimerRef.current = setTimeout(() => {
+      onContentChangeRef.current?.(path, content)
+      if (isTauri()) {
+        invoke('write_note', { path, content }).catch((err: unknown) =>
+          console.error('Autosave failed:', err)
+        )
+      }
+    }, 1000)
+  }, [])
+
+  // Clean up timer on unmount
+  useEffect(() => () => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+  }, [])
+
   // Cache parsed blocks per tab path for instant switching
   const tabCacheRef = useRef<Map<string, any[]>>(new Map())
   const prevActivePathRef = useRef<string | null>(null)
@@ -282,6 +306,7 @@ export const Editor = memo(function Editor({
     if (!tab) return
 
     const applyBlocks = (blocks: any[]) => {
+      isSwappingRef.current = true
       try {
         const current = editor.document
         if (current.length > 0 && blocks.length > 0) {
@@ -297,6 +322,8 @@ export const Editor = memo(function Editor({
         } catch (err2) {
           console.error('Fallback also failed:', err2)
         }
+      } finally {
+        isSwappingRef.current = false
       }
     }
 
@@ -358,6 +385,27 @@ export const Editor = memo(function Editor({
     }
     tabPathsRef.current = currentPaths
   }, [tabs])
+
+  // Autosave: subscribe to editor changes and debounce-write to disk
+  const isSwappingRef = useRef(false)
+  useEffect(() => {
+    const unsubscribe = editor.onChange(() => {
+      // Skip change events triggered by tab-switching content swaps
+      if (isSwappingRef.current) return
+      const path = prevActivePathRef.current
+      if (!path) return
+      const tab = tabs.find(t => t.entry.path === path)
+      if (!tab) return
+      // Serialize current blocks back to markdown
+      const blocks = editor.document
+      const markdown = editor.blocksToMarkdownLossy(blocks)
+      // Reconstruct full file content: original frontmatter + body
+      const [fm] = splitFrontmatter(tab.content)
+      const fullContent = fm ? `${fm}\n\n${markdown}` : markdown
+      debouncedSave(path, fullContent)
+    })
+    return unsubscribe
+  }, [editor, tabs, debouncedSave])
 
   // Focus editor when a new note is created (signaled via custom event)
   useEffect(() => {

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -73,4 +73,55 @@ describe('StatusBar', () => {
     fireEvent.click(vaultButton)
     expect(screen.queryByText('Work Vault')).not.toBeInTheDocument()
   })
+
+  it('shows "Add vault..." option when onAddVault is provided', () => {
+    render(<StatusBar noteCount={100} vaultPath="/Users/luca/Laputa" vaults={vaults} onSwitchVault={vi.fn()} onAddVault={vi.fn()} />)
+
+    fireEvent.click(screen.getByTitle('Switch vault'))
+    expect(screen.getByText('Add vault...')).toBeInTheDocument()
+  })
+
+  it('calls onAddVault when "Add vault..." is clicked', () => {
+    const onAddVault = vi.fn()
+    render(<StatusBar noteCount={100} vaultPath="/Users/luca/Laputa" vaults={vaults} onSwitchVault={vi.fn()} onAddVault={onAddVault} />)
+
+    fireEvent.click(screen.getByTitle('Switch vault'))
+    fireEvent.click(screen.getByText('Add vault...'))
+
+    expect(onAddVault).toHaveBeenCalledOnce()
+  })
+
+  it('shows remove buttons when onRemoveVault is provided and multiple vaults exist', () => {
+    render(<StatusBar noteCount={100} vaultPath="/Users/luca/Laputa" vaults={vaults} onSwitchVault={vi.fn()} onRemoveVault={vi.fn()} />)
+
+    fireEvent.click(screen.getByTitle('Switch vault'))
+    const removeButtons = screen.getAllByTitle(/Remove .+ from list/)
+    expect(removeButtons.length).toBe(2)
+  })
+
+  it('does not show remove buttons with single vault', () => {
+    const singleVault = [{ label: 'Only', path: '/only' }]
+    render(<StatusBar noteCount={100} vaultPath="/only" vaults={singleVault} onSwitchVault={vi.fn()} onRemoveVault={vi.fn()} />)
+
+    fireEvent.click(screen.getByTitle('Switch vault'))
+    expect(screen.queryByTitle(/Remove .+ from list/)).not.toBeInTheDocument()
+  })
+
+  it('calls onRemoveVault with correct path when remove button is clicked', () => {
+    const onRemoveVault = vi.fn()
+    render(<StatusBar noteCount={100} vaultPath="/Users/luca/Laputa" vaults={vaults} onSwitchVault={vi.fn()} onRemoveVault={onRemoveVault} />)
+
+    fireEvent.click(screen.getByTitle('Switch vault'))
+    const removeWork = screen.getByTitle('Remove Work Vault from list')
+    fireEvent.click(removeWork)
+
+    expect(onRemoveVault).toHaveBeenCalledWith('/Users/luca/Work')
+  })
+
+  it('does not show "Add vault..." when onAddVault is not provided', () => {
+    render(<StatusBar noteCount={100} vaultPath="/Users/luca/Laputa" vaults={vaults} onSwitchVault={vi.fn()} />)
+
+    fireEvent.click(screen.getByTitle('Switch vault'))
+    expect(screen.queryByText('Add vault...')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Package, GitBranch, RefreshCw, Sparkles, FileText, Bell, Settings, FolderOpen, Check } from 'lucide-react'
+import { Package, GitBranch, RefreshCw, Sparkles, FileText, Bell, Settings, FolderOpen, Check, Plus, Trash2 } from 'lucide-react'
 
 export interface VaultOption {
   label: string
@@ -11,6 +11,8 @@ interface StatusBarProps {
   vaultPath: string
   vaults: VaultOption[]
   onSwitchVault: (path: string) => void
+  onAddVault?: () => void
+  onRemoveVault?: (path: string) => void
 }
 
 function VaultMenuItem({ vault, isActive, onSelect }: { vault: VaultOption; isActive: boolean; onSelect: () => void }) {
@@ -31,7 +33,13 @@ function VaultMenuItem({ vault, isActive, onSelect }: { vault: VaultOption; isAc
   )
 }
 
-function VaultMenu({ vaults, vaultPath, onSwitchVault }: { vaults: VaultOption[]; vaultPath: string; onSwitchVault: (path: string) => void }) {
+function VaultMenu({ vaults, vaultPath, onSwitchVault, onAddVault, onRemoveVault }: {
+  vaults: VaultOption[]
+  vaultPath: string
+  onSwitchVault: (path: string) => void
+  onAddVault?: () => void
+  onRemoveVault?: (path: string) => void
+}) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const activeVault = vaults.find((v) => v.path === vaultPath)
@@ -52,8 +60,44 @@ function VaultMenu({ vaults, vaultPath, onSwitchVault }: { vaults: VaultOption[]
         {activeVault?.label ?? 'Vault'}
       </span>
       {open && (
-        <div style={{ position: 'absolute', bottom: '100%', left: 0, marginBottom: 4, background: 'var(--sidebar)', border: '1px solid var(--border)', borderRadius: 6, padding: 4, minWidth: 160, boxShadow: '0 4px 12px rgba(0,0,0,0.3)', zIndex: 1000 }}>
-          {vaults.map((v) => <VaultMenuItem key={v.path} vault={v} isActive={v.path === vaultPath} onSelect={() => { onSwitchVault(v.path); setOpen(false) }} />)}
+        <div style={{ position: 'absolute', bottom: '100%', left: 0, marginBottom: 4, background: 'var(--sidebar)', border: '1px solid var(--border)', borderRadius: 6, padding: 4, minWidth: 180, boxShadow: '0 4px 12px rgba(0,0,0,0.3)', zIndex: 1000 }}>
+          {vaults.map((v) => (
+            <div key={v.path} style={{ display: 'flex', alignItems: 'center' }}>
+              <div style={{ flex: 1 }}>
+                <VaultMenuItem vault={v} isActive={v.path === vaultPath} onSelect={() => { onSwitchVault(v.path); setOpen(false) }} />
+              </div>
+              {onRemoveVault && vaults.length > 1 && (
+                <div
+                  role="button"
+                  onClick={(e) => { e.stopPropagation(); onRemoveVault(v.path); setOpen(false) }}
+                  style={{ padding: '4px', cursor: 'pointer', color: 'var(--muted-foreground)', borderRadius: 3, display: 'flex', alignItems: 'center' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--destructive)' }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--muted-foreground)' }}
+                  title={`Remove ${v.label} from list`}
+                >
+                  <Trash2 size={11} />
+                </div>
+              )}
+            </div>
+          ))}
+          {onAddVault && (
+            <>
+              <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+              <div
+                role="button"
+                onClick={() => { onAddVault(); setOpen(false) }}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 6, padding: '4px 8px', borderRadius: 4, cursor: 'pointer',
+                  color: 'var(--muted-foreground)', fontSize: 12,
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--hover)' }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
+              >
+                <Plus size={12} />
+                Add vault...
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>
@@ -64,11 +108,11 @@ const ICON_STYLE = { display: 'flex', alignItems: 'center', gap: 4 } as const
 const DISABLED_STYLE = { display: 'flex', alignItems: 'center', opacity: 0.4, cursor: 'not-allowed' } as const
 const SEP_STYLE = { color: 'var(--border)' } as const
 
-export function StatusBar({ noteCount, vaultPath, vaults, onSwitchVault }: StatusBarProps) {
+export function StatusBar({ noteCount, vaultPath, vaults, onSwitchVault, onAddVault, onRemoveVault }: StatusBarProps) {
   return (
     <footer style={{ height: 30, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'var(--sidebar)', borderTop: '1px solid var(--border)', padding: '0 8px', fontSize: 11, color: 'var(--muted-foreground)' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-        <VaultMenu vaults={vaults} vaultPath={vaultPath} onSwitchVault={onSwitchVault} />
+        <VaultMenu vaults={vaults} vaultPath={vaultPath} onSwitchVault={onSwitchVault} onAddVault={onAddVault} onRemoveVault={onRemoveVault} />
         <span style={SEP_STYLE}>|</span>
         <span style={ICON_STYLE}><Package size={13} />v0.4.2</span>
         <span style={SEP_STYLE}>|</span>

--- a/src/components/WelcomeScreen.test.tsx
+++ b/src/components/WelcomeScreen.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WelcomeScreen } from './WelcomeScreen'
+
+describe('WelcomeScreen', () => {
+  it('renders welcome message', () => {
+    render(<WelcomeScreen onOpenFolder={vi.fn()} onCreateVault={vi.fn()} error={null} />)
+    expect(screen.getByText('Welcome to Laputa')).toBeInTheDocument()
+    expect(screen.getByText(/Open a folder of markdown files/)).toBeInTheDocument()
+  })
+
+  it('renders both action buttons', () => {
+    render(<WelcomeScreen onOpenFolder={vi.fn()} onCreateVault={vi.fn()} error={null} />)
+    expect(screen.getByText('Open Existing Folder')).toBeInTheDocument()
+    expect(screen.getByText('Create New Vault')).toBeInTheDocument()
+  })
+
+  it('calls onOpenFolder when "Open Existing Folder" is clicked', () => {
+    const onOpenFolder = vi.fn()
+    render(<WelcomeScreen onOpenFolder={onOpenFolder} onCreateVault={vi.fn()} error={null} />)
+    fireEvent.click(screen.getByText('Open Existing Folder'))
+    expect(onOpenFolder).toHaveBeenCalledOnce()
+  })
+
+  it('calls onCreateVault when "Create New Vault" is clicked', () => {
+    const onCreateVault = vi.fn()
+    render(<WelcomeScreen onOpenFolder={vi.fn()} onCreateVault={onCreateVault} error={null} />)
+    fireEvent.click(screen.getByText('Create New Vault'))
+    expect(onCreateVault).toHaveBeenCalledOnce()
+  })
+
+  it('displays error message when error prop is set', () => {
+    render(<WelcomeScreen onOpenFolder={vi.fn()} onCreateVault={vi.fn()} error="Folder does not exist" />)
+    expect(screen.getByText('Folder does not exist')).toBeInTheDocument()
+  })
+
+  it('does not display error when error is null', () => {
+    render(<WelcomeScreen onOpenFolder={vi.fn()} onCreateVault={vi.fn()} error={null} />)
+    expect(screen.queryByText('Folder does not exist')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { FolderOpen, Plus, AlertCircle } from 'lucide-react'
+
+interface WelcomeScreenProps {
+  onOpenFolder: () => void
+  onCreateVault: () => void
+  error: string | null
+}
+
+export function WelcomeScreen({ onOpenFolder, onCreateVault, error }: WelcomeScreenProps) {
+  const [hoveredButton, setHoveredButton] = useState<'open' | 'create' | null>(null)
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '100vh',
+      width: '100vw',
+      background: 'var(--sidebar)',
+      color: 'var(--foreground)',
+      fontFamily: 'inherit',
+    }}>
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 32,
+        maxWidth: 420,
+        textAlign: 'center',
+      }}>
+        <h1 style={{
+          fontSize: 28,
+          fontWeight: 600,
+          margin: 0,
+          color: 'var(--foreground)',
+        }}>
+          Welcome to Laputa
+        </h1>
+        <p style={{
+          fontSize: 14,
+          color: 'var(--muted-foreground)',
+          margin: 0,
+          lineHeight: 1.6,
+        }}>
+          Open a folder of markdown files to get started, or create a new vault.
+        </p>
+
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          width: '100%',
+          maxWidth: 300,
+        }}>
+          <button
+            onClick={onOpenFolder}
+            onMouseEnter={() => setHoveredButton('open')}
+            onMouseLeave={() => setHoveredButton(null)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              padding: '10px 20px',
+              borderRadius: 6,
+              border: 'none',
+              background: hoveredButton === 'open' ? 'var(--primary)' : 'var(--primary)',
+              color: 'var(--primary-foreground)',
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: 'pointer',
+              opacity: hoveredButton === 'open' ? 0.9 : 1,
+              transition: 'opacity 0.15s',
+            }}
+          >
+            <FolderOpen size={16} />
+            Open Existing Folder
+          </button>
+
+          <button
+            onClick={onCreateVault}
+            onMouseEnter={() => setHoveredButton('create')}
+            onMouseLeave={() => setHoveredButton(null)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              padding: '10px 20px',
+              borderRadius: 6,
+              border: '1px solid var(--border)',
+              background: hoveredButton === 'create' ? 'var(--bg-hover)' : 'var(--background)',
+              color: 'var(--foreground)',
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: 'pointer',
+              transition: 'background 0.15s',
+            }}
+          >
+            <Plus size={16} />
+            Create New Vault
+          </button>
+        </div>
+
+        {error && (
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '8px 12px',
+            borderRadius: 6,
+            background: 'var(--destructive)',
+            color: 'var(--destructive-foreground)',
+            fontSize: 13,
+            width: '100%',
+            maxWidth: 300,
+          }}>
+            <AlertCircle size={14} style={{ flexShrink: 0 }} />
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useNoteActions.test.ts
+++ b/src/hooks/useNoteActions.test.ts
@@ -175,7 +175,7 @@ describe('buildNoteContent', () => {
 
 describe('resolveNewNote', () => {
   it('uses TYPE_FOLDER_MAP for known types', () => {
-    const { entry, content } = resolveNewNote('My Project', 'Project')
+    const { entry, content } = resolveNewNote('My Project', 'Project', '/Users/luca/Laputa')
     expect(entry.path).toBe('/Users/luca/Laputa/project/my-project.md')
     expect(entry.isA).toBe('Project')
     expect(entry.status).toBe('Active')
@@ -184,30 +184,40 @@ describe('resolveNewNote', () => {
   })
 
   it('falls back to slugified type for custom types', () => {
-    const { entry } = resolveNewNote('First Recipe', 'Recipe')
+    const { entry } = resolveNewNote('First Recipe', 'Recipe', '/Users/luca/Laputa')
     expect(entry.path).toBe('/Users/luca/Laputa/recipe/first-recipe.md')
   })
 
   it('omits status for Topic type', () => {
-    const { entry, content } = resolveNewNote('Machine Learning', 'Topic')
+    const { entry, content } = resolveNewNote('Machine Learning', 'Topic', '/Users/luca/Laputa')
     expect(entry.status).toBeNull()
     expect(content).not.toContain('status:')
   })
 
   it('omits status for Person type', () => {
-    const { entry } = resolveNewNote('John Doe', 'Person')
+    const { entry } = resolveNewNote('John Doe', 'Person', '/Users/luca/Laputa')
     expect(entry.status).toBeNull()
+  })
+
+  it('uses provided vaultPath instead of hardcoded path', () => {
+    const { entry } = resolveNewNote('My Note', 'Note', '/custom/vault')
+    expect(entry.path).toBe('/custom/vault/note/my-note.md')
   })
 })
 
 describe('resolveNewType', () => {
   it('creates a type entry in the type folder', () => {
-    const { entry, content } = resolveNewType('Recipe')
+    const { entry, content } = resolveNewType('Recipe', '/Users/luca/Laputa')
     expect(entry.path).toBe('/Users/luca/Laputa/type/recipe.md')
     expect(entry.isA).toBe('Type')
     expect(entry.status).toBeNull()
     expect(content).toContain('Is A: Type')
     expect(content).toContain('# Recipe')
+  })
+
+  it('uses provided vaultPath instead of hardcoded path', () => {
+    const { entry } = resolveNewType('Book', '/custom/vault')
+    expect(entry.path).toBe('/custom/vault/type/book.md')
   })
 })
 
@@ -223,7 +233,7 @@ describe('useNoteActions hook', () => {
   it('handleCreateNote calls addEntry and creates correct entry', () => {
     const entries: VaultEntry[] = []
     const { result } = renderHook(() =>
-      useNoteActions(addEntry, updateContent, entries, setToastMessage)
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
     )
 
     act(() => {
@@ -238,10 +248,41 @@ describe('useNoteActions hook', () => {
     expect(createdContent).toContain('title: Test Note')
   })
 
+  it('handleCreateNote registers mock content in non-Tauri mode', async () => {
+    const { addMockEntry } = await import('../mock-tauri')
+    const entries: VaultEntry[] = []
+    const { result } = renderHook(() =>
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
+    )
+
+    act(() => {
+      result.current.handleCreateNote('Persisted Note', 'Note')
+    })
+
+    expect(addMockEntry).toHaveBeenCalledTimes(1)
+    const [mockEntry, mockContent] = (addMockEntry as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(mockEntry.path).toContain('note/persisted-note.md')
+    expect(mockContent).toContain('title: Persisted Note')
+  })
+
+  it('handleCreateNote uses provided vaultPath for entry path', () => {
+    const entries: VaultEntry[] = []
+    const { result } = renderHook(() =>
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/my/vault')
+    )
+
+    act(() => {
+      result.current.handleCreateNote('Custom Path Note', 'Project')
+    })
+
+    const [createdEntry] = addEntry.mock.calls[0]
+    expect(createdEntry.path).toBe('/my/vault/project/custom-path-note.md')
+  })
+
   it('handleCreateType creates type entry', () => {
     const entries: VaultEntry[] = []
     const { result } = renderHook(() =>
-      useNoteActions(addEntry, updateContent, entries, setToastMessage)
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
     )
 
     act(() => {
@@ -259,7 +300,7 @@ describe('useNoteActions hook', () => {
     const entries = [target]
 
     const { result } = renderHook(() =>
-      useNoteActions(addEntry, updateContent, entries, setToastMessage)
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
     )
 
     await act(async () => {
@@ -275,7 +316,7 @@ describe('useNoteActions hook', () => {
     const entries: VaultEntry[] = []
 
     const { result } = renderHook(() =>
-      useNoteActions(addEntry, updateContent, entries, setToastMessage)
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
     )
 
     act(() => {
@@ -289,7 +330,7 @@ describe('useNoteActions hook', () => {
   it('handleUpdateFrontmatter calls mock and shows toast on success', async () => {
     const entries: VaultEntry[] = []
     const { result } = renderHook(() =>
-      useNoteActions(addEntry, updateContent, entries, setToastMessage)
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
     )
 
     await act(async () => {
@@ -303,7 +344,7 @@ describe('useNoteActions hook', () => {
   it('handleDeleteProperty calls mock and shows toast on success', async () => {
     const entries: VaultEntry[] = []
     const { result } = renderHook(() =>
-      useNoteActions(addEntry, updateContent, entries, setToastMessage)
+      useNoteActions(addEntry, updateContent, entries, setToastMessage, '/Users/luca/Laputa')
     )
 
     await act(async () => {

--- a/src/hooks/useNoteActions.ts
+++ b/src/hooks/useNoteActions.ts
@@ -106,6 +106,12 @@ const NO_STATUS_TYPES = new Set(['Topic', 'Person'])
 function addEntryWithMock(entry: VaultEntry, content: string, addEntry: (e: VaultEntry, c: string) => void) {
   if (!isTauri()) addMockEntry(entry, content)
   addEntry(entry, content)
+  // Persist to disk when running inside Tauri
+  if (isTauri()) {
+    invoke('write_note', { path: entry.path, content }).catch((err) =>
+      console.error('Failed to write note to disk:', err)
+    )
+  }
 }
 
 export function buildNoteContent(title: string, type: string, status: string | null): string {
@@ -115,17 +121,17 @@ export function buildNoteContent(title: string, type: string, status: string | n
   return `${lines.join('\n')}\n\n# ${title}\n\n`
 }
 
-export function resolveNewNote(title: string, type: string): { entry: VaultEntry; content: string } {
+export function resolveNewNote(title: string, type: string, vaultPath: string): { entry: VaultEntry; content: string } {
   const folder = TYPE_FOLDER_MAP[type] || slugify(type)
   const slug = slugify(title)
   const status = NO_STATUS_TYPES.has(type) ? null : 'Active'
-  const entry = buildNewEntry({ path: `/Users/luca/Laputa/${folder}/${slug}.md`, slug, title, type, status })
+  const entry = buildNewEntry({ path: `${vaultPath}/${folder}/${slug}.md`, slug, title, type, status })
   return { entry, content: buildNoteContent(title, type, status) }
 }
 
-export function resolveNewType(typeName: string): { entry: VaultEntry; content: string } {
+export function resolveNewType(typeName: string, vaultPath: string): { entry: VaultEntry; content: string } {
   const slug = slugify(typeName)
-  const entry = buildNewEntry({ path: `/Users/luca/Laputa/type/${slug}.md`, slug, title: typeName, type: 'Type', status: null })
+  const entry = buildNewEntry({ path: `${vaultPath}/type/${slug}.md`, slug, title: typeName, type: 'Type', status: null })
   return { entry, content: `---\nIs A: Type\n---\n\n# ${typeName}\n\n` }
 }
 
@@ -141,6 +147,7 @@ export function useNoteActions(
   updateContent: (path: string, content: string) => void,
   entries: VaultEntry[],
   setToastMessage: (msg: string | null) => void,
+  vaultPath: string,
 ) {
   const tabMgmt = useTabManagement()
   const { setTabs, handleSelectNote, activeTabPathRef, handleSwitchTab } = tabMgmt
@@ -159,16 +166,16 @@ export function useNoteActions(
   }, [entries, handleSelectNote])
 
   const handleCreateNote = useCallback((title: string, type: string) => {
-    const { entry, content } = resolveNewNote(title, type)
+    const { entry, content } = resolveNewNote(title, type, vaultPath)
     addEntryWithMock(entry, content, addEntry)
     handleSelectNote(entry)
-  }, [handleSelectNote, addEntry])
+  }, [handleSelectNote, addEntry, vaultPath])
 
   const handleCreateType = useCallback((typeName: string) => {
-    const { entry, content } = resolveNewType(typeName)
+    const { entry, content } = resolveNewType(typeName, vaultPath)
     addEntryWithMock(entry, content, addEntry)
     handleSelectNote(entry)
-  }, [handleSelectNote, addEntry])
+  }, [handleSelectNote, addEntry, vaultPath])
 
   const runFrontmatterOp = useCallback(async (op: 'update' | 'delete', path: string, key: string, value?: FrontmatterValue) => {
     try {

--- a/src/hooks/useVaultConfig.test.ts
+++ b/src/hooks/useVaultConfig.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useVaultConfig } from './useVaultConfig'
+
+const mockInvokeFn = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('../mock-tauri', () => ({
+  isTauri: () => false,
+  mockInvoke: (cmd: string, args?: any) => mockInvokeFn(cmd, args),
+}))
+
+describe('useVaultConfig', () => {
+  beforeEach(() => {
+    mockInvokeFn.mockReset()
+    mockInvokeFn.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_vaults') return [{ label: 'Demo', path: '/demo' }]
+      if (cmd === 'add_vault') return { label: 'New', path: '/new' }
+      if (cmd === 'remove_vault') return null
+      if (cmd === 'init_vault') return null
+      return null
+    })
+  })
+
+  it('loads vaults on mount', async () => {
+    const { result } = renderHook(() => useVaultConfig())
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.vaults).toEqual([{ label: 'Demo', path: '/demo' }])
+    expect(mockInvokeFn).toHaveBeenCalledWith('get_vaults', undefined)
+  })
+
+  it('addVault calls add_vault and updates state', async () => {
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let addedVault: any
+    await act(async () => {
+      addedVault = await result.current.addVault('/new')
+    })
+
+    expect(addedVault).toEqual({ label: 'New', path: '/new' })
+    expect(result.current.vaults).toHaveLength(2)
+    expect(result.current.vaults[1]).toEqual({ label: 'New', path: '/new' })
+    expect(mockInvokeFn).toHaveBeenCalledWith('add_vault', { path: '/new' })
+  })
+
+  it('addVault deduplicates by path', async () => {
+    mockInvokeFn.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_vaults') return [{ label: 'Demo', path: '/demo' }]
+      if (cmd === 'add_vault') return { label: 'Demo', path: '/demo' }
+      return null
+    })
+
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.addVault('/demo')
+    })
+
+    // Should still have just 1 vault, not duplicated
+    expect(result.current.vaults).toHaveLength(1)
+  })
+
+  it('removeVault calls remove_vault and updates state', async () => {
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.removeVault('/demo')
+    })
+
+    expect(result.current.vaults).toHaveLength(0)
+    expect(mockInvokeFn).toHaveBeenCalledWith('remove_vault', { path: '/demo' })
+  })
+
+  it('initVault calls init_vault', async () => {
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.initVault('/new-vault')
+    })
+
+    expect(mockInvokeFn).toHaveBeenCalledWith('init_vault', { path: '/new-vault' })
+  })
+
+  it('addVault sets error on failure', async () => {
+    mockInvokeFn.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_vaults') return []
+      if (cmd === 'add_vault') throw new Error('Folder does not exist: /bad')
+      return null
+    })
+
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      try { await result.current.addVault('/bad') } catch { /* expected */ }
+    })
+
+    expect(result.current.error).toContain('Folder does not exist')
+  })
+
+  it('clearError resets error state', async () => {
+    mockInvokeFn.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_vaults') return []
+      if (cmd === 'add_vault') throw new Error('fail')
+      return null
+    })
+
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      try { await result.current.addVault('/bad') } catch { /* expected */ }
+    })
+    expect(result.current.error).toBeTruthy()
+
+    act(() => { result.current.clearError() })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('handles empty vault list gracefully', async () => {
+    mockInvokeFn.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_vaults') return []
+      return null
+    })
+
+    const { result } = renderHook(() => useVaultConfig())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.vaults).toEqual([])
+  })
+})

--- a/src/hooks/useVaultConfig.ts
+++ b/src/hooks/useVaultConfig.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { isTauri, mockInvoke } from '../mock-tauri'
+
+export interface VaultConfig {
+  label: string
+  path: string
+}
+
+function tauriCall<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  return isTauri() ? invoke<T>(command, args) : mockInvoke<T>(command, args)
+}
+
+export function useVaultConfig() {
+  const [vaults, setVaults] = useState<VaultConfig[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load vault list on mount
+  useEffect(() => {
+    tauriCall<VaultConfig[]>('get_vaults')
+      .then((v) => { setVaults(v); setLoading(false) })
+      .catch((err) => { console.warn('Failed to load vaults:', err); setLoading(false) })
+  }, [])
+
+  const addVault = useCallback(async (path: string): Promise<VaultConfig> => {
+    setError(null)
+    try {
+      const vault = await tauriCall<VaultConfig>('add_vault', { path })
+      setVaults((prev) => {
+        // Deduplicate by path
+        if (prev.some((v) => v.path === vault.path)) return prev
+        return [...prev, vault]
+      })
+      return vault
+    } catch (err) {
+      const msg = String(err)
+      setError(msg)
+      throw new Error(msg)
+    }
+  }, [])
+
+  const removeVault = useCallback(async (path: string) => {
+    setError(null)
+    try {
+      await tauriCall<void>('remove_vault', { path })
+      setVaults((prev) => prev.filter((v) => v.path !== path))
+    } catch (err) {
+      const msg = String(err)
+      setError(msg)
+    }
+  }, [])
+
+  const initVault = useCallback(async (path: string) => {
+    setError(null)
+    try {
+      await tauriCall<void>('init_vault', { path })
+    } catch (err) {
+      const msg = String(err)
+      setError(msg)
+      throw new Error(msg)
+    }
+  }, [])
+
+  const clearError = useCallback(() => setError(null), [])
+
+  return { vaults, loading, error, addVault, removeVault, initVault, clearError }
+}

--- a/src/hooks/useVaultLoader.test.ts
+++ b/src/hooks/useVaultLoader.test.ts
@@ -26,7 +26,7 @@ const mockGitHistory: GitCommit[] = [
   { hash: 'abc1234567', shortHash: 'abc1234', message: 'initial commit', author: 'luca', date: 1700000000 },
 ]
 
-function defaultMockInvoke(cmd: string, args?: Record<string, unknown>) {
+function defaultMockInvoke(cmd: string, args?: Record<string, unknown>): Promise<any> {
   if (cmd === 'list_vault') return Promise.resolve(mockEntries)
   if (cmd === 'get_all_content') return Promise.resolve(mockContent)
   if (cmd === 'get_modified_files') return Promise.resolve(mockModifiedFiles)
@@ -46,7 +46,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 vi.mock('../mock-tauri', () => ({
   isTauri: () => false,
-  mockInvoke: (...args: any[]) => mockInvokeFn(...args),
+  mockInvoke: (cmd: string, args?: any) => mockInvokeFn(cmd, args),
 }))
 
 describe('useVaultLoader', () => {
@@ -164,7 +164,7 @@ describe('useVaultLoader', () => {
     })
 
     it('returns empty array on error', async () => {
-      mockInvokeFn.mockImplementation((cmd: string) => {
+      mockInvokeFn.mockImplementation((cmd: string): Promise<any> => {
         if (cmd === 'get_file_history') return Promise.reject(new Error('fail'))
         if (cmd === 'list_vault') return Promise.resolve([])
         if (cmd === 'get_all_content') return Promise.resolve({})

--- a/src/mock-tauri.ts
+++ b/src/mock-tauri.ts
@@ -1673,6 +1673,13 @@ const mockHandlers: Record<string, (args: any) => any> = {
       stop_reason: 'end_turn',
     }
   },
+  write_note: (args: { path: string; content: string }) => {
+    MOCK_CONTENT[args.path] = args.content
+    if (typeof window !== 'undefined') {
+      window.__mockContent = MOCK_CONTENT
+    }
+    return null
+  },
   save_image: (args: { vault_path?: string; filename: string; data: string }) => {
     // Return a plausible file path matching the real Rust backend behavior
     const vault = args.vault_path ?? '/Users/luca/Laputa'

--- a/src/mock-tauri.ts
+++ b/src/mock-tauri.ts
@@ -1679,6 +1679,20 @@ const mockHandlers: Record<string, (args: any) => any> = {
     const timestamp = Date.now()
     return `${vault}/attachments/${timestamp}-${args.filename}`
   },
+  get_vaults: () => {
+    // In mock mode, return a single demo vault so the app works in the browser
+    return [{ label: 'Demo v2', path: '/Users/luca/Workspace/laputa-app/demo-vault-v2' }]
+  },
+  add_vault: (args: { path: string }) => {
+    const label = args.path.split('/').pop() ?? 'Vault'
+    return { label, path: args.path }
+  },
+  remove_vault: () => {
+    return null
+  },
+  init_vault: () => {
+    return null
+  },
   rename_note: (args: { vault_path: string; old_path: string; new_title: string }) => {
     const oldContent = MOCK_CONTENT[args.old_path] ?? ''
     const slug = args.new_title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')


### PR DESCRIPTION
Replace hardcoded `/Users/luca/Laputa` paths with user-selected vaults.

**Features:**
- Vault picker UI (create new vault or add existing folder)
- Vault list persisted to local config
- `get_vaults` / `add_vault` / `remove_vault` / `init_vault` Rust commands
- WelcomeScreen when no vault is configured

**Fixes (found during testing):**
- Notes were never written to disk → added `write_note` Rust command
- Editor changes not persisted → autosave debounced 1s
- `resolveNewNote` used hardcoded Laputa path → now uses active vaultPath

Tested by Luca ✅ (some minor UX bugs deferred to bug-squashing session)