### PR TITLE
refactor: raise CodeScene code health threshold to 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,13 @@ jobs:
       # comments on PRs). This step enforces a minimum floor on the
       # project-wide Hotspot Code Health score (weighted avg of the most
       # frequently edited files — the ones that matter most).
-      # Current baseline: 8.73 | Aspirational target: 9.5
-      - name: Hotspot Code Health gate (≥8.45)
+      # Current baseline: 9.33 | Aspirational target: 9.5
+      - name: Hotspot Code Health gate (≥9.2)
         env:
           CODESCENE_PAT: ${{ secrets.CODESCENE_PAT }}
           CODESCENE_PROJECT_ID: ${{ secrets.CODESCENE_PROJECT_ID }}
         run: |
-          THRESHOLD=8.45
+          THRESHOLD=9.2
           SCORE=$(curl -sf \
             -H "Authorization: Bearer $CODESCENE_PAT" \
             -H "Accept: application/json" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ pnpm test                           # unit tests
 pnpm test:coverage                  # frontend ≥70% coverage
 cargo test                          # Rust tests
 cargo llvm-cov --manifest-path src-tauri/Cargo.toml --fail-under-lines 85
-pre_commit_code_health_safeguard    # CodeScene ≥8.5 — if it fails, fix structurally (see below)
+pre_commit_code_health_safeguard    # CodeScene ≥9.2 — if it fails, fix structurally (see below)
 ```
 
 **CI is a safety net, not a discovery tool.** If CI catches something you didn't catch locally, that's a process failure. All these tools are available locally — use them while you code, not just at the end.


### PR DESCRIPTION
Raises the minimum code health gate from 8.5 to 9.2 in CI and CLAUDE.md. Current project score is 9.33, safely above the new bar.