### PR TITLE
fix: remove double border-radius causing rounded corners below macOS title bar

### DIFF
--- a/design/window-frame-fix.pen
+++ b/design/window-frame-fix.pen
@@ -1,0 +1,1 @@
+{"children":[],"variables":{}}

--- a/src/App.css
+++ b/src/App.css
@@ -5,7 +5,6 @@
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-  border-radius: 10px;
   box-shadow: inset 0 0 0 1px var(--border-primary);
 }
 


### PR DESCRIPTION
## Problem
Visible rounded corners appeared below the macOS title bar (between window frame and app content).

## Root cause
With `titleBarStyle: 'Transparent'`, macOS natively clips window content to its own corner radius. The `.app-shell` CSS had `border-radius: 10px` which created a double-rounding artifact. The existing inset box-shadow already provides a clean 1px border — no CSS radius needed.

## Fix
Removed `border-radius: 10px` from `.app-shell` in `src/App.css`. Option 2 (custom title bar with traffic lights) evaluated and rejected — too complex, not worth it.

## Tests
739 frontend + 228 Rust tests pass, code health gates pass.