### PR TITLE
fix: pass modifiedFiles to NoteList so Changes view filters correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,7 +202,7 @@ function App() {
         </div>
         <ResizeHandle onResize={layout.handleSidebarResize} />
         <div className="app__note-list" style={{ width: layout.noteListWidth }}>
-          <NoteList entries={vault.entries} selection={selection} selectedNote={activeTab?.entry ?? null} allContent={vault.allContent} getNoteStatus={vault.getNoteStatus} onSelectNote={notes.handleSelectNote} onReplaceActiveTab={notes.handleReplaceActiveTab} onCreateNote={handleCreateNoteImmediate} />
+          <NoteList entries={vault.entries} selection={selection} selectedNote={activeTab?.entry ?? null} allContent={vault.allContent} modifiedFiles={vault.modifiedFiles} getNoteStatus={vault.getNoteStatus} onSelectNote={notes.handleSelectNote} onReplaceActiveTab={notes.handleReplaceActiveTab} onCreateNote={handleCreateNoteImmediate} />
         </div>
         <ResizeHandle onResize={layout.handleNoteListResize} />
         <div className="app__editor">

--- a/src/components/NoteList.test.tsx
+++ b/src/components/NoteList.test.tsx
@@ -950,5 +950,17 @@ describe('NoteList — virtual list with large datasets', () => {
       expect(screen.getByText('Build Laputa App')).toBeInTheDocument()
       expect(screen.queryByText('Facebook Ads Strategy')).not.toBeInTheDocument()
     })
+
+    it('shows modified notes when both getNoteStatus and modifiedFiles are provided', () => {
+      // Regression: App.tsx passes both getNoteStatus and modifiedFiles.
+      // The changes filter must use modifiedFiles for filtering even when getNoteStatus is present.
+      const getNoteStatus = (path: string) => modifiedFiles.some((f) => f.path === path) ? 'modified' as const : 'clean' as const
+      render(
+        <NoteList entries={mockEntries} selection={changesSelection} selectedNote={null} modifiedFiles={modifiedFiles} getNoteStatus={getNoteStatus} onSelectNote={noopSelect} onReplaceActiveTab={noopReplace} allContent={{}} onCreateNote={vi.fn()} />
+      )
+      expect(screen.getByText('Build Laputa App')).toBeInTheDocument()
+      expect(screen.getByText('Facebook Ads Strategy')).toBeInTheDocument()
+      expect(screen.queryByText('Matteo Cellini')).not.toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
Closes Todoist task 6g4v4cpMmmx6W2Gv. App.tsx passed getNoteStatus but not modifiedFiles to NoteList. The Changes view uses modifiedPathSet (derived from modifiedFiles) to filter entries, so it was always empty — showing 'no pending changes' even with modifications present.