### PR TITLE
fix: refresh dirty state after rename so indicator reflects reality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,9 +165,8 @@ function App() {
   }, [notes])
 
   const handleRenameTab = useCallback(async (path: string, newTitle: string) => {
-    // Save any pending content before renaming so the file on disk is up to date
     await savePendingForPath(path)
-    notes.handleRenameNote(path, newTitle, vaultPath, vault.replaceEntry)
+    await notes.handleRenameNote(path, newTitle, vaultPath, vault.replaceEntry).then(vault.loadModifiedFiles)
   }, [notes, vaultPath, vault, savePendingForPath])
 
   const { setViewMode } = useViewMode()

--- a/src/hooks/useEditorSave.test.ts
+++ b/src/hooks/useEditorSave.test.ts
@@ -124,6 +124,21 @@ describe('useEditorSave', () => {
     expect(onAfterSave).toHaveBeenCalledOnce()
   })
 
+  it('calls onAfterSave even when nothing is pending (e.g. after rename)', async () => {
+    const onAfterSave = vi.fn()
+    const { result } = renderHook(() =>
+      useEditorSave({ updateVaultContent, setTabs, setToastMessage, onAfterSave })
+    )
+
+    // No content buffered — simulate Cmd+S after a rename that already flushed pending
+    await act(async () => {
+      await result.current.handleSave()
+    })
+
+    expect(setToastMessage).toHaveBeenCalledWith('Nothing to save')
+    expect(onAfterSave).toHaveBeenCalledOnce()
+  })
+
   it('does not call onAfterSave when save fails', async () => {
     mockInvokeFn.mockRejectedValueOnce(new Error('Disk full'))
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/hooks/useEditorSave.ts
+++ b/src/hooks/useEditorSave.ts
@@ -45,8 +45,7 @@ export function useEditorSave({ updateVaultContent, setTabs, setToastMessage, on
   const handleSave = useCallback(async () => {
     try {
       const saved = await flushPending()
-      if (!saved) { setToastMessage('Nothing to save'); return }
-      setToastMessage('Saved')
+      setToastMessage(saved ? 'Saved' : 'Nothing to save')
       onAfterSave?.()
     } catch (err) {
       console.error('Save failed:', err)


### PR DESCRIPTION
Fixes 🐛 Rinominare una nota non aggiorna il dirty state.

Renaming a note no longer leaves the dirty indicator stale:
- `handleRenameTab` in App.tsx now chains `.then(vault.loadModifiedFiles)` to refresh dirty state after rename
- `handleSave` in useEditorSave.ts now always calls `onAfterSave?.()` even when nothing was pending (so Cmd+S after rename refreshes dirty state)

Regression test added in `useEditorSave.test.ts`. All 568 tests pass, cargo 218 tests pass, coverage 89.89%.