### PR TITLE
feat: back/forward navigation between opened notes

### DIFF
--- a/design/back-forward-nav.pen
+++ b/design/back-forward-nav.pen
@@ -1,0 +1,323 @@
+{
+  "children": [
+    {
+      "type": "frame",
+      "id": "nav-state-1",
+      "x": 0,
+      "y": 0,
+      "name": "State 1 — Default (both disabled)",
+      "width": 600,
+      "height": 80,
+      "fill": "#FFFFFF",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "text",
+          "id": "label1",
+          "content": "State 1: No history — both buttons disabled",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "400",
+          "fill": "#888888",
+          "padding": [4, 8]
+        },
+        {
+          "type": "frame",
+          "id": "tabbar1",
+          "name": "Tab Bar",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "#F8F8F8",
+          "stroke": {
+            "align": "inside",
+            "thickness": { "bottom": 1 },
+            "fill": "#E5E5E5"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "navbtns1",
+              "name": "Nav Buttons",
+              "gap": 4,
+              "padding": [0, 8],
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": { "right": 1, "bottom": 1 },
+                "fill": "#E5E5E5"
+              },
+              "height": "fill_container",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "back1",
+                  "name": "Back (disabled)",
+                  "width": 15,
+                  "height": 15,
+                  "iconFontName": "arrow-left",
+                  "iconFontFamily": "phosphor",
+                  "fill": "#C0C0C0",
+                  "opacity": 0.4
+                },
+                {
+                  "type": "icon_font",
+                  "id": "fwd1",
+                  "name": "Forward (disabled)",
+                  "width": 15,
+                  "height": 15,
+                  "iconFontName": "arrow-right",
+                  "iconFontFamily": "phosphor",
+                  "fill": "#C0C0C0",
+                  "opacity": 0.4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tab1a",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": { "align": "inside", "thickness": { "right": 1 }, "fill": "#E5E5E5" },
+              "gap": 6,
+              "padding": [0, 14],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tab1aTxt",
+                  "content": "Laputa App",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500",
+                  "fill": "#1A1A1A"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "nav-state-2",
+      "x": 0,
+      "y": 100,
+      "name": "State 2 — One note opened (back disabled)",
+      "width": 600,
+      "height": 80,
+      "fill": "#FFFFFF",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "text",
+          "id": "label2",
+          "content": "State 2: One note visited — back disabled, forward disabled",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "400",
+          "fill": "#888888",
+          "padding": [4, 8]
+        },
+        {
+          "type": "frame",
+          "id": "tabbar2",
+          "name": "Tab Bar",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "#F8F8F8",
+          "stroke": {
+            "align": "inside",
+            "thickness": { "bottom": 1 },
+            "fill": "#E5E5E5"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "navbtns2",
+              "name": "Nav Buttons",
+              "gap": 4,
+              "padding": [0, 8],
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": { "right": 1, "bottom": 1 },
+                "fill": "#E5E5E5"
+              },
+              "height": "fill_container",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "back2",
+                  "name": "Back (disabled)",
+                  "width": 15,
+                  "height": 15,
+                  "iconFontName": "arrow-left",
+                  "iconFontFamily": "phosphor",
+                  "fill": "#C0C0C0",
+                  "opacity": 0.4
+                },
+                {
+                  "type": "icon_font",
+                  "id": "fwd2",
+                  "name": "Forward (disabled)",
+                  "width": 15,
+                  "height": 15,
+                  "iconFontName": "arrow-right",
+                  "iconFontFamily": "phosphor",
+                  "fill": "#C0C0C0",
+                  "opacity": 0.4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tab2a",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": { "align": "inside", "thickness": { "right": 1 }, "fill": "#E5E5E5" },
+              "gap": 6,
+              "padding": [0, 14],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tab2aTxt",
+                  "content": "Project Alpha",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500",
+                  "fill": "#1A1A1A"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "nav-state-3",
+      "x": 0,
+      "y": 200,
+      "name": "State 3 — Two notes visited (back enabled)",
+      "width": 600,
+      "height": 80,
+      "fill": "#FFFFFF",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "text",
+          "id": "label3",
+          "content": "State 3: Two notes visited — back enabled, forward disabled",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "400",
+          "fill": "#888888",
+          "padding": [4, 8]
+        },
+        {
+          "type": "frame",
+          "id": "tabbar3",
+          "name": "Tab Bar",
+          "width": "fill_container",
+          "height": 45,
+          "fill": "#F8F8F8",
+          "stroke": {
+            "align": "inside",
+            "thickness": { "bottom": 1 },
+            "fill": "#E5E5E5"
+          },
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "navbtns3",
+              "name": "Nav Buttons",
+              "gap": 4,
+              "padding": [0, 8],
+              "alignItems": "center",
+              "stroke": {
+                "align": "inside",
+                "thickness": { "right": 1, "bottom": 1 },
+                "fill": "#E5E5E5"
+              },
+              "height": "fill_container",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "back3",
+                  "name": "Back (enabled)",
+                  "width": 15,
+                  "height": 15,
+                  "iconFontName": "arrow-left",
+                  "iconFontFamily": "phosphor",
+                  "fill": "#666666"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "fwd3",
+                  "name": "Forward (disabled)",
+                  "width": 15,
+                  "height": 15,
+                  "iconFontName": "arrow-right",
+                  "iconFontFamily": "phosphor",
+                  "fill": "#C0C0C0",
+                  "opacity": 0.4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tab3a",
+              "name": "Tab Active",
+              "height": "fill_container",
+              "fill": "#FFFFFF",
+              "stroke": { "align": "inside", "thickness": { "right": 1 }, "fill": "#E5E5E5" },
+              "gap": 6,
+              "padding": [0, 14],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tab3aTxt",
+                  "content": "Meeting Notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500",
+                  "fill": "#1A1A1A"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tab3b",
+              "name": "Tab Inactive",
+              "height": "fill_container",
+              "fill": "transparent",
+              "stroke": { "align": "inside", "thickness": { "right": 1, "bottom": 1 }, "fill": "#E5E5E5" },
+              "gap": 6,
+              "padding": [0, 14],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tab3bTxt",
+                  "content": "Project Alpha",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "400",
+                  "fill": "#888888"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {}
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useDialogs } from './hooks/useDialogs'
 import { useVaultSwitcher } from './hooks/useVaultSwitcher'
 import { useGitHistory } from './hooks/useGitHistory'
 import { useUpdater } from './hooks/useUpdater'
+import { useNavigationHistory } from './hooks/useNavigationHistory'
 import { UpdateBanner } from './components/UpdateBanner'
 import { setApiKey } from './utils/ai-chat'
 import { extractOutgoingLinks } from './utils/wikilinks'
@@ -99,6 +100,35 @@ function App() {
 
   const notes = useNoteActions({ addEntry: vault.addEntry, removeEntry: vault.removeEntry, updateContent: vault.updateContent, entries: vault.entries, setToastMessage, updateEntry: vault.updateEntry })
 
+  const navHistory = useNavigationHistory()
+
+  // Push to navigation history whenever the active tab changes (user-initiated)
+  const navFromHistoryRef = useRef(false)
+  useEffect(() => {
+    if (notes.activeTabPath && !navFromHistoryRef.current) {
+      navHistory.push(notes.activeTabPath)
+    }
+    navFromHistoryRef.current = false
+  }, [notes.activeTabPath]) // eslint-disable-line react-hooks/exhaustive-deps -- navHistory.push is stable
+
+  const isTabOpen = useCallback((path: string) => notes.tabs.some(t => t.entry.path === path), [notes.tabs])
+
+  const handleGoBack = useCallback(() => {
+    const target = navHistory.goBack(isTabOpen)
+    if (target) {
+      navFromHistoryRef.current = true
+      notes.handleSwitchTab(target)
+    }
+  }, [navHistory, isTabOpen, notes])
+
+  const handleGoForward = useCallback(() => {
+    const target = navHistory.goForward(isTabOpen)
+    if (target) {
+      navFromHistoryRef.current = true
+      notes.handleSwitchTab(target)
+    }
+  }, [navHistory, isTabOpen, notes])
+
   const { handleSave, handleContentChange, savePendingForPath, savePending } = useEditorSaveWithLinks({
     updateContent: vault.updateContent, updateEntry: vault.updateEntry,
     setTabs: notes.setTabs, setToastMessage, onAfterSave: vault.loadModifiedFiles,
@@ -142,6 +172,8 @@ function App() {
     onSelect: setSelection, onCloseTab: notes.handleCloseTab,
     onSwitchTab: notes.handleSwitchTab, onReplaceActiveTab: notes.handleReplaceActiveTab,
     onSelectNote: notes.handleSelectNote,
+    onGoBack: handleGoBack, onGoForward: handleGoForward,
+    canGoBack: navHistory.canGoBack, canGoForward: navHistory.canGoForward,
   })
 
   const { status: updateStatus, actions: updateActions } = useUpdater()
@@ -201,6 +233,10 @@ function App() {
             onUnarchiveNote={entryActions.handleUnarchiveNote}
             onRenameTab={handleRenameTab}
             onContentChange={handleContentChange}
+            canGoBack={navHistory.canGoBack}
+            canGoForward={navHistory.canGoForward}
+            onGoBack={handleGoBack}
+            onGoForward={handleGoForward}
           />
         </div>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,6 +129,46 @@ function App() {
     }
   }, [navHistory, isTabOpen, notes])
 
+  // Mouse button 3/4 (back/forward) and macOS trackpad two-finger swipe
+  useEffect(() => {
+    const handleMouseBack = (e: MouseEvent) => {
+      if (e.button === 3) { e.preventDefault(); handleGoBack() }
+      if (e.button === 4) { e.preventDefault(); handleGoForward() }
+    }
+    window.addEventListener('mouseup', handleMouseBack)
+
+    // Trackpad swipe: accumulate horizontal wheel delta and trigger on threshold
+    let accumulatedDeltaX = 0
+    let resetTimer: ReturnType<typeof setTimeout> | null = null
+    const SWIPE_THRESHOLD = 120
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only handle horizontal-dominant gestures (trackpad swipe)
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return
+      if (e.ctrlKey || e.metaKey) return // ignore pinch-zoom
+
+      accumulatedDeltaX += e.deltaX
+
+      if (resetTimer) clearTimeout(resetTimer)
+      resetTimer = setTimeout(() => { accumulatedDeltaX = 0 }, 300)
+
+      if (accumulatedDeltaX > SWIPE_THRESHOLD) {
+        accumulatedDeltaX = 0
+        handleGoForward()
+      } else if (accumulatedDeltaX < -SWIPE_THRESHOLD) {
+        accumulatedDeltaX = 0
+        handleGoBack()
+      }
+    }
+    window.addEventListener('wheel', handleWheel, { passive: true })
+
+    return () => {
+      window.removeEventListener('mouseup', handleMouseBack)
+      window.removeEventListener('wheel', handleWheel)
+      if (resetTimer) clearTimeout(resetTimer)
+    }
+  }, [handleGoBack, handleGoForward])
+
   const { handleSave, handleContentChange, savePendingForPath, savePending } = useEditorSaveWithLinks({
     updateContent: vault.updateContent, updateEntry: vault.updateEntry,
     setTabs: notes.setTabs, setToastMessage, onAfterSave: vault.loadModifiedFiles,

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -60,6 +60,10 @@ interface EditorProps {
   onUnarchiveNote?: (path: string) => void
   onRenameTab?: (path: string, newTitle: string) => void
   onContentChange?: (path: string, content: string) => void
+  canGoBack?: boolean
+  canGoForward?: boolean
+  onGoBack?: () => void
+  onGoForward?: () => void
 }
 
 // --- Custom Inline Content: WikiLink ---
@@ -235,6 +239,7 @@ export const Editor = memo(function Editor({
   onArchiveNote, onUnarchiveNote,
   onRenameTab,
   onContentChange,
+  canGoBack, canGoForward, onGoBack, onGoForward,
 }: EditorProps) {
   const [diffMode, setDiffMode] = useState(false)
   const [diffContent, setDiffContent] = useState<string | null>(null)
@@ -488,6 +493,10 @@ export const Editor = memo(function Editor({
       onCreateNote={onCreateNote}
       onReorderTabs={onReorderTabs}
       onRenameTab={onRenameTab}
+      canGoBack={canGoBack}
+      canGoForward={canGoForward}
+      onGoBack={onGoBack}
+      onGoForward={onGoForward}
     />
   )
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -2,7 +2,7 @@ import { memo, useState, useRef, useCallback, useEffect } from 'react'
 import type { VaultEntry, NoteStatus } from '../types'
 import { cn } from '@/lib/utils'
 import { X } from 'lucide-react'
-import { Plus, Columns, ArrowsOutSimple } from '@phosphor-icons/react'
+import { Plus, Columns, ArrowsOutSimple, ArrowLeft, ArrowRight } from '@phosphor-icons/react'
 
 interface Tab {
   entry: VaultEntry
@@ -18,6 +18,10 @@ interface TabBarProps {
   onCreateNote?: () => void
   onReorderTabs?: (fromIndex: number, toIndex: number) => void
   onRenameTab?: (path: string, newTitle: string) => void
+  canGoBack?: boolean
+  canGoForward?: boolean
+  onGoBack?: () => void
+  onGoForward?: () => void
 }
 
 const DISABLED_ICON_STYLE = { opacity: 0.4, cursor: 'not-allowed' } as const
@@ -250,6 +254,49 @@ function TabItem({ tab, isActive, isEditing, noteStatus, isDragging, showDropBef
   )
 }
 
+function NavButtons({ canGoBack, canGoForward, onGoBack, onGoForward }: {
+  canGoBack?: boolean; canGoForward?: boolean; onGoBack?: () => void; onGoForward?: () => void
+}) {
+  return (
+    <div
+      className="flex shrink-0 items-center"
+      style={{
+        gap: 4, padding: '0 8px',
+        borderRight: '1px solid var(--sidebar-border)',
+        borderBottom: '1px solid var(--sidebar-border)',
+        WebkitAppRegion: 'no-drag',
+      } as React.CSSProperties}
+    >
+      <button
+        className={cn(
+          "flex items-center justify-center border-none bg-transparent p-0.5 rounded-sm transition-colors",
+          canGoBack ? "text-muted-foreground cursor-pointer hover:text-foreground hover:bg-accent" : "text-muted-foreground"
+        )}
+        style={canGoBack ? undefined : DISABLED_ICON_STYLE}
+        disabled={!canGoBack}
+        onClick={onGoBack}
+        title="Back (⌘[)"
+        data-testid="nav-back"
+      >
+        <ArrowLeft size={15} />
+      </button>
+      <button
+        className={cn(
+          "flex items-center justify-center border-none bg-transparent p-0.5 rounded-sm transition-colors",
+          canGoForward ? "text-muted-foreground cursor-pointer hover:text-foreground hover:bg-accent" : "text-muted-foreground"
+        )}
+        style={canGoForward ? undefined : DISABLED_ICON_STYLE}
+        disabled={!canGoForward}
+        onClick={onGoForward}
+        title="Forward (⌘])"
+        data-testid="nav-forward"
+      >
+        <ArrowRight size={15} />
+      </button>
+    </div>
+  )
+}
+
 function TabBarActions({ onCreateNote }: { onCreateNote?: () => void }) {
   return (
     <div
@@ -276,6 +323,7 @@ function TabBarActions({ onCreateNote }: { onCreateNote?: () => void }) {
 
 export const TabBar = memo(function TabBar({
   tabs, activeTabPath, getNoteStatus, onSwitchTab, onCloseTab, onCreateNote, onReorderTabs, onRenameTab,
+  canGoBack, canGoForward, onGoBack, onGoForward,
 }: TabBarProps) {
   const { dragIndex, dropIndex, handleDragStart, handleDragEnd, handleDragOver, handleDrop, handleBarDragLeave } = useTabDrag(onReorderTabs)
   const [editingPath, setEditingPath] = useState<string | null>(null)
@@ -287,6 +335,7 @@ export const TabBar = memo(function TabBar({
       data-tauri-drag-region
       onDragLeave={handleBarDragLeave}
     >
+      <NavButtons canGoBack={canGoBack} canGoForward={canGoForward} onGoBack={onGoBack} onGoForward={onGoForward} />
       {tabs.map((tab, index) => (
         <TabItem
           key={tab.entry.path}

--- a/src/hooks/useAppCommands.ts
+++ b/src/hooks/useAppCommands.ts
@@ -33,6 +33,10 @@ interface AppCommandsConfig {
   onSwitchTab: (path: string) => void
   onReplaceActiveTab: (entry: VaultEntry) => void
   onSelectNote: (entry: VaultEntry) => void
+  onGoBack?: () => void
+  onGoForward?: () => void
+  canGoBack?: boolean
+  canGoForward?: boolean
 }
 
 /** Sets up keyboard shortcuts, command registry, and keyboard navigation. */
@@ -47,6 +51,8 @@ export function useAppCommands(config: AppCommandsConfig): CommandAction[] {
     onTrashNote: config.onTrashNote,
     onArchiveNote: config.onArchiveNote,
     onSetViewMode: config.onSetViewMode,
+    onGoBack: config.onGoBack,
+    onGoForward: config.onGoForward,
     activeTabPathRef: config.activeTabPathRef,
     handleCloseTabRef: config.handleCloseTabRef,
   })
@@ -67,6 +73,10 @@ export function useAppCommands(config: AppCommandsConfig): CommandAction[] {
     onToggleInspector: config.onToggleInspector,
     onSelect: config.onSelect,
     onCloseTab: config.onCloseTab,
+    onGoBack: config.onGoBack,
+    onGoForward: config.onGoForward,
+    canGoBack: config.canGoBack,
+    canGoForward: config.canGoForward,
   })
 
   useKeyboardNavigation({

--- a/src/hooks/useAppKeyboard.ts
+++ b/src/hooks/useAppKeyboard.ts
@@ -11,6 +11,8 @@ interface KeyboardActions {
   onTrashNote: (path: string) => void
   onArchiveNote: (path: string) => void
   onSetViewMode: (mode: ViewMode) => void
+  onGoBack?: () => void
+  onGoForward?: () => void
   activeTabPathRef: React.MutableRefObject<string | null>
   handleCloseTabRef: React.MutableRefObject<(path: string) => void>
 }
@@ -56,7 +58,7 @@ function handleCmdKey(e: KeyboardEvent, keyMap: Record<string, ShortcutHandler>)
 
 export function useAppKeyboard({
   onQuickOpen, onCommandPalette, onSearch, onCreateNote, onSave, onOpenSettings, onTrashNote, onArchiveNote,
-  onSetViewMode, activeTabPathRef, handleCloseTabRef,
+  onSetViewMode, onGoBack, onGoForward, activeTabPathRef, handleCloseTabRef,
 }: KeyboardActions) {
   useEffect(() => {
     const withActiveTab = (fn: (path: string) => void): ShortcutHandler => () => {
@@ -74,6 +76,8 @@ export function useAppKeyboard({
       w: withActiveTab((path) => handleCloseTabRef.current(path)),
       Backspace: withActiveTab(onTrashNote),
       Delete: withActiveTab(onTrashNote),
+      '[': () => onGoBack?.(),
+      ']': () => onGoForward?.(),
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -89,5 +93,5 @@ export function useAppKeyboard({
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [onQuickOpen, onCommandPalette, onSearch, onCreateNote, onSave, onOpenSettings, onTrashNote, onArchiveNote, activeTabPathRef, handleCloseTabRef, onSetViewMode])
+  }, [onQuickOpen, onCommandPalette, onSearch, onCreateNote, onSave, onOpenSettings, onTrashNote, onArchiveNote, activeTabPathRef, handleCloseTabRef, onSetViewMode, onGoBack, onGoForward])
 }

--- a/src/hooks/useCommandRegistry.ts
+++ b/src/hooks/useCommandRegistry.ts
@@ -31,6 +31,10 @@ interface CommandRegistryConfig {
   onToggleInspector: () => void
   onSelect: (sel: SidebarSelection) => void
   onCloseTab: (path: string) => void
+  onGoBack?: () => void
+  onGoForward?: () => void
+  canGoBack?: boolean
+  canGoForward?: boolean
 }
 
 const GROUP_ORDER: CommandGroup[] = ['Navigation', 'Note', 'Git', 'View', 'Settings']
@@ -45,6 +49,7 @@ export function useCommandRegistry(config: CommandRegistryConfig): CommandAction
     onQuickOpen, onCreateNote, onSave, onOpenSettings,
     onTrashNote, onArchiveNote, onUnarchiveNote,
     onCommitPush, onSetViewMode, onToggleInspector, onSelect, onCloseTab,
+    onGoBack, onGoForward, canGoBack, canGoForward,
   } = config
 
   const hasActiveNote = activeTabPath !== null
@@ -64,6 +69,8 @@ export function useCommandRegistry(config: CommandRegistryConfig): CommandAction
       { id: 'go-archived', label: 'Go to Archived', group: 'Navigation', keywords: [], enabled: true, execute: () => onSelect({ kind: 'filter', filter: 'archived' }) },
       { id: 'go-trash', label: 'Go to Trash', group: 'Navigation', keywords: ['deleted'], enabled: true, execute: () => onSelect({ kind: 'filter', filter: 'trash' }) },
       { id: 'go-changes', label: 'Go to Changes', group: 'Navigation', keywords: ['git', 'modified', 'pending'], enabled: true, execute: () => onSelect({ kind: 'filter', filter: 'changes' }) },
+      { id: 'go-back', label: 'Go Back', group: 'Navigation', shortcut: '⌘[', keywords: ['previous', 'history', 'back'], enabled: !!canGoBack, execute: () => onGoBack?.() },
+      { id: 'go-forward', label: 'Go Forward', group: 'Navigation', shortcut: '⌘]', keywords: ['next', 'history', 'forward'], enabled: !!canGoForward, execute: () => onGoForward?.() },
 
       // Note actions (contextual)
       { id: 'create-note', label: 'Create New Note', group: 'Note', shortcut: '⌘N', keywords: ['new', 'add'], enabled: true, execute: onCreateNote },
@@ -96,5 +103,6 @@ export function useCommandRegistry(config: CommandRegistryConfig): CommandAction
     onQuickOpen, onCreateNote, onSave, onOpenSettings,
     onTrashNote, onArchiveNote, onUnarchiveNote,
     onCommitPush, onSetViewMode, onToggleInspector, onSelect, onCloseTab,
+    onGoBack, onGoForward, canGoBack, canGoForward,
   ])
 }

--- a/src/hooks/useNavigationHistory.test.ts
+++ b/src/hooks/useNavigationHistory.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useNavigationHistory } from './useNavigationHistory'
+
+describe('useNavigationHistory', () => {
+  it('starts with empty state', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    expect(result.current.canGoBack).toBe(false)
+    expect(result.current.canGoForward).toBe(false)
+  })
+
+  it('push adds path to history', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => result.current.push('/a'))
+    expect(result.current.canGoBack).toBe(false)
+    expect(result.current.canGoForward).toBe(false)
+  })
+
+  it('back returns previous path after two pushes', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b') })
+    expect(result.current.canGoBack).toBe(true)
+
+    let target: string | null = null
+    act(() => { target = result.current.goBack() })
+    expect(target).toBe('/a')
+    expect(result.current.canGoBack).toBe(false)
+    expect(result.current.canGoForward).toBe(true)
+  })
+
+  it('forward returns next path after going back', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b') })
+    act(() => { result.current.goBack() })
+
+    let target: string | null = null
+    act(() => { target = result.current.goForward() })
+    expect(target).toBe('/b')
+    expect(result.current.canGoForward).toBe(false)
+  })
+
+  it('push after back clears forward stack', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b'); result.current.push('/c') })
+    act(() => { result.current.goBack() })
+    expect(result.current.canGoForward).toBe(true)
+
+    act(() => { result.current.push('/d') })
+    expect(result.current.canGoForward).toBe(false)
+
+    let target: string | null = null
+    act(() => { target = result.current.goBack() })
+    expect(target).toBe('/b')
+  })
+
+  it('duplicate push is a no-op', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/a') })
+    expect(result.current.canGoBack).toBe(false)
+  })
+
+  it('goBack skips invalid paths', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b'); result.current.push('/c') })
+
+    let target: string | null = null
+    act(() => { target = result.current.goBack((p) => p !== '/b') })
+    expect(target).toBe('/a')
+  })
+
+  it('goForward skips invalid paths', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b'); result.current.push('/c') })
+    act(() => { result.current.goBack(); result.current.goBack() })
+
+    let target: string | null = null
+    act(() => { target = result.current.goForward((p) => p !== '/b') })
+    expect(target).toBe('/c')
+  })
+
+  it('goBack returns null when nothing valid remains', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a') })
+
+    let target: string | null = 'should-be-null'
+    act(() => { target = result.current.goBack() })
+    expect(target).toBeNull()
+  })
+
+  it('goForward returns null at end of history', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a') })
+
+    let target: string | null = 'should-be-null'
+    act(() => { target = result.current.goForward() })
+    expect(target).toBeNull()
+  })
+
+  it('removePath adjusts cursor correctly', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b'); result.current.push('/c') })
+    act(() => { result.current.removePath('/b') })
+
+    let target: string | null = null
+    act(() => { target = result.current.goBack() })
+    expect(target).toBe('/a')
+  })
+
+  it('removePath when current note is removed', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => { result.current.push('/a'); result.current.push('/b') })
+    act(() => { result.current.removePath('/b') })
+    // After removing /b (cursor was at index 1), cursor should adjust
+    expect(result.current.canGoBack).toBe(false)
+    expect(result.current.canGoForward).toBe(false)
+  })
+
+  it('handles long navigation chain', () => {
+    const { result } = renderHook(() => useNavigationHistory())
+    act(() => {
+      for (let i = 0; i < 10; i++) result.current.push(`/${i}`)
+    })
+    expect(result.current.canGoBack).toBe(true)
+
+    // Go all the way back
+    for (let i = 8; i >= 0; i--) {
+      let target: string | null = null
+      act(() => { target = result.current.goBack() })
+      expect(target).toBe(`/${i}`)
+    }
+    expect(result.current.canGoBack).toBe(false)
+
+    // Go all the way forward
+    for (let i = 1; i <= 9; i++) {
+      let target: string | null = null
+      act(() => { target = result.current.goForward() })
+      expect(target).toBe(`/${i}`)
+    }
+    expect(result.current.canGoForward).toBe(false)
+  })
+})

--- a/src/hooks/useNavigationHistory.ts
+++ b/src/hooks/useNavigationHistory.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface HistoryState {
+  stack: string[]
+  cursor: number
+}
+
+const EMPTY: HistoryState = { stack: [], cursor: -1 }
+const MAX_HISTORY = 200
+
+/**
+ * Manages a browser-style back/forward navigation stack of note paths.
+ *
+ * - `push(path)` adds a path, clearing any forward history.
+ * - `goBack()` / `goForward()` return the target path (or null).
+ * - Deleted/invalid paths are skipped transparently.
+ */
+export function useNavigationHistory() {
+  const [state, setState] = useState<HistoryState>(EMPTY)
+  const stateRef = useRef(state)
+  useEffect(() => { stateRef.current = state })
+
+  const push = useCallback((path: string) => {
+    setState((prev) => {
+      if (prev.cursor >= 0 && prev.stack[prev.cursor] === path) return prev
+      const truncated = prev.stack.slice(0, prev.cursor + 1)
+      const stack = truncated.length >= MAX_HISTORY
+        ? [...truncated.slice(truncated.length - MAX_HISTORY + 1), path]
+        : [...truncated, path]
+      return { stack, cursor: stack.length - 1 }
+    })
+  }, [])
+
+  const canGoBack = state.cursor > 0
+  const canGoForward = state.cursor < state.stack.length - 1
+
+  const goBack = useCallback((isValid?: (path: string) => boolean): string | null => {
+    const { stack, cursor } = stateRef.current
+    for (let i = cursor - 1; i >= 0; i--) {
+      if (!isValid || isValid(stack[i])) {
+        setState({ stack, cursor: i })
+        return stack[i]
+      }
+    }
+    return null
+  }, [])
+
+  const goForward = useCallback((isValid?: (path: string) => boolean): string | null => {
+    const { stack, cursor } = stateRef.current
+    for (let i = cursor + 1; i < stack.length; i++) {
+      if (!isValid || isValid(stack[i])) {
+        setState({ stack, cursor: i })
+        return stack[i]
+      }
+    }
+    return null
+  }, [])
+
+  /** Remove a path from history (e.g. when a tab is closed). */
+  const removePath = useCallback((path: string) => {
+    setState((prev) => {
+      const idx = prev.stack.indexOf(path)
+      if (idx === -1) return prev
+      const stack = prev.stack.filter((p) => p !== path)
+      const cursor = prev.cursor > idx ? prev.cursor - 1
+        : prev.cursor === idx ? Math.min(prev.cursor, stack.length - 1)
+        : prev.cursor
+      return { stack, cursor: Math.max(cursor, stack.length > 0 ? 0 : -1) }
+    })
+  }, [])
+
+  return { canGoBack, canGoForward, push, goBack, goForward, removePath }
+}


### PR DESCRIPTION
Closes Todoist task 6g54fVrPc9rq6x9M. Implements browser-style back/forward navigation with useNavigationHistory hook, keyboard shortcuts (Cmd+[ / Cmd+]), and mouse button 3/4 support. Optimistic merge after Claude Code QA passed.