### PR TITLE
fix: restore Cmd+1/2/3 layout shortcuts (regression from App.tsx refactor)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -117,6 +117,7 @@ describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    // Reset view mode between tests so sidebar starts visible
     localStorage.removeItem('laputa-view-mode')
   })
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -182,4 +182,55 @@ describe('App', () => {
     const appShell = document.querySelector('.app-shell')
     expect(appShell).toBeInTheDocument()
   })
+
+  it('Cmd+1 hides sidebar and note list (editor-only mode)', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(screen.getByText('All Notes')).toBeInTheDocument()
+    })
+
+    // All panels visible by default
+    expect(document.querySelector('.app__sidebar')).toBeInTheDocument()
+    expect(document.querySelector('.app__note-list')).toBeInTheDocument()
+
+    // Cmd+1 → editor-only
+    fireEvent.keyDown(window, { key: '1', metaKey: true })
+    await waitFor(() => {
+      expect(document.querySelector('.app__sidebar')).not.toBeInTheDocument()
+      expect(document.querySelector('.app__note-list')).not.toBeInTheDocument()
+    })
+  })
+
+  it('Cmd+2 shows editor + note list (sidebar hidden)', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(screen.getByText('All Notes')).toBeInTheDocument()
+    })
+
+    fireEvent.keyDown(window, { key: '2', metaKey: true })
+    await waitFor(() => {
+      expect(document.querySelector('.app__sidebar')).not.toBeInTheDocument()
+      expect(document.querySelector('.app__note-list')).toBeInTheDocument()
+    })
+  })
+
+  it('Cmd+3 restores all panels after Cmd+1', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(screen.getByText('All Notes')).toBeInTheDocument()
+    })
+
+    // Switch to editor-only first
+    fireEvent.keyDown(window, { key: '1', metaKey: true })
+    await waitFor(() => {
+      expect(document.querySelector('.app__sidebar')).not.toBeInTheDocument()
+    })
+
+    // Cmd+3 → all panels
+    fireEvent.keyDown(window, { key: '3', metaKey: true })
+    await waitFor(() => {
+      expect(document.querySelector('.app__sidebar')).toBeInTheDocument()
+      expect(document.querySelector('.app__note-list')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -116,6 +116,7 @@ import App from './App'
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+
     localStorage.removeItem('laputa-view-mode')
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,7 @@ function App() {
     await notes.handleRenameNote(path, newTitle, vaultSwitcher.vaultPath, vault.replaceEntry).then(vault.loadModifiedFiles)
   }, [notes, vaultSwitcher.vaultPath, vault, savePendingForPath])
 
-  const { setViewMode } = useViewMode()
+  const { setViewMode, sidebarVisible, noteListVisible } = useViewMode()
 
   const commands = useAppCommands({
     activeTabPath: notes.activeTabPath, activeTabPathRef: notes.activeTabPathRef,
@@ -125,14 +125,22 @@ function App() {
     <div className="app-shell">
       <UpdateBanner status={updateStatus} actions={updateActions} />
       <div className="app">
-        <div className="app__sidebar" style={{ width: layout.sidebarWidth }}>
-          <Sidebar entries={vault.entries} selection={selection} onSelect={setSelection} onSelectNote={notes.handleSelectNote} onCreateType={notes.handleCreateNoteImmediate} onCreateNewType={dialogs.openCreateType} onCustomizeType={entryActions.handleCustomizeType} onReorderSections={entryActions.handleReorderSections} modifiedCount={vault.modifiedFiles.length} onCommitPush={commitFlow.openCommitDialog} />
-        </div>
-        <ResizeHandle onResize={layout.handleSidebarResize} />
-        <div className="app__note-list" style={{ width: layout.noteListWidth }}>
-          <NoteList entries={vault.entries} selection={selection} selectedNote={activeTab?.entry ?? null} allContent={vault.allContent} modifiedFiles={vault.modifiedFiles} getNoteStatus={vault.getNoteStatus} onSelectNote={notes.handleSelectNote} onReplaceActiveTab={notes.handleReplaceActiveTab} onCreateNote={notes.handleCreateNoteImmediate} />
-        </div>
-        <ResizeHandle onResize={layout.handleNoteListResize} />
+        {sidebarVisible && (
+          <>
+            <div className="app__sidebar" style={{ width: layout.sidebarWidth }}>
+              <Sidebar entries={vault.entries} selection={selection} onSelect={setSelection} onSelectNote={notes.handleSelectNote} onCreateType={notes.handleCreateNoteImmediate} onCreateNewType={dialogs.openCreateType} onCustomizeType={entryActions.handleCustomizeType} onReorderSections={entryActions.handleReorderSections} modifiedCount={vault.modifiedFiles.length} onCommitPush={commitFlow.openCommitDialog} />
+            </div>
+            <ResizeHandle onResize={layout.handleSidebarResize} />
+          </>
+        )}
+        {noteListVisible && (
+          <>
+            <div className="app__note-list" style={{ width: layout.noteListWidth }}>
+              <NoteList entries={vault.entries} selection={selection} selectedNote={activeTab?.entry ?? null} allContent={vault.allContent} modifiedFiles={vault.modifiedFiles} getNoteStatus={vault.getNoteStatus} onSelectNote={notes.handleSelectNote} onReplaceActiveTab={notes.handleReplaceActiveTab} onCreateNote={notes.handleCreateNoteImmediate} />
+            </div>
+            <ResizeHandle onResize={layout.handleNoteListResize} />
+          </>
+        )}
         <div className="app__editor">
           <Editor
             tabs={notes.tabs}


### PR DESCRIPTION
## Problem
Cmd+1/2/3 stopped switching panel layouts after PR #62 (App.tsx hooks extraction).

## Root cause
`useViewMode()` hook correctly computed `sidebarVisible`/`noteListVisible` flags, but App.tsx only destructured `setViewMode` — the visibility flags were never passed to the render tree after the refactor.

## Fix
Extract visibility flags from the hook and conditionally render sidebar/note-list panels based on them.

Added 3 regression tests to prevent this from silently breaking again.

## Tests
742 tests pass, code health 9.3.