### PR TITLE
fix: backlinks update reactively when wiki-links are added or removed

### DIFF
--- a/src-tauri/src/vault/cache.rs
+++ b/src-tauri/src/vault/cache.rs
@@ -6,10 +6,19 @@ use super::{parse_md_file, scan_vault, VaultEntry};
 
 // --- Vault Cache ---
 
+/// Bump this when VaultEntry fields change to force a full rescan.
+const CACHE_VERSION: u32 = 2;
+
 #[derive(Debug, Serialize, Deserialize)]
 struct VaultCache {
+    #[serde(default = "default_cache_version")]
+    version: u32,
     commit_hash: String,
     entries: Vec<VaultEntry>,
+}
+
+fn default_cache_version() -> u32 {
+    1
 }
 
 fn cache_path(vault: &Path) -> std::path::PathBuf {
@@ -140,6 +149,7 @@ fn finalize_and_cache(vault: &Path, mut entries: Vec<VaultEntry>, hash: String) 
     write_cache(
         vault,
         &VaultCache {
+            version: CACHE_VERSION,
             commit_hash: hash,
             entries: entries.clone(),
         },
@@ -202,6 +212,10 @@ pub fn scan_vault_cached(vault_path: &Path) -> Result<Vec<VaultEntry>, String> {
     };
 
     if let Some(cache) = load_cache(vault_path) {
+        if cache.version != CACHE_VERSION {
+            let entries = scan_vault(vault_path)?;
+            return Ok(finalize_and_cache(vault_path, entries, current_hash));
+        }
         return if cache.commit_hash == current_hash {
             Ok(update_same_commit(vault_path, cache))
         } else {

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -12,7 +12,8 @@ pub use rename::{rename_note, RenameResult};
 pub use trash::purge_trash;
 
 use parsing::{
-    capitalize_first, contains_wikilink, extract_snippet, extract_title, parse_iso_date,
+    capitalize_first, contains_wikilink, extract_outgoing_links, extract_snippet, extract_title,
+    parse_iso_date,
 };
 
 use gray_matter::engine::YAML;
@@ -59,6 +60,10 @@ pub struct VaultEntry {
     pub color: Option<String>,
     /// Display order for Type entries in sidebar (lower = higher). None = use default order.
     pub order: Option<i64>,
+    /// All wikilink targets found in the note content (body + frontmatter).
+    /// Extracted from `[[target]]` and `[[target|display]]` patterns.
+    #[serde(rename = "outgoingLinks", default)]
+    pub outgoing_links: Vec<String>,
 }
 
 /// Intermediate struct to capture YAML frontmatter fields.
@@ -263,6 +268,7 @@ pub fn parse_md_file(path: &Path) -> Result<VaultEntry, String> {
 
     let title = extract_title(&parsed.content, &filename);
     let snippet = extract_snippet(&content);
+    let outgoing_links = extract_outgoing_links(&content);
     let (modified_at, file_size) = read_file_metadata(path)?;
     let created_at = parse_created_at(&frontmatter);
     let is_a = resolve_is_a(frontmatter.is_a, path);
@@ -312,6 +318,7 @@ pub fn parse_md_file(path: &Path) -> Result<VaultEntry, String> {
         icon: frontmatter.icon,
         color: frontmatter.color,
         order: frontmatter.order,
+        outgoing_links,
     })
 }
 
@@ -924,6 +931,37 @@ References:
         let content = "# Some Type\n";
         let entry = parse_test_entry(&dir, "type/some-type.md", content);
         assert_eq!(entry.is_a, Some("Type".to_string()));
+    }
+
+    // --- outgoing_links tests ---
+
+    #[test]
+    fn test_outgoing_links_extracted_from_content_body() {
+        let dir = TempDir::new().unwrap();
+        let content =
+            "---\nIs A: Note\n---\n# My Note\n\nSee [[person/alice]] and [[topic/rust]].";
+        let entry = parse_test_entry(&dir, "note/my-note.md", content);
+        assert_eq!(
+            entry.outgoing_links,
+            vec!["person/alice", "topic/rust"]
+        );
+    }
+
+    #[test]
+    fn test_outgoing_links_includes_frontmatter_wikilinks() {
+        let dir = TempDir::new().unwrap();
+        let content = "---\nHas:\n  - \"[[task/design]]\"\n---\n# Note\n\nSee [[person/bob]].";
+        let entry = parse_test_entry(&dir, "note/test.md", content);
+        assert!(entry.outgoing_links.contains(&"task/design".to_string()));
+        assert!(entry.outgoing_links.contains(&"person/bob".to_string()));
+    }
+
+    #[test]
+    fn test_outgoing_links_handles_pipe_syntax() {
+        let dir = TempDir::new().unwrap();
+        let content = "# Note\n\nSee [[project/alpha|Alpha Project]] for details.";
+        let entry = parse_test_entry(&dir, "test.md", content);
+        assert!(entry.outgoing_links.contains(&"project/alpha".to_string()));
     }
 
     // Frontmatter update/delete tests are in frontmatter.rs

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -938,13 +938,9 @@ References:
     #[test]
     fn test_outgoing_links_extracted_from_content_body() {
         let dir = TempDir::new().unwrap();
-        let content =
-            "---\nIs A: Note\n---\n# My Note\n\nSee [[person/alice]] and [[topic/rust]].";
+        let content = "---\nIs A: Note\n---\n# My Note\n\nSee [[person/alice]] and [[topic/rust]].";
         let entry = parse_test_entry(&dir, "note/my-note.md", content);
-        assert_eq!(
-            entry.outgoing_links,
-            vec!["person/alice", "topic/rust"]
-        );
+        assert_eq!(entry.outgoing_links, vec!["person/alice", "topic/rust"]);
     }
 
     #[test]

--- a/src-tauri/src/vault/parsing.rs
+++ b/src-tauri/src/vault/parsing.rs
@@ -124,6 +124,36 @@ pub(super) fn contains_wikilink(s: &str) -> bool {
     s.contains("[[") && s.contains("]]")
 }
 
+/// Extract all outgoing wikilink targets from content.
+/// Finds `[[target]]` and `[[target|display]]` patterns, returning just the target part.
+/// Returns a sorted, deduplicated Vec of targets.
+pub(super) fn extract_outgoing_links(content: &str) -> Vec<String> {
+    let mut links = Vec::new();
+    let mut search_from = 0;
+    let bytes = content.as_bytes();
+    while search_from + 3 < bytes.len() {
+        let Some(start) = content[search_from..].find("[[") else {
+            break;
+        };
+        let abs_start = search_from + start + 2;
+        let Some(end) = content[abs_start..].find("]]") else {
+            break;
+        };
+        let inner = &content[abs_start..abs_start + end];
+        let target = match inner.find('|') {
+            Some(idx) => &inner[..idx],
+            None => inner,
+        };
+        if !target.is_empty() {
+            links.push(target.to_string());
+        }
+        search_from = abs_start + end + 2;
+    }
+    links.sort();
+    links.dedup();
+    links
+}
+
 pub(super) fn capitalize_first(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
@@ -427,5 +457,56 @@ mod tests {
         assert!(parse_iso_date("not-a-date").is_none());
         assert!(parse_iso_date("").is_none());
         assert!(parse_iso_date("2025-13-45").is_none());
+    }
+
+    // --- extract_outgoing_links tests ---
+
+    #[test]
+    fn test_extract_outgoing_links_basic() {
+        let content = "# Note\n\nSee [[Alice]] and [[Bob]] for details.";
+        let links = extract_outgoing_links(content);
+        assert_eq!(links, vec!["Alice", "Bob"]);
+    }
+
+    #[test]
+    fn test_extract_outgoing_links_pipe_syntax() {
+        let content = "Link to [[project/alpha|Alpha Project]] here.";
+        let links = extract_outgoing_links(content);
+        assert_eq!(links, vec!["project/alpha"]);
+    }
+
+    #[test]
+    fn test_extract_outgoing_links_deduplicates() {
+        let content = "See [[Alice]] and then [[Alice]] again.";
+        let links = extract_outgoing_links(content);
+        assert_eq!(links, vec!["Alice"]);
+    }
+
+    #[test]
+    fn test_extract_outgoing_links_sorted() {
+        let content = "[[Zebra]] then [[Alpha]] then [[Middle]]";
+        let links = extract_outgoing_links(content);
+        assert_eq!(links, vec!["Alpha", "Middle", "Zebra"]);
+    }
+
+    #[test]
+    fn test_extract_outgoing_links_with_frontmatter() {
+        let content = "---\nHas:\n  - \"[[task/design]]\"\n---\n# Note\n\nSee [[person/alice]].";
+        let links = extract_outgoing_links(content);
+        assert_eq!(links, vec!["person/alice", "task/design"]);
+    }
+
+    #[test]
+    fn test_extract_outgoing_links_empty_content() {
+        assert!(extract_outgoing_links("").is_empty());
+        assert!(extract_outgoing_links("No links here").is_empty());
+    }
+
+    #[test]
+    fn test_extract_outgoing_links_unclosed_bracket() {
+        // First [[ matches with the only ]], yielding "unclosed and [[valid"
+        let content = "[[unclosed and [[valid]]";
+        let links = extract_outgoing_links(content);
+        assert_eq!(links, vec!["unclosed and [[valid"]);
     }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -34,6 +34,7 @@ const mockEntries = [
     modifiedAt: 1700000000,
     createdAt: null,
     fileSize: 1024,
+    outgoingLinks: [],
   },
   {
     path: '/vault/topic/dev.md',
@@ -49,6 +50,7 @@ const mockEntries = [
     modifiedAt: 1700000000,
     createdAt: null,
     fileSize: 256,
+    outgoingLinks: [],
   },
 ]
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { Editor } from './components/Editor'
@@ -26,6 +26,7 @@ import { useGitHistory } from './hooks/useGitHistory'
 import { useUpdater } from './hooks/useUpdater'
 import { UpdateBanner } from './components/UpdateBanner'
 import { setApiKey } from './utils/ai-chat'
+import { extractOutgoingLinks } from './utils/wikilinks'
 import type { SidebarSelection } from './types'
 import './App.css'
 
@@ -49,6 +50,34 @@ function useLayoutPanels() {
   return { sidebarWidth, noteListWidth, inspectorWidth, inspectorCollapsed, setInspectorCollapsed, handleSidebarResize, handleNoteListResize, handleInspectorResize }
 }
 
+/** Wraps useEditorSave to also keep outgoingLinks in sync on save and on content change. */
+function useEditorSaveWithLinks(config: {
+  updateContent: (path: string, content: string) => void
+  updateEntry: (path: string, patch: Partial<import('./types').VaultEntry>) => void
+  setTabs: Parameters<typeof useEditorSave>[0]['setTabs']
+  setToastMessage: (msg: string | null) => void
+  onAfterSave: () => void
+}) {
+  const { updateContent, updateEntry } = config
+  const saveContent = useCallback((path: string, content: string) => {
+    updateContent(path, content)
+    updateEntry(path, { outgoingLinks: extractOutgoingLinks(content) })
+  }, [updateContent, updateEntry])
+  const editor = useEditorSave({ updateVaultContent: saveContent, setTabs: config.setTabs, setToastMessage: config.setToastMessage, onAfterSave: config.onAfterSave })
+  const { handleContentChange: rawOnChange } = editor
+  const prevLinksKeyRef = useRef('')
+  const handleContentChange = useCallback((path: string, content: string) => {
+    rawOnChange(path, content)
+    const links = extractOutgoingLinks(content)
+    const key = links.join('\0')
+    if (key !== prevLinksKeyRef.current) {
+      prevLinksKeyRef.current = key
+      updateEntry(path, { outgoingLinks: links })
+    }
+  }, [rawOnChange, updateEntry])
+  return { ...editor, handleContentChange }
+}
+
 function App() {
   const [selection, setSelection] = useState<SidebarSelection>(DEFAULT_SELECTION)
   const layout = useLayoutPanels()
@@ -70,11 +99,9 @@ function App() {
 
   const notes = useNoteActions({ addEntry: vault.addEntry, removeEntry: vault.removeEntry, updateContent: vault.updateContent, entries: vault.entries, setToastMessage, updateEntry: vault.updateEntry })
 
-  const { handleSave, handleContentChange, savePendingForPath, savePending } = useEditorSave({
-    updateVaultContent: vault.updateContent,
-    setTabs: notes.setTabs,
-    setToastMessage,
-    onAfterSave: vault.loadModifiedFiles,
+  const { handleSave, handleContentChange, savePendingForPath, savePending } = useEditorSaveWithLinks({
+    updateContent: vault.updateContent, updateEntry: vault.updateEntry,
+    setTabs: notes.setTabs, setToastMessage, onAfterSave: vault.loadModifiedFiles,
   })
 
   const commitFlow = useCommitFlow({ savePending, loadModifiedFiles: vault.loadModifiedFiles, commitAndPush: vault.commitAndPush, setToastMessage })

--- a/src/components/DynamicPropertiesPanel.test.tsx
+++ b/src/components/DynamicPropertiesPanel.test.tsx
@@ -34,6 +34,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -74,6 +74,7 @@ const mockEntry: VaultEntry = {
   icon: null,
   color: null,
     order: null,
+  outgoingLinks: [],
 }
 
 const mockContent = `---

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -534,7 +534,6 @@ export const Editor = memo(function Editor({
         entry={inspectorEntry}
         content={inspectorContent}
         entries={entries}
-        allContent={allContent}
         gitHistory={gitHistory}
         onNavigate={onNavigateWikilink}
         onViewCommitDiff={handleViewCommitDiff}

--- a/src/components/Inspector.test.tsx
+++ b/src/components/Inspector.test.tsx
@@ -25,6 +25,7 @@ const mockEntry: VaultEntry = {
   icon: null,
   color: null,
     order: null,
+  outgoingLinks: [],
 }
 
 const mockContent = `---
@@ -66,12 +67,8 @@ const referrerEntry: VaultEntry = {
   relationships: {},
   icon: null,
   color: null,
-    order: null,
-}
-
-const allContent: Record<string, string> = {
-  '/vault/note/referrer.md': '# Referrer\n\nSee [[Test Project]] for details.',
-  '/vault/project/test.md': '# Test Project\n\nSome content.',
+  order: null,
+  outgoingLinks: ['Test Project'],
 }
 
 const now = Math.floor(Date.now() / 1000)
@@ -87,7 +84,6 @@ const defaultProps = {
   entry: null as VaultEntry | null,
   content: null as string | null,
   entries: [] as VaultEntry[],
-  allContent: {} as Record<string, string>,
   gitHistory: [] as GitCommit[],
   onNavigate: () => {},
 }
@@ -179,18 +175,41 @@ This is a test note with some words to count.
     expect(screen.getByText('No relationships')).toBeInTheDocument()
   })
 
-  it('shows backlinks from notes that reference the current note', () => {
+  it('shows backlinks from notes that reference the current note via outgoingLinks', () => {
     render(
       <Inspector
         {...defaultProps}
         entry={mockEntry}
         content={mockContent}
         entries={[mockEntry, referrerEntry]}
-        allContent={allContent}
       />
     )
     expect(screen.getByText('Referrer Note')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument() // count badge
+  })
+
+  it('updates backlinks reactively when outgoingLinks changes', () => {
+    const { rerender } = render(
+      <Inspector
+        {...defaultProps}
+        entry={mockEntry}
+        content={mockContent}
+        entries={[mockEntry, { ...referrerEntry, outgoingLinks: [] }]}
+      />
+    )
+    // Initially no backlinks because referrer has empty outgoingLinks
+    expect(screen.getByText('No backlinks')).toBeInTheDocument()
+
+    // Rerender with updated outgoingLinks (simulates adding [[Test Project]] to referrer)
+    rerender(
+      <Inspector
+        {...defaultProps}
+        entry={mockEntry}
+        content={mockContent}
+        entries={[mockEntry, { ...referrerEntry, outgoingLinks: ['Test Project'] }]}
+      />
+    )
+    expect(screen.getByText('Referrer Note')).toBeInTheDocument()
   })
 
   it('shows "No backlinks" when no notes reference the current note', () => {
@@ -200,7 +219,6 @@ This is a test note with some words to count.
         entry={mockEntry}
         content={mockContent}
         entries={[mockEntry]}
-        allContent={{}}
       />
     )
     expect(screen.getByText('No backlinks')).toBeInTheDocument()
@@ -214,7 +232,7 @@ This is a test note with some words to count.
         entry={mockEntry}
         content={mockContent}
         entries={[mockEntry, referrerEntry]}
-        allContent={allContent}
+
         onNavigate={onNavigate}
       />
     )
@@ -348,6 +366,7 @@ This is a test note with some words to count.
       icon: null,
       color: null,
       order: null,
+      outgoingLinks: [],
     }
 
     const essayEntry: VaultEntry = {
@@ -372,6 +391,7 @@ This is a test note with some words to count.
       icon: null,
       color: null,
       order: null,
+      outgoingLinks: [],
     }
 
     const procedureEntry: VaultEntry = {
@@ -396,6 +416,7 @@ This is a test note with some words to count.
       icon: null,
       color: null,
       order: null,
+      outgoingLinks: [],
     }
 
     const experimentEntry: VaultEntry = {
@@ -420,6 +441,7 @@ This is a test note with some words to count.
       icon: null,
       color: null,
       order: null,
+      outgoingLinks: [],
     }
 
     const targetContent = `---
@@ -438,7 +460,7 @@ Status: Active
           entry={targetEntry}
           content={targetContent}
           entries={[targetEntry, essayEntry, procedureEntry, experimentEntry]}
-          allContent={{}}
+
         />
       )
       expect(screen.getByText('On Writing Well')).toBeInTheDocument()
@@ -453,7 +475,7 @@ Status: Active
           entry={targetEntry}
           content={targetContent}
           entries={[targetEntry, essayEntry, experimentEntry]}
-          allContent={{}}
+
         />
       )
       expect(screen.getByText(/via Belongs to/)).toBeInTheDocument()
@@ -467,7 +489,7 @@ Status: Active
           entry={targetEntry}
           content={targetContent}
           entries={[targetEntry, essayEntry, procedureEntry]}
-          allContent={{}}
+
         />
       )
       // 2 entries reference via Belongs to — badge appears in the Referenced by header
@@ -484,7 +506,7 @@ Status: Active
           entry={targetEntry}
           content={targetContent}
           entries={[targetEntry]}
-          allContent={{}}
+
         />
       )
       expect(screen.getByText('No references')).toBeInTheDocument()
@@ -498,7 +520,7 @@ Status: Active
           entry={targetEntry}
           content={targetContent}
           entries={[targetEntry, essayEntry]}
-          allContent={{}}
+
           onNavigate={onNavigate}
         />
       )
@@ -522,7 +544,7 @@ Status: Active
           entry={typeEntry}
           content="---\nIs A: Type\n---\n# Responsibility\n"
           entries={[typeEntry, essayEntry]}
-          allContent={{}}
+
         />
       )
       // On Writing Well references responsibility via "Belongs to" (path match), not via "Type"
@@ -546,7 +568,7 @@ Status: Active
           entry={aliasedTarget}
           content={targetContent}
           entries={[aliasedTarget, referrer]}
-          allContent={{}}
+
         />
       )
       expect(screen.getByText('On Writing Well')).toBeInTheDocument()
@@ -567,7 +589,7 @@ Status: Active
           entry={selfRef}
           content={targetContent}
           entries={[selfRef]}
-          allContent={{}}
+
         />
       )
       expect(screen.getByText('No references')).toBeInTheDocument()

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -16,7 +16,6 @@ interface InspectorProps {
   entry: VaultEntry | null
   content: string | null
   entries: VaultEntry[]
-  allContent: Record<string, string>
   gitHistory: GitCommit[]
   onNavigate: (target: string) => void
   onViewCommitDiff?: (commitHash: string) => void
@@ -25,21 +24,22 @@ interface InspectorProps {
   onAddProperty?: (path: string, key: string, value: FrontmatterValue) => Promise<void>
 }
 
-function useBacklinks(entry: VaultEntry | null, entries: VaultEntry[], allContent: Record<string, string>): VaultEntry[] {
+function useBacklinks(entry: VaultEntry | null, entries: VaultEntry[]): VaultEntry[] {
   return useMemo(() => {
     if (!entry) return []
-    const targets = [entry.title, ...entry.aliases]
-    const stem = entry.filename.replace(/\.md$/, '')
-    const pathStem = entry.path.replace(/^.*\/Laputa\//, '').replace(/\.md$/, '')
+    const matchTargets = new Set([
+      entry.title, ...entry.aliases,
+      entry.filename.replace(/\.md$/, ''),
+      entry.path.replace(/^.*\/Laputa\//, '').replace(/\.md$/, ''),
+    ])
 
     return entries.filter((e) => {
       if (e.path === entry.path) return false
-      const c = allContent[e.path]
-      if (!c) return false
-      for (const t of targets) { if (c.includes(`[[${t}]]`)) return true }
-      return c.includes(`[[${stem}]]`) || c.includes(`[[${pathStem}]]`) || c.includes(`[[${pathStem}|`)
+      return e.outgoingLinks.some((target) =>
+        matchTargets.has(target) || matchTargets.has(target.split('/').pop() ?? '')
+      )
     })
-  }, [entry, entries, allContent])
+  }, [entry, entries])
 }
 
 function useReferencedBy(entry: VaultEntry | null, entries: VaultEntry[]): ReferencedByItem[] {
@@ -113,10 +113,10 @@ function EmptyInspector() {
 }
 
 export function Inspector({
-  collapsed, onToggle, entry, content, entries, allContent, gitHistory, onNavigate,
+  collapsed, onToggle, entry, content, entries, gitHistory, onNavigate,
   onViewCommitDiff, onUpdateFrontmatter, onDeleteProperty, onAddProperty,
 }: InspectorProps) {
-  const backlinks = useBacklinks(entry, entries, allContent)
+  const backlinks = useBacklinks(entry, entries)
   const referencedBy = useReferencedBy(entry, entries)
   const frontmatter = useMemo(() => parseFrontmatter(content), [content])
   const typeEntryMap = useMemo(() => {

--- a/src/components/InspectorPanels.test.tsx
+++ b/src/components/InspectorPanels.test.tsx
@@ -26,6 +26,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/components/NoteList.test.tsx
+++ b/src/components/NoteList.test.tsx
@@ -33,6 +33,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/note/facebook-ads-strategy.md',
@@ -59,6 +60,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/person/matteo-cellini.md',
@@ -82,6 +84,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/event/2026-02-14-kickoff.md',
@@ -105,6 +108,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/topic/software-development.md',
@@ -128,6 +132,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
 ]
 
@@ -343,6 +348,7 @@ describe('getSortComparator', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
     ...overrides,
   })
 
@@ -453,6 +459,7 @@ describe('NoteList sort controls', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
     ...overrides,
   })
 
@@ -645,6 +652,7 @@ const trashedEntry: VaultEntry = {
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
 }
 
 const expiredTrashedEntry: VaultEntry = {
@@ -669,6 +677,7 @@ const expiredTrashedEntry: VaultEntry = {
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
 }
 
 const entriesWithTrashed = [...mockEntries, trashedEntry, expiredTrashedEntry]
@@ -822,6 +831,7 @@ describe('NoteList — virtual list with large datasets', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
     ...overrides,
   })
 

--- a/src/components/QuickOpenPalette.test.tsx
+++ b/src/components/QuickOpenPalette.test.tsx
@@ -25,6 +25,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -38,6 +38,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/responsibility/grow-newsletter.md',
@@ -61,6 +62,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/experiment/stock-screener.md',
@@ -84,6 +86,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/procedure/weekly-essays.md',
@@ -107,6 +110,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/topic/software-development.md',
@@ -130,6 +134,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/topic/trading.md',
@@ -153,6 +158,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/person/alice.md',
@@ -176,6 +182,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/vault/event/kickoff.md',
@@ -199,6 +206,7 @@ const mockEntries: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
 ]
 
@@ -381,6 +389,7 @@ describe('Sidebar', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
       },
       {
         path: '/vault/type/book.md',
@@ -404,6 +413,7 @@ describe('Sidebar', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
       },
       {
         path: '/vault/recipe/pasta.md',
@@ -427,6 +437,7 @@ describe('Sidebar', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
       },
     ]
 
@@ -479,6 +490,7 @@ describe('Sidebar', () => {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
       }
       render(<Sidebar entries={[...mockEntries, projectTypeEntry]} selection={defaultSelection} onSelect={() => {}} />)
       // "Projects" should appear once (the built-in section), not twice
@@ -591,19 +603,19 @@ describe('Sidebar', () => {
         path: '/vault/type/project.md', filename: 'project.md', title: 'Project', isA: 'Type',
         aliases: [], belongsTo: [], relatedTo: [], status: null, owner: null, cadence: null,
         archived: false, trashed: false, trashedAt: null, modifiedAt: 1700000000, createdAt: null, fileSize: 200, snippet: '',
-        relationships: {}, icon: null, color: null, order: 5,
+        relationships: {}, icon: null, color: null, order: 5, outgoingLinks: [],
       },
       {
         path: '/vault/type/topic.md', filename: 'topic.md', title: 'Topic', isA: 'Type',
         aliases: [], belongsTo: [], relatedTo: [], status: null, owner: null, cadence: null,
         archived: false, trashed: false, trashedAt: null, modifiedAt: 1700000000, createdAt: null, fileSize: 200, snippet: '',
-        relationships: {}, icon: null, color: null, order: 0,
+        relationships: {}, icon: null, color: null, order: 0, outgoingLinks: [],
       },
       {
         path: '/vault/type/person.md', filename: 'person.md', title: 'Person', isA: 'Type',
         aliases: [], belongsTo: [], relatedTo: [], status: null, owner: null, cadence: null,
         archived: false, trashed: false, trashedAt: null, modifiedAt: 1700000000, createdAt: null, fileSize: 200, snippet: '',
-        relationships: {}, icon: null, color: null, order: 1,
+        relationships: {}, icon: null, color: null, order: 1, outgoingLinks: [],
       },
     ]
 

--- a/src/hooks/useCommandRegistry.test.ts
+++ b/src/hooks/useCommandRegistry.test.ts
@@ -25,6 +25,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/hooks/useEntryActions.test.ts
+++ b/src/hooks/useEntryActions.test.ts
@@ -25,6 +25,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/hooks/useKeyboardNavigation.test.ts
+++ b/src/hooks/useKeyboardNavigation.test.ts
@@ -29,6 +29,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/hooks/useNoteActions.test.ts
+++ b/src/hooks/useNoteActions.test.ts
@@ -51,6 +51,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/hooks/useNoteActions.ts
+++ b/src/hooks/useNoteActions.ts
@@ -63,7 +63,7 @@ export function buildNewEntry({ path, slug, title, type, status }: NewEntryParam
     aliases: [], belongsTo: [], relatedTo: [],
     status, owner: null, cadence: null, archived: false, trashed: false, trashedAt: null,
     modifiedAt: now, createdAt: now, fileSize: 0,
-    snippet: '', relationships: {}, icon: null, color: null, order: null,
+    snippet: '', relationships: {}, icon: null, color: null, order: null, outgoingLinks: [],
   }
 }
 

--- a/src/hooks/useTabManagement.test.ts
+++ b/src/hooks/useTabManagement.test.ts
@@ -31,6 +31,7 @@ const makeEntry = (overrides: Partial<VaultEntry> = {}): VaultEntry => ({
   icon: null,
   color: null,
   order: null,
+  outgoingLinks: [],
   ...overrides,
 })
 

--- a/src/hooks/useVaultLoader.test.ts
+++ b/src/hooks/useVaultLoader.test.ts
@@ -10,7 +10,7 @@ const mockEntries: VaultEntry[] = [
     status: 'Active', owner: null, cadence: null,
     archived: false, trashed: false, trashedAt: null,
     modifiedAt: 1700000000, createdAt: 1700000000, fileSize: 100,
-    snippet: '', relationships: {}, icon: null, color: null, order: null,
+    snippet: '', relationships: {}, icon: null, color: null, order: null, outgoingLinks: [],
   },
 ]
 

--- a/src/mock-tauri/mock-entries.ts
+++ b/src/mock-tauri/mock-entries.ts
@@ -34,6 +34,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/responsibility/grow-newsletter.md',
@@ -66,6 +67,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/responsibility/manage-sponsorships.md',
@@ -92,6 +94,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/procedure/write-weekly-essays.md',
@@ -118,6 +121,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/procedure/run-sponsorships.md',
@@ -144,6 +148,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/experiment/stock-screener.md',
@@ -171,6 +176,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/note/facebook-ads-strategy.md',
@@ -198,6 +204,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/note/budget-allocation.md',
@@ -224,6 +231,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/person/matteo-cellini.md',
@@ -249,6 +257,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/person/maria-bianchi.md',
@@ -350,6 +359,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/topic/software-development.md',
@@ -376,6 +386,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/topic/trading.md',
@@ -402,6 +413,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/essay/on-writing-well.md',
@@ -428,6 +440,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/essay/engineering-leadership-101.md',
@@ -455,6 +468,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/essay/ai-agents-primer.md',
@@ -481,6 +495,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   // --- Type documents ---
   {
@@ -505,6 +520,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 0,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/responsibility.md',
@@ -528,6 +544,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 1,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/procedure.md',
@@ -551,6 +568,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 2,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/experiment.md',
@@ -574,6 +592,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 3,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/person.md',
@@ -597,6 +616,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 4,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/event.md',
@@ -620,6 +640,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 5,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/topic.md',
@@ -643,6 +664,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 6,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/essay.md',
@@ -666,6 +688,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 7,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/note.md',
@@ -689,6 +712,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: 8,
+    outgoingLinks: [],
   },
   // --- Custom type documents ---
   {
@@ -713,6 +737,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: 'cooking-pot',
     color: 'orange',
     order: 9,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/type/book.md',
@@ -736,6 +761,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: 'book-open',
     color: 'green',
     order: 10,
+    outgoingLinks: [],
   },
   // --- Instances of custom types ---
   {
@@ -762,6 +788,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/book/designing-data-intensive-applications.md',
@@ -787,6 +814,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   // --- Trashed entries ---
   {
@@ -814,6 +842,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/note/deprecated-api-notes.md',
@@ -839,6 +868,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   {
     path: '/Users/luca/Laputa/experiment/failed-seo-experiment.md',
@@ -865,6 +895,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
   },
   // --- Archived entries ---
   {
@@ -884,6 +915,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
     modifiedAt: now - 86400 * 120,
     createdAt: now - 86400 * 200,
     fileSize: 680,
@@ -910,6 +942,7 @@ export const MOCK_ENTRIES: VaultEntry[] = [
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
     modifiedAt: now - 86400 * 90,
     createdAt: now - 86400 * 150,
     fileSize: 520,
@@ -968,6 +1001,7 @@ function generateBulkEntries(count: number): VaultEntry[] {
       icon: null,
       color: null,
       order: null,
+      outgoingLinks: [],
     })
   }
   return entries

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface VaultEntry {
   color: string | null
   /** Display order for Type entries in sidebar (lower = higher). null = use default order. */
   order: number | null
+  /** All wikilink targets found in the note content. Extracted from [[target]] patterns. */
+  outgoingLinks: string[]
 }
 
 export type NoteStatus = 'new' | 'modified' | 'clean'

--- a/src/utils/wikilinkColors.test.ts
+++ b/src/utils/wikilinkColors.test.ts
@@ -25,6 +25,7 @@ function makeEntry(overrides: Partial<VaultEntry>): VaultEntry {
     icon: null,
     color: null,
     order: null,
+    outgoingLinks: [],
     ...overrides,
   }
 }

--- a/src/utils/wikilinks.test.ts
+++ b/src/utils/wikilinks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { preProcessWikilinks, injectWikilinks, restoreWikilinksInBlocks, splitFrontmatter, countWords } from './wikilinks'
+import { preProcessWikilinks, injectWikilinks, restoreWikilinksInBlocks, splitFrontmatter, countWords, extractOutgoingLinks } from './wikilinks'
 
 interface TestBlock {
   type?: string
@@ -379,5 +379,45 @@ describe('restoreWikilinksInBlocks', () => {
     // Find the text that was the wikilink
     const texts = restored[0].content!.map(n => n.text).join('')
     expect(texts).toContain('[[Target]]')
+  })
+})
+
+describe('extractOutgoingLinks', () => {
+  it('extracts simple wikilink targets', () => {
+    const content = 'See [[My Note]] for details.'
+    expect(extractOutgoingLinks(content)).toEqual(['My Note'])
+  })
+
+  it('extracts alias wikilinks (target only)', () => {
+    const content = 'Link to [[project/my-project|My Project]] here.'
+    expect(extractOutgoingLinks(content)).toEqual(['project/my-project'])
+  })
+
+  it('extracts multiple wikilinks sorted and deduplicated', () => {
+    const content = 'See [[B]] and [[A]] and [[B]] again.'
+    expect(extractOutgoingLinks(content)).toEqual(['A', 'B'])
+  })
+
+  it('returns empty array for content with no wikilinks', () => {
+    expect(extractOutgoingLinks('No links here')).toEqual([])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(extractOutgoingLinks('')).toEqual([])
+  })
+
+  it('extracts wikilinks from frontmatter values', () => {
+    const content = '---\nbelongs_to:\n  - "[[quarter/q1-2026]]"\n---\n\n# Title\n'
+    expect(extractOutgoingLinks(content)).toEqual(['quarter/q1-2026'])
+  })
+
+  it('handles wikilinks in various positions', () => {
+    const content = '[[First]] middle [[Second]] end [[Third]]'
+    expect(extractOutgoingLinks(content)).toEqual(['First', 'Second', 'Third'])
+  })
+
+  it('ignores empty wikilinks', () => {
+    const content = 'Text [[]] and [[Valid]]'
+    expect(extractOutgoingLinks(content)).toEqual(['Valid'])
   })
 })

--- a/src/utils/wikilinks.ts
+++ b/src/utils/wikilinks.ts
@@ -104,6 +104,22 @@ export function splitFrontmatter(content: string): [string, string] {
   return [content.slice(0, to), content.slice(to)]
 }
 
+/** Extract all outgoing wikilink targets from content.
+ * Finds [[target]] and [[target|display]] patterns, returning just the target part.
+ * Returns a sorted, deduplicated array. */
+export function extractOutgoingLinks(content: string): string[] {
+  const links: string[] = []
+  const re = /\[\[([^\]]+)\]\]/g
+  let match
+  while ((match = re.exec(content)) !== null) {
+    const inner = match[1]
+    const pipeIdx = inner.indexOf('|')
+    const target = pipeIdx !== -1 ? inner.slice(0, pipeIdx) : inner
+    if (target) links.push(target)
+  }
+  return [...new Set(links)].sort()
+}
+
 export function countWords(content: string): number {
   const [, body] = splitFrontmatter(content)
   const withoutTitle = body.replace(/^\s*# [^\n]+\n?/, '')


### PR DESCRIPTION
Fixes backlinks not updating when wiki-links are added to a note. Root cause: useBacklinks scanned allContent (always empty in Tauri mode). Fixed by extracting outgoing_links in Rust and rewriting useBacklinks to use it.

All checks pass: 735 frontend tests, 238 Rust tests, coverage gates, code health.