### PR TITLE
fix: apply text-[12px] to URL values in Properties panel

### DIFF
--- a/src/components/EditableValue.tsx
+++ b/src/components/EditableValue.tsx
@@ -38,7 +38,7 @@ export function UrlValue({
   if (isEditing) {
     return (
       <input
-        className="w-full rounded border border-ring bg-muted px-2 py-1 text-[13px] text-foreground outline-none focus:border-primary"
+        className="w-full rounded border border-ring bg-muted px-2 py-1 text-[12px] text-foreground outline-none focus:border-primary"
         type="text"
         value={editValue}
         onChange={(e) => setEditValue(e.target.value)}
@@ -52,7 +52,7 @@ export function UrlValue({
   return (
     <span className="group/url inline-flex min-w-0 items-center gap-1">
       <span
-        className="min-w-0 cursor-pointer truncate rounded px-1 py-0.5 text-right text-secondary-foreground transition-colors hover:text-primary hover:underline"
+        className="min-w-0 cursor-pointer truncate rounded px-1 py-0.5 text-right text-[12px] text-secondary-foreground transition-colors hover:text-primary hover:underline"
         onClick={handleOpen}
         title={value}
         data-testid="url-link"


### PR DESCRIPTION
## Problem
URL property values had larger text than other property types in the Properties panel.

## Root cause
PR #43 (properties-text-size) applied `text-[12px]` to `EditableValue` but missed the `UrlValue` component in the same file.

## Fix
- Display span: added missing `text-[12px]` class
- Edit input: changed `text-[13px]` → `text-[12px]`

## Tests
658/658 passing ✅