### PR TITLE
fix: use type-defined colors and icons in Relations/Backlinks/ReferencedBy panels

### DIFF
--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -119,6 +119,11 @@ export function Inspector({
   const backlinks = useBacklinks(entry, entries, allContent)
   const referencedBy = useReferencedBy(entry, entries)
   const frontmatter = useMemo(() => parseFrontmatter(content), [content])
+  const typeEntryMap = useMemo(() => {
+    const map: Record<string, VaultEntry> = {}
+    for (const e of entries) { if (e.isA === 'Type') map[e.title] = e }
+    return map
+  }, [entries])
 
   const handleUpdateProperty = useCallback((key: string, value: FrontmatterValue) => {
     if (entry && onUpdateFrontmatter) onUpdateFrontmatter(entry.path, key, value)
@@ -148,13 +153,13 @@ export function Inspector({
                 onNavigate={onNavigate}
               />
               <DynamicRelationshipsPanel
-                frontmatter={frontmatter} entries={entries} onNavigate={onNavigate}
+                frontmatter={frontmatter} entries={entries} typeEntryMap={typeEntryMap} onNavigate={onNavigate}
                 onAddProperty={onAddProperty ? handleAddProperty : undefined}
                 onUpdateProperty={onUpdateFrontmatter ? handleUpdateProperty : undefined}
                 onDeleteProperty={onDeleteProperty ? handleDeleteProperty : undefined}
               />
-              <ReferencedByPanel items={referencedBy} onNavigate={onNavigate} />
-              <BacklinksPanel backlinks={backlinks} onNavigate={onNavigate} />
+              <ReferencedByPanel items={referencedBy} typeEntryMap={typeEntryMap} onNavigate={onNavigate} />
+              <BacklinksPanel backlinks={backlinks} typeEntryMap={typeEntryMap} onNavigate={onNavigate} />
               <GitHistoryPanel commits={gitHistory} onViewCommitDiff={onViewCommitDiff} />
             </>
           ) : (

--- a/src/components/InspectorPanels.test.tsx
+++ b/src/components/InspectorPanels.test.tsx
@@ -44,6 +44,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('shows "No relationships" when frontmatter has no relations', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{ Status: 'Active', title: 'Test' }}
         entries={entries}
         onNavigate={onNavigate}
@@ -55,6 +56,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('renders relationship groups with wikilinks', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{
           'Belongs to': ['[[project/my-project]]'],
           'Related to': ['[[topic/ai]]'],
@@ -70,6 +72,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('navigates when clicking a relationship link', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
         entries={entries}
         onNavigate={onNavigate}
@@ -84,6 +87,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('renders single string wikilink value', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{ Owner: '[[person/luca]]' }}
         entries={[makeEntry({ path: '/vault/person/luca.md', filename: 'luca.md', title: 'Luca', isA: 'Person' })]  }
         onNavigate={onNavigate}
@@ -96,6 +100,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('renders + Link existing button when onAddProperty provided', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{}}
         entries={entries}
         onNavigate={onNavigate}
@@ -108,6 +113,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('opens add relationship form when button clicked', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{}}
         entries={entries}
         onNavigate={onNavigate}
@@ -122,6 +128,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('adds relationship via form', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{}}
         entries={entries}
         onNavigate={onNavigate}
@@ -138,6 +145,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('cancels add relationship form', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{}}
         entries={entries}
         onNavigate={onNavigate}
@@ -155,6 +163,7 @@ describe('DynamicRelationshipsPanel', () => {
     })
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{ 'Belongs to': ['[[project/old]]'] }}
         entries={[archivedEntry]}
         onNavigate={onNavigate}
@@ -170,6 +179,7 @@ describe('DynamicRelationshipsPanel', () => {
     })
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{ 'Belongs to': ['[[project/trash]]'] }}
         entries={[trashedEntry]}
         onNavigate={onNavigate}
@@ -181,6 +191,7 @@ describe('DynamicRelationshipsPanel', () => {
   it('handles aliased wikilinks [[path|Display]]', () => {
     render(
       <DynamicRelationshipsPanel
+        typeEntryMap={{}}
         frontmatter={{ 'Belongs to': ['[[project/my-project|My Cool Project]]'] }}
         entries={entries}
         onNavigate={onNavigate}
@@ -200,6 +211,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('shows remove buttons on relation refs when editing is enabled', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -213,6 +225,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('does not show remove buttons when editing is disabled', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -224,6 +237,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('calls onDeleteProperty when removing the last ref in a group', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -238,6 +252,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('calls onUpdateProperty with remaining refs when removing one of many', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Related to': ['[[project/my-project]]', '[[topic/ai]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -253,6 +268,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('calls onUpdateProperty with string when two refs become one', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Has': ['[[project/my-project]]', '[[topic/ai]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -269,6 +285,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('shows inline add button for each relationship group when editing is enabled', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -282,6 +299,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('opens inline add input when add button clicked', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -296,6 +314,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('adds a note to an existing relationship via inline add', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -313,6 +332,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('does not add duplicate refs', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[AI]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -330,6 +350,7 @@ describe('DynamicRelationshipsPanel', () => {
     it('closes inline add on Escape', () => {
       render(
         <DynamicRelationshipsPanel
+          typeEntryMap={{}}
           frontmatter={{ 'Belongs to': ['[[project/my-project]]'] }}
           entries={entries}
           onNavigate={onNavigate}
@@ -354,7 +375,7 @@ describe('BacklinksPanel', () => {
   })
 
   it('shows "No backlinks" when empty', () => {
-    render(<BacklinksPanel backlinks={[]} onNavigate={onNavigate} />)
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={[]} onNavigate={onNavigate} />)
     expect(screen.getByText('No backlinks')).toBeInTheDocument()
   })
 
@@ -363,21 +384,21 @@ describe('BacklinksPanel', () => {
       makeEntry({ title: 'Referencing Note', isA: 'Note' }),
       makeEntry({ title: 'Another Note', isA: 'Project', path: '/vault/project/another.md' }),
     ]
-    render(<BacklinksPanel backlinks={backlinks} onNavigate={onNavigate} />)
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
     expect(screen.getByText('Referencing Note')).toBeInTheDocument()
     expect(screen.getByText('Another Note')).toBeInTheDocument()
   })
 
   it('navigates when clicking backlink', () => {
     const backlinks = [makeEntry({ title: 'Reference' })]
-    render(<BacklinksPanel backlinks={backlinks} onNavigate={onNavigate} />)
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
     fireEvent.click(screen.getByText('Reference'))
     expect(onNavigate).toHaveBeenCalledWith('Reference')
   })
 
   it('shows count when backlinks exist', () => {
     const backlinks = [makeEntry(), makeEntry({ path: '/vault/b.md', title: 'B' })]
-    render(<BacklinksPanel backlinks={backlinks} onNavigate={onNavigate} />)
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 })
@@ -390,7 +411,7 @@ describe('ReferencedByPanel', () => {
   })
 
   it('shows "No references" when items is empty', () => {
-    render(<ReferencedByPanel items={[]} onNavigate={onNavigate} />)
+    render(<ReferencedByPanel typeEntryMap={{}} items={[]} onNavigate={onNavigate} />)
     expect(screen.getByText('No references')).toBeInTheDocument()
   })
 
@@ -400,7 +421,7 @@ describe('ReferencedByPanel', () => {
       { entry: makeEntry({ path: '/vault/essay/b.md', title: 'On Writing Well', isA: 'Essay' }), viaKey: 'Belongs to' },
       { entry: makeEntry({ path: '/vault/exp/c.md', title: 'SEO Experiment', isA: 'Experiment' }), viaKey: 'Related to' },
     ]
-    render(<ReferencedByPanel items={items} onNavigate={onNavigate} />)
+    render(<ReferencedByPanel typeEntryMap={{}} items={items} onNavigate={onNavigate} />)
 
     expect(screen.getByText('Write Essays')).toBeInTheDocument()
     expect(screen.getByText('On Writing Well')).toBeInTheDocument()
@@ -415,7 +436,7 @@ describe('ReferencedByPanel', () => {
       { entry: makeEntry({ path: '/vault/b.md', title: 'B' }), viaKey: 'Has' },
       { entry: makeEntry({ path: '/vault/c.md', title: 'C' }), viaKey: 'Topics' },
     ]
-    render(<ReferencedByPanel items={items} onNavigate={onNavigate} />)
+    render(<ReferencedByPanel typeEntryMap={{}} items={items} onNavigate={onNavigate} />)
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 
@@ -423,7 +444,7 @@ describe('ReferencedByPanel', () => {
     const items: ReferencedByItem[] = [
       { entry: makeEntry({ path: '/vault/a.md', title: 'My Note' }), viaKey: 'Belongs to' },
     ]
-    render(<ReferencedByPanel items={items} onNavigate={onNavigate} />)
+    render(<ReferencedByPanel typeEntryMap={{}} items={items} onNavigate={onNavigate} />)
     fireEvent.click(screen.getByText('My Note'))
     expect(onNavigate).toHaveBeenCalledWith('My Note')
   })
@@ -432,7 +453,7 @@ describe('ReferencedByPanel', () => {
     const items: ReferencedByItem[] = [
       { entry: makeEntry({ path: '/vault/a.md', title: 'Old Note', archived: true }), viaKey: 'Has' },
     ]
-    render(<ReferencedByPanel items={items} onNavigate={onNavigate} />)
+    render(<ReferencedByPanel typeEntryMap={{}} items={items} onNavigate={onNavigate} />)
     expect(screen.getByTitle('Archived')).toBeInTheDocument()
   })
 
@@ -440,7 +461,7 @@ describe('ReferencedByPanel', () => {
     const items: ReferencedByItem[] = [
       { entry: makeEntry({ path: '/vault/a.md', title: 'Trash Note', trashed: true }), viaKey: 'Has' },
     ]
-    render(<ReferencedByPanel items={items} onNavigate={onNavigate} />)
+    render(<ReferencedByPanel typeEntryMap={{}} items={items} onNavigate={onNavigate} />)
     expect(screen.getByTitle('Trashed')).toBeInTheDocument()
   })
 })

--- a/src/components/InspectorPanels.tsx
+++ b/src/components/InspectorPanels.tsx
@@ -2,24 +2,12 @@ import { useMemo, useCallback, useState, useRef } from 'react'
 import type { ComponentType, SVGAttributes } from 'react'
 import { wikilinkTarget, wikilinkDisplay } from '../utils/wikilink'
 import type { VaultEntry, GitCommit } from '../types'
-import {
-  Wrench, Flask, Target, ArrowsClockwise,
-  Users, CalendarBlank, Tag, FileText, StackSimple, Trash, X, Plus,
-} from '@phosphor-icons/react'
+import { Trash, X, Plus } from '@phosphor-icons/react'
 import type { ParsedFrontmatter } from '../utils/frontmatter'
 import { RELATIONSHIP_KEYS, containsWikilinks } from './DynamicPropertiesPanel'
 import { getTypeColor, getTypeLightColor } from '../utils/typeColors'
+import { getTypeIcon } from './NoteItem'
 import type { FrontmatterValue } from './Inspector'
-
-const TYPE_ICON_MAP: Record<string, ComponentType<SVGAttributes<SVGSVGElement>>> = {
-  Project: Wrench, Experiment: Flask, Responsibility: Target,
-  Procedure: ArrowsClockwise, Person: Users, Event: CalendarBlank,
-  Topic: Tag, Type: StackSimple,
-}
-
-function getTypeIcon(isA: string | undefined): ComponentType<SVGAttributes<SVGSVGElement>> {
-  return (isA && TYPE_ICON_MAP[isA]) || FileText
-}
 
 function isWikilink(value: string): boolean {
   return /^\[\[.*\]\]$/.test(value)
@@ -92,18 +80,19 @@ function entryStatusTitle(entry: VaultEntry | undefined): string | undefined {
   return undefined
 }
 
-function resolveRefProps(ref: string, entries: VaultEntry[]) {
+function resolveRefProps(ref: string, entries: VaultEntry[], typeEntryMap: Record<string, VaultEntry>) {
   const resolved = resolveRef(ref, entries)
-  const refType = resolved?.isA ?? undefined
+  const refType = resolved?.isA ?? null
+  const te = typeEntryMap[refType ?? '']
   return {
     label: wikilinkDisplay(ref),
-    typeColor: refType ? getTypeColor(refType) : 'var(--accent-blue)',
-    bgColor: refType ? getTypeLightColor(refType) : 'var(--accent-blue-light)',
+    typeColor: getTypeColor(refType, te?.color),
+    bgColor: getTypeLightColor(refType, te?.color),
     isArchived: resolved?.archived ?? false,
     isTrashed: resolved?.trashed ?? false,
     target: wikilinkTarget(ref),
     title: entryStatusTitle(resolved),
-    TypeIcon: getTypeIcon(refType),
+    TypeIcon: getTypeIcon(refType, te?.icon),
   }
 }
 
@@ -173,8 +162,9 @@ function InlineAddNote({ entries, onAdd }: {
   )
 }
 
-function RelationshipGroup({ label, refs, entries, onNavigate, onRemoveRef, onAddRef }: {
-  label: string; refs: string[]; entries: VaultEntry[]; onNavigate: (target: string) => void
+function RelationshipGroup({ label, refs, entries, typeEntryMap, onNavigate, onRemoveRef, onAddRef }: {
+  label: string; refs: string[]; entries: VaultEntry[]; typeEntryMap: Record<string, VaultEntry>
+  onNavigate: (target: string) => void
   onRemoveRef?: (ref: string) => void; onAddRef?: (noteTitle: string) => void
 }) {
   if (refs.length === 0) return null
@@ -183,7 +173,7 @@ function RelationshipGroup({ label, refs, entries, onNavigate, onRemoveRef, onAd
       <span className="font-mono-overline mb-1 block text-muted-foreground">{label}</span>
       <div className="flex flex-col gap-1">
         {refs.map((ref, idx) => {
-          const props = resolveRefProps(ref, entries)
+          const props = resolveRefProps(ref, entries, typeEntryMap)
           return (
             <LinkButton
               key={`${ref}-${idx}`}
@@ -254,8 +244,9 @@ function AddRelationshipForm({ entries, onAddProperty }: {
   )
 }
 
-export function DynamicRelationshipsPanel({ frontmatter, entries, onNavigate, onAddProperty, onUpdateProperty, onDeleteProperty }: {
-  frontmatter: ParsedFrontmatter; entries: VaultEntry[]; onNavigate: (target: string) => void
+export function DynamicRelationshipsPanel({ frontmatter, entries, typeEntryMap, onNavigate, onAddProperty, onUpdateProperty, onDeleteProperty }: {
+  frontmatter: ParsedFrontmatter; entries: VaultEntry[]; typeEntryMap: Record<string, VaultEntry>
+  onNavigate: (target: string) => void
   onAddProperty?: (key: string, value: FrontmatterValue) => void
   onUpdateProperty?: (key: string, value: FrontmatterValue) => void
   onDeleteProperty?: (key: string) => void
@@ -291,7 +282,7 @@ export function DynamicRelationshipsPanel({ frontmatter, entries, onNavigate, on
         ? <p className="m-0 text-[13px] text-muted-foreground">No relationships</p>
         : relationshipEntries.map(({ key, refs }) => (
           <RelationshipGroup
-            key={key} label={key} refs={refs} entries={entries} onNavigate={onNavigate}
+            key={key} label={key} refs={refs} entries={entries} typeEntryMap={typeEntryMap} onNavigate={onNavigate}
             onRemoveRef={canEdit ? (ref) => handleRemoveRef(key, ref) : undefined}
             onAddRef={canEdit ? (noteTitle) => handleAddRef(key, noteTitle) : undefined}
           />
@@ -305,7 +296,7 @@ export function DynamicRelationshipsPanel({ frontmatter, entries, onNavigate, on
   )
 }
 
-export function BacklinksPanel({ backlinks, onNavigate }: { backlinks: VaultEntry[]; onNavigate: (target: string) => void }) {
+export function BacklinksPanel({ backlinks, typeEntryMap, onNavigate }: { backlinks: VaultEntry[]; typeEntryMap: Record<string, VaultEntry>; onNavigate: (target: string) => void }) {
   return (
     <div>
       <h4 className="font-mono-overline mb-2 text-muted-foreground">
@@ -315,9 +306,12 @@ export function BacklinksPanel({ backlinks, onNavigate }: { backlinks: VaultEntr
         ? <p className="m-0 text-[13px] text-muted-foreground">No backlinks</p>
         : (
           <div className="flex flex-col gap-0.5">
-            {backlinks.map((e) => (
-              <LinkButton key={e.path} label={e.title} typeColor={e.isA ? getTypeColor(e.isA) : 'var(--accent-blue)'} isArchived={e.archived} isTrashed={e.trashed} onClick={() => onNavigate(e.title)} title={e.trashed ? 'Trashed' : e.archived ? 'Archived' : undefined} TypeIcon={getTypeIcon(e.isA ?? undefined)} />
-            ))}
+            {backlinks.map((e) => {
+              const te = typeEntryMap[e.isA ?? '']
+              return (
+                <LinkButton key={e.path} label={e.title} typeColor={getTypeColor(e.isA, te?.color)} isArchived={e.archived} isTrashed={e.trashed} onClick={() => onNavigate(e.title)} title={e.trashed ? 'Trashed' : e.archived ? 'Archived' : undefined} TypeIcon={getTypeIcon(e.isA, te?.icon)} />
+              )
+            })}
           </div>
         )
       }
@@ -330,8 +324,9 @@ export interface ReferencedByItem {
   viaKey: string
 }
 
-export function ReferencedByPanel({ items, onNavigate }: {
+export function ReferencedByPanel({ items, typeEntryMap, onNavigate }: {
   items: ReferencedByItem[]
+  typeEntryMap: Record<string, VaultEntry>
   onNavigate: (target: string) => void
 }) {
   const grouped = useMemo(() => {
@@ -359,18 +354,21 @@ export function ReferencedByPanel({ items, onNavigate }: {
                   via {viaKey}
                 </span>
                 <div className="flex flex-col gap-0.5">
-                  {groupEntries.map((e) => (
-                    <LinkButton
-                      key={e.path}
-                      label={e.title}
-                      typeColor={e.isA ? getTypeColor(e.isA) : 'var(--accent-blue)'}
-                      isArchived={e.archived}
-                      isTrashed={e.trashed}
-                      onClick={() => onNavigate(e.title)}
-                      title={e.trashed ? 'Trashed' : e.archived ? 'Archived' : undefined}
-                      TypeIcon={getTypeIcon(e.isA ?? undefined)}
-                    />
-                  ))}
+                  {groupEntries.map((e) => {
+                    const te = typeEntryMap[e.isA ?? '']
+                    return (
+                      <LinkButton
+                        key={e.path}
+                        label={e.title}
+                        typeColor={getTypeColor(e.isA, te?.color)}
+                        isArchived={e.archived}
+                        isTrashed={e.trashed}
+                        onClick={() => onNavigate(e.title)}
+                        title={e.trashed ? 'Trashed' : e.archived ? 'Archived' : undefined}
+                        TypeIcon={getTypeIcon(e.isA, te?.icon)}
+                      />
+                    )
+                  })}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Problem
Notes in Relations/Backlinks/ReferencedBy panels were always showing default blue color instead of their type-defined color and icon.

## Root cause
`InspectorPanels.tsx` had a local `getTypeIcon` that didn't support custom icons, and all calls to `getTypeColor`/`getTypeLightColor`/`getTypeIcon` were missing the custom color/icon overrides from the Type entry. NoteList did this correctly by looking up the Type entry via `typeEntryMap` and passing `te?.color`/`te?.icon`.

## Changes
- `Inspector.tsx`: Build `typeEntryMap` from entries and pass to all inspector panels
- `InspectorPanels.tsx`: Remove duplicate local `TYPE_ICON_MAP` and `getTypeIcon`; import shared `getTypeIcon` from `NoteItem`; thread `typeEntryMap` through all panels; pass custom `te?.color` and `te?.icon` to all color/icon resolution calls
- `InspectorPanels.test.tsx`: Updated all test renders to pass `typeEntryMap` prop

## Tests
658/658 passing ✅