### PR TITLE
fix: align Type row padding with other property rows in Properties panel

### DIFF
--- a/src/components/DynamicPropertiesPanel.tsx
+++ b/src/components/DynamicPropertiesPanel.tsx
@@ -150,7 +150,7 @@ const TYPE_NONE = '__none__'
 function ReadOnlyType({ isA, onNavigate }: { isA?: string | null; onNavigate?: (target: string) => void }) {
   if (!isA) return null
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex items-center justify-between px-1.5">
       <span className="font-mono-overline shrink-0 text-muted-foreground">Type</span>
       {onNavigate ? (
         <button
@@ -178,7 +178,7 @@ function TypeSelector({ isA, availableTypes, onUpdateProperty, onNavigate }: {
     : availableTypes
 
   return (
-    <div className="flex items-center justify-between" data-testid="type-selector">
+    <div className="flex items-center justify-between px-1.5" data-testid="type-selector">
       <span className="font-mono-overline shrink-0 text-muted-foreground">Type</span>
       <Select value={currentValue} onValueChange={v => onUpdateProperty('type', v === TYPE_NONE ? null : v)}>
         <SelectTrigger


### PR DESCRIPTION
## Problem
The 'Type' property row was flush-left while all other rows had a slight left indent, causing misalignment in the Properties panel.

## Root cause
`ReadOnlyType` and `TypeSelector` container divs were missing `px-1.5` padding that `PropertyRow` and `InfoRow` already had.

## Fix
Added `px-1.5` to the container `<div>` of both `ReadOnlyType` and `TypeSelector` in `DynamicPropertiesPanel.tsx`.

## Tests
658/658 passing ✅