### PR TITLE
fix: add 1px inset border between macOS window frame and app content

### DIFF
--- a/design/window-frame-border.pen
+++ b/design/window-frame-border.pen
@@ -1,0 +1,1 @@
+{"children":[],"variables":{}}

--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,8 @@
   height: 100vh;
   width: 100vw;
   overflow: hidden;
+  border-radius: 10px;
+  box-shadow: inset 0 0 0 1px var(--border-primary);
 }
 
 .app {


### PR DESCRIPTION
Adds box-shadow inset 1px border to .app-shell with border-radius matching macOS window corners. Separates the frameless window from app content visually.