### PR TITLE
ci: switch test job from macos-latest to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Tests & Quality Checks
-    runs-on: macos-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
CI test job was using `runs-on: macos-latest` (GitHub-hosted macOS runner at $0.08/min). With 65+ PRs in 2 days, this burned the monthly Actions budget.

## Fix
Changed `runs-on: macos-latest` → `runs-on: self-hosted` in `.github/workflows/ci.yml`.

The self-hosted Mac mini already has everything needed (same toolchain as the Release workflow). Setup actions kept for version pinning.

## Result
- CI runs on local Mac mini: free
- GitHub-hosted macOS minutes: 0