### PR TITLE
design: add full-layout context frames to ui-design.pen

### DIFF
--- a/design/design-full-layouts.pen
+++ b/design/design-full-layouts.pen
@@ -1,0 +1,13769 @@
+{
+  "children": [
+    {
+      "type": "frame",
+      "id": "X6DiX",
+      "x": 0,
+      "y": 0,
+      "name": "Full Layout — Editor Focused",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "QXp_S",
+          "name": "macOS Title Bar",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "a7ql_",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "PIagL",
+                  "name": "closeBtn",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "UkrIX",
+                  "name": "minimizeBtn",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "rpllF",
+                  "name": "maximizeBtn",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "YHu8M",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "AUMkh",
+              "name": "Panel: Sidebar",
+              "clip": true,
+              "width": 250,
+              "height": "fill_container",
+              "fill": "$--sidebar",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--sidebar-border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jIs8c",
+                  "name": "Filters",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "gap": 1,
+                  "padding": [
+                    8,
+                    8,
+                    16,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "uDixt",
+                      "name": "filterAll",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "0ZAuF",
+                          "name": "leftAll",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "CvmcV",
+                              "name": "iconAll",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tray-fill",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "_IXF5",
+                              "name": "fAllTxt",
+                              "fill": "$--foreground",
+                              "content": "Untagged",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cc5p7",
+                          "name": "countAll",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "wekdD",
+                              "name": "badgeAllTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UzJob",
+                      "name": "filterUntagged",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "UassE",
+                          "name": "leftUntagged",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "94gjp",
+                              "name": "untaggedIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Z4kx8",
+                              "name": "untaggedTxt",
+                              "fill": "$--primary",
+                              "content": "All Notes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "mxu-s",
+                          "name": "countUntagged",
+                          "height": 20,
+                          "fill": "$--primary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "766If",
+                              "name": "untaggedBadgeTxt",
+                              "fill": "$--primary-foreground",
+                              "content": "9247",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ],
+                      "fill": "#4a9eff18"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "j6x6d",
+                      "name": "filterTrash",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "2-DOi",
+                          "name": "leftTrash",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "otR4H",
+                              "name": "trashIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "trash",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "XnkPL",
+                              "name": "trashTxt",
+                              "fill": "$--foreground",
+                              "content": "Archive",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FVqx6",
+                          "name": "countTrash",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "3QQmO",
+                              "name": "trashBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IGH4B",
+                      "name": "filterChanges",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "RM0XF",
+                          "name": "leftChanges",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "i-4iz",
+                              "name": "iconChanges",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "git-branch",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Px5GR",
+                              "name": "fChangesTxt",
+                              "fill": "$--foreground",
+                              "content": "Changes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "wO3WO",
+                          "name": "countChanges",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "YJxJn",
+                              "name": "badgeChangesTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jXROv",
+                  "name": "Sections",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    8,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sO-XL",
+                      "name": "projGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6,
+                        8,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "8e7Vt",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "rcsfO",
+                              "name": "leftProj",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "gytXN",
+                                  "name": "projIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "wrench",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-red"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "-s_mS",
+                                  "name": "projLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Projects",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "CwD_O",
+                              "name": "projChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "52A6U",
+                          "name": "projItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "BgNaS",
+                              "name": "proj1Txt",
+                              "fill": "$--accent-red",
+                              "content": "Laputa App",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VdDh5",
+                          "name": "projItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "A0wXl",
+                              "name": "proj2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Portfolio Rewrite",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fZ-0x",
+                          "name": "projItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "TtXDd",
+                              "name": "proj3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "AI Habit Tracker",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GZd6p",
+                      "name": "respGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "E6xqR",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "fa0Nk",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "S8AHA",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "medal",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "xe_g8",
+                                  "name": "respLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Responsibilities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "XpuwI",
+                              "name": "respChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "shgFZ",
+                      "name": "procGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "8Ujcl",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "J4tD5",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "jdHxB",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Gt0UH",
+                                  "name": "Procedures",
+                                  "fill": "$--foreground",
+                                  "content": "Procedures",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "GFHmg",
+                              "name": "procChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hiql_",
+                      "name": "peopleGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hC4r1",
+                          "name": "peopleHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "TrVIO",
+                              "name": "leftPeople",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Dr2Jm",
+                                  "name": "peopleIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "users",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "lzFwD",
+                                  "name": "peopleLbl",
+                                  "fill": "$--foreground",
+                                  "content": "People",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "u7Y66",
+                              "name": "peopleChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "v05Mj",
+                      "name": "eventsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "KVmYN",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "P0NRp",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "NaHtD",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "YsEle",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Events",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "b0yk2",
+                              "name": "eventsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oMYo2",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "TUZI-",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "6uK9k",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "WJIXx",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "tag",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "3dn7l",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Topics",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "yPQuN",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N-qVJ",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dsXnU",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "aW1pQ",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SQjcs",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Vv4ha",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Notes",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "P1KUL",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MhWVM",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zgDZ5",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                0
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "sMBNg",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "gFAJs",
+                                  "name": "eventsLbl",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Create new type",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EyZli",
+                  "name": "Commit Area",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "1JRzZ",
+                      "name": "commitBtn",
+                      "width": "fill_container",
+                      "fill": "$--primary",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Ts-7a",
+                          "name": "commitIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "git-commit-horizontal",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary-foreground"
+                        },
+                        {
+                          "type": "text",
+                          "id": "pEh20",
+                          "name": "commitTxt",
+                          "fill": "$--primary-foreground",
+                          "content": "Commit & Push",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZC4Tp",
+                          "name": "commitBadge",
+                          "height": 18,
+                          "fill": "#ffffff40",
+                          "cornerRadius": 9,
+                          "padding": [
+                            0,
+                            5
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "dH3M0",
+                              "name": "commitBadgeTxt",
+                              "fill": "$--white",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "iayXd",
+              "name": "Resize Handle",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "KYP3S",
+              "name": "Panel: NoteList",
+              "clip": true,
+              "width": 300,
+              "height": "fill_container",
+              "fill": "$--card",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "udhLQ",
+                  "name": "NoteList Header",
+                  "width": "fill_container",
+                  "height": 45,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ajmdp",
+                      "name": "nlTitle",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "5SvsJ",
+                      "name": "nlActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "qFJVP",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "magnifying-glass",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "cgafy",
+                          "name": "plusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "koQ0J",
+                  "name": "Note Items",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "1H3yZ",
+                      "name": "Backlinks Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "3kSDX",
+                          "name": "Note Item Selected",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E9E9E7"
+                          },
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "id": "Ha8HS",
+                              "name": "leftAccent",
+                              "fill": "$--accent-red",
+                              "width": 3,
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "pvIeZ",
+                              "name": "noteSelContent",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "miGdK",
+                                  "name": "noteSelRow",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "XsFs9",
+                                      "name": "titleGroup",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "qGt0S",
+                                          "name": "noteSelTitle",
+                                          "fill": "$--foreground",
+                                          "content": "Laputa App",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "nbrro",
+                                          "name": "ico",
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "wrench",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "2ONoL",
+                                  "name": "noteSelSnip",
+                                  "fill": "$--foreground",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Personal knowledge and life management desktop app...",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "9An2M",
+                                  "name": "noteSelTime",
+                                  "fill": "$--accent-red",
+                                  "content": "2m ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kZZVQ",
+                      "name": "Related Notes Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "15OPP",
+                          "name": "Related Notes Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "VZfPV",
+                              "name": "rnLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "yt3sX",
+                                  "name": "rnLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "RELATED NOTES",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "rMUGk",
+                                  "name": "rnCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lxFxs",
+                              "name": "rnRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "T9Tni",
+                                  "name": "rnFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "7zq2S",
+                                  "name": "rnPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "k2dd-",
+                                  "name": "rnChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "64sl5",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Jgqoc",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "u-lDr",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Sx4pi",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Portfolio Rewrite",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "FKgVd",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Or7kg",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Redesigning portfolio site with modern stack and updated visual language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "icctC",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "lpkip",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "hV9DU",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "4MowJ",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "OqjO4",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Sample note 2",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "geEmd",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "ya9zF",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Lorem ipsum dolor sit amet consequetur with modern stack and updated language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "yfwf5",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "piEtY",
+                      "name": "Events Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fOL6M",
+                          "name": "Events Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "cx0o6",
+                              "name": "evLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "4073P",
+                                  "name": "evLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "EVENTS",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "up3pe",
+                                  "name": "evCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QCl7r",
+                              "name": "evRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "r-KNu",
+                                  "name": "evFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "4-yEN",
+                                  "name": "evPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "is8Ce",
+                                  "name": "evChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2Bw0D",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "bDrW1",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "dIBZK",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "YXOiG",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Grant",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "UHaDj",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "wHYGL",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "zyqm_",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "BVMQi",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Kj543",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "_csvb",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "fsnPK",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Matteo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "O3Je-",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "NGfVJ",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dw3Za",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "fKf2N",
+              "name": "Resize Handle 2",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "MLegO",
+              "name": "Panel: Editor",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$--background",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "2UACq",
+                  "name": "Tab Bar",
+                  "width": "fill_container",
+                  "height": 45,
+                  "fill": "$--sidebar",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--sidebar-border"
+                  },
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "RjysZ",
+                      "name": "Tab Active",
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZWVUX",
+                          "name": "tab1Txt",
+                          "fill": "$--foreground",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "5xN9D",
+                          "name": "tab1Close",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bqwJh",
+                      "name": "Tab Inactive",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1,
+                          "bottom": 1
+                        },
+                        "fill": "$--sidebar-border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jxV4d",
+                          "name": "tab2Txt",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "ZS9l6",
+                          "name": "tab2Close",
+                          "opacity": 0,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fqCqt",
+                      "name": "tabSpacer",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "$--border"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "KdlSR",
+                      "name": "tabControls",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1,
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_around",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "68hyI",
+                          "name": "iconPlus",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "-LdMX",
+                          "name": "iconSplit",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "columns",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "tyTM3",
+                          "name": "iconExpand",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrows-out-simple",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4w-0l",
+                  "name": "Editor Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "NuCqT",
+                      "name": "Editor Left",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "bkLPb",
+                          "name": "Info Bar",
+                          "width": "fill_container",
+                          "height": 45,
+                          "fill": "$--background",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "htutC",
+                              "name": "infoLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "K65hN",
+                                  "name": "breadcrumbType",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Project",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "3Xf0o",
+                                  "name": "breadcrumbSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "›",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "eNhLA",
+                                  "name": "breadcrumbName",
+                                  "fill": "$--foreground",
+                                  "content": "Laputa App",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "TLxAY",
+                                  "name": "dotSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "5hBHI",
+                                  "name": "modifiedTxt",
+                                  "fill": "$--accent-yellow",
+                                  "content": "M",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xfmHb",
+                              "name": "infoRight",
+                              "gap": 12,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "tzPx4",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "magnifying-glass",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "z9LJI",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "git-branch",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "19AWC",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cursor-text",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "8TamW",
+                                  "name": "iconAI",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sparkle",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "a6NOM",
+                                  "name": "iconMore",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "dots-three",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uoKNo",
+                          "name": "Editor Content",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": [
+                            32,
+                            64
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "bhmHx",
+                              "name": "editorP1",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Personal knowledge and life management desktop app, built with Tauri v2 + React + TypeScript + CodeMirror 6. It reads a vault of markdown files with YAML frontmatter and presents them in a four-panel UI inspired by Bear Notes.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "pmflZ",
+                              "name": "editorH2",
+                              "fill": "$--foreground",
+                              "content": "Architecture",
+                              "lineHeight": 1.3,
+                              "fontFamily": "Inter",
+                              "fontSize": 24,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "YPHOR",
+                              "name": "editorP2",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The app uses a four-panel layout: Sidebar for navigation, NoteList for browsing, Editor for content, and Inspector for metadata. All data lives in markdown files with YAML frontmatter, git-versioned.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8m_Ts",
+                      "name": "Inspector",
+                      "clip": true,
+                      "width": 260,
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "gr1Z5",
+                          "name": "Inspector Header",
+                          "width": "fill_container",
+                          "height": 45,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "608WF",
+                              "name": "leftGroup",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Bpugj",
+                                  "name": "propIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sliders-horizontal",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "hxMyO",
+                                  "name": "inspTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Properties",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "_i79H",
+                              "name": "sidebarIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "x",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VgKF5",
+                          "name": "Inspector Body",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "JeUUj",
+                              "name": "Properties Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "LEpT-",
+                                  "name": "addPropBtn",
+                                  "width": "fill_container",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$--border"
+                                  },
+                                  "padding": [
+                                    6,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "1nsVc",
+                                      "name": "addPropTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "+ Add property",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "AUN9O",
+                                  "name": "propType",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "EnTXQ",
+                                      "name": "propTypeLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TYPE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "vS0Af",
+                                      "name": "propTypeVal",
+                                      "fill": "$--foreground",
+                                      "content": "Project",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "s0Vdq",
+                                  "name": "propStatus",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "UUhF3",
+                                      "name": "propStatusLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "STATUS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "UMqtv",
+                                      "name": "propStatusBadge",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 16,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "transparent"
+                                      },
+                                      "gap": 8,
+                                      "padding": [
+                                        1,
+                                        6
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "P2h15",
+                                          "name": "Badge Text",
+                                          "fill": "$--accent-green",
+                                          "content": "ACTIVE",
+                                          "lineHeight": 1.33,
+                                          "textAlign": "center",
+                                          "textAlignVertical": "middle",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 1.2
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Ye0W8",
+                                  "name": "propOwner",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ZvN9n",
+                                      "name": "propOwnerLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "OWNER",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "p18lp",
+                                      "name": "propOwnerVal",
+                                      "fill": "$--foreground",
+                                      "content": "Luca",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "YgQHc",
+                              "name": "Relationships Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 16,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "MK0WC",
+                                  "name": "relGroup1",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "_rh_c",
+                                      "name": "relGrp1Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "BELONGS TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "wQayu",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "5BZc-",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Laputa",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "bj3hA",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "9NFxD",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "HoFKQ",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Building",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "U_GEF",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Hf4E8",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "yVLK0",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "EShyo",
+                                  "name": "relGroup2",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "CPHxH",
+                                      "name": "relGrp2Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "RELATED TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "F4ygG",
+                                      "name": "relMigrationBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-red-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "5xPef",
+                                          "name": "migrationTxt",
+                                          "fill": "$--accent-red",
+                                          "content": "Shadcn Migration",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "tLBGZ",
+                                          "name": "expIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "flask",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "3UaSi",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "suN12",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "zL5_Y",
+                              "name": "Backlinks Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "JbVdn",
+                                  "name": "blTitle",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ob0bb",
+                                      "name": "blTitleTxt",
+                                      "rotation": -0.5285936385085725,
+                                      "fill": "$--muted-foreground",
+                                      "content": "BACKLINKS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "3ZsuW",
+                                  "name": "blItem1",
+                                  "fill": "$--primary",
+                                  "content": "Portfolio Rewrite",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wkQVV",
+                                  "name": "blItem2",
+                                  "fill": "$--primary",
+                                  "content": "Meeting with Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6s0lo",
+                                  "name": "blItem3",
+                                  "fill": "$--primary",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "r7vXk",
+                              "name": "History Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "iw_bo",
+                                  "name": "histTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "HISTORY",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "xzvFM",
+                                  "name": "histItem1",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Ut4ez",
+                                      "name": "histItem1Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "a089f44 · feat: migrate to shadcn/ui",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "svS7D",
+                                      "name": "histItem1Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 16, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "rwIrR",
+                                  "name": "histItem2",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "l6CYP",
+                                      "name": "histItem2Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "5a4b4ac · feat: emoji favicon",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "httIc",
+                                      "name": "histItem2Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 15, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Lo-el",
+          "name": "lightStatusBar",
+          "width": "fill_container",
+          "height": 30,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            8
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "b51Tr",
+              "name": "Status Left",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "ojWSJ",
+                  "name": "versionIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "box",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "qB18p",
+                  "name": "versionText",
+                  "fill": "$--muted-foreground",
+                  "content": "v0.4.2",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "ykdyj",
+                  "name": "sep1",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "3B0P6",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "HpD4X",
+                  "name": "branchText",
+                  "fill": "$--muted-foreground",
+                  "content": "main",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "6RVGg",
+                  "name": "sep2",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "h9Ul_",
+                  "name": "syncIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-green"
+                },
+                {
+                  "type": "text",
+                  "id": "yer4n",
+                  "name": "syncText",
+                  "fill": "$--muted-foreground",
+                  "content": "Synced 2m ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ggt4q",
+              "name": "Status Right",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "YowOM",
+                  "name": "aiIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-purple"
+                },
+                {
+                  "type": "text",
+                  "id": "bVd9g",
+                  "name": "aiText",
+                  "fill": "$--muted-foreground",
+                  "content": "Claude Sonnet 4",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "8QSq1",
+                  "name": "sep3",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "z-rFh",
+                  "name": "notesCount",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "U_qqx",
+                  "name": "notesText",
+                  "fill": "$--muted-foreground",
+                  "content": "1,247 notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "MQE9Z",
+                  "name": "sep4",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "XB_ZN",
+                  "name": "bellIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "bell",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "gmulL",
+                  "name": "settingsIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "QR-Au",
+      "x": 0,
+      "y": 1050,
+      "name": "Full Layout — Search Panel Active",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "D2byp",
+          "name": "macOS Title Bar",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "EDFgx",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "DfcH7",
+                  "name": "closeBtn",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "k4jwL",
+                  "name": "minimizeBtn",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "4la7Z",
+                  "name": "maximizeBtn",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "md1g3",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "A_kBk",
+              "name": "Panel: Sidebar",
+              "clip": true,
+              "width": 250,
+              "height": "fill_container",
+              "fill": "$--sidebar",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--sidebar-border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GLS8B",
+                  "name": "Filters",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "gap": 1,
+                  "padding": [
+                    8,
+                    8,
+                    16,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "5KmsU",
+                      "name": "filterAll",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CO7qs",
+                          "name": "leftAll",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "UqiN-",
+                              "name": "iconAll",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tray-fill",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "GQxwa",
+                              "name": "fAllTxt",
+                              "fill": "$--foreground",
+                              "content": "Untagged",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OszI0",
+                          "name": "countAll",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "aws3Z",
+                              "name": "badgeAllTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dwASK",
+                      "name": "filterUntagged",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "RFfYP",
+                          "name": "leftUntagged",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "b4vff",
+                              "name": "untaggedIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "t3WAm",
+                              "name": "untaggedTxt",
+                              "fill": "$--primary",
+                              "content": "All Notes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fHpat",
+                          "name": "countUntagged",
+                          "height": 20,
+                          "fill": "$--primary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ZOPgU",
+                              "name": "untaggedBadgeTxt",
+                              "fill": "$--primary-foreground",
+                              "content": "9247",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ],
+                      "fill": "#4a9eff18"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xfTev",
+                      "name": "filterTrash",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Y4E4C",
+                          "name": "leftTrash",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "kK01T",
+                              "name": "trashIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "trash",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "-LXnc",
+                              "name": "trashTxt",
+                              "fill": "$--foreground",
+                              "content": "Archive",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nt-Xb",
+                          "name": "countTrash",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "rRo0q",
+                              "name": "trashBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F3pkw",
+                      "name": "filterChanges",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wcNVU",
+                          "name": "leftChanges",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "xhrmm",
+                              "name": "iconChanges",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "git-branch",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "prgnw",
+                              "name": "fChangesTxt",
+                              "fill": "$--foreground",
+                              "content": "Changes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "PugNW",
+                          "name": "countChanges",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "5bfMY",
+                              "name": "badgeChangesTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JUzOE",
+                  "name": "Sections",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    8,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OXkKG",
+                      "name": "projGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6,
+                        8,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "G9YEB",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "jL0bz",
+                              "name": "leftProj",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "1LJDb",
+                                  "name": "projIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "wrench",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-red"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fsRhn",
+                                  "name": "projLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Projects",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "EK_iu",
+                              "name": "projChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "_MfW7",
+                          "name": "projItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "buYPs",
+                              "name": "proj1Txt",
+                              "fill": "$--accent-red",
+                              "content": "Laputa App",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TsI_D",
+                          "name": "projItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "_h7S1",
+                              "name": "proj2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Portfolio Rewrite",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "bNfnr",
+                          "name": "projItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "9SY8F",
+                              "name": "proj3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "AI Habit Tracker",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CjIEL",
+                      "name": "respGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "U5NLf",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "5yyfh",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "hjjpp",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "medal",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "8paVp",
+                                  "name": "respLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Responsibilities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "YKDWL",
+                              "name": "respChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lmqzR",
+                      "name": "procGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "UOvjm",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "j6Mzi",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "hTccp",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "0o3Rd",
+                                  "name": "Procedures",
+                                  "fill": "$--foreground",
+                                  "content": "Procedures",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "CuU3s",
+                              "name": "procChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Lbn-0",
+                      "name": "peopleGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "k4VBq",
+                          "name": "peopleHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Ilgp-",
+                              "name": "leftPeople",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "AK0H9",
+                                  "name": "peopleIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "users",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "s9plC",
+                                  "name": "peopleLbl",
+                                  "fill": "$--foreground",
+                                  "content": "People",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "Ry1Km",
+                              "name": "peopleChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Xo_LE",
+                      "name": "eventsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "x-sYh",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "XG0mM",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "xinWJ",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "5YiYH",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Events",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "4kX5T",
+                              "name": "eventsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N2Kl0",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "OC_Wz",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "_COf_",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "5ddUS",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "tag",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "mYK3y",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Topics",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "CUHPs",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "c-AgB",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "updPo",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "kIAbE",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "JQy54",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Hh9wq",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Notes",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "27zSn",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FQdQQ",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "FWkK6",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                0
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "V0gxx",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "AM8SJ",
+                                  "name": "eventsLbl",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Create new type",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "a4iCv",
+                  "name": "Commit Area",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c6wjQ",
+                      "name": "commitBtn",
+                      "width": "fill_container",
+                      "fill": "$--primary",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "8YmeU",
+                          "name": "commitIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "git-commit-horizontal",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary-foreground"
+                        },
+                        {
+                          "type": "text",
+                          "id": "3miZQ",
+                          "name": "commitTxt",
+                          "fill": "$--primary-foreground",
+                          "content": "Commit & Push",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "YXy6F",
+                          "name": "commitBadge",
+                          "height": 18,
+                          "fill": "#ffffff40",
+                          "cornerRadius": 9,
+                          "padding": [
+                            0,
+                            5
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "9q2NX",
+                              "name": "commitBadgeTxt",
+                              "fill": "$--white",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "S5zsk",
+              "name": "Resize Handle",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "RL1ew",
+              "name": "Panel: NoteList",
+              "clip": true,
+              "width": 300,
+              "height": "fill_container",
+              "fill": "$--card",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AVROe",
+                  "name": "NoteList Header",
+                  "width": "fill_container",
+                  "height": 45,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "3Dlx5",
+                      "name": "nlTitle",
+                      "fill": "$--foreground",
+                      "content": "All Notes",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "B_hDb",
+                      "name": "nlActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "1o_2j",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "magnifying-glass",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "wI4DJ",
+                          "name": "plusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Rqh8Y",
+                  "name": "Note Items",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GsD3O",
+                      "name": "Backlinks Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "O3ith",
+                          "name": "Note Item Selected",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E9E9E7"
+                          },
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "id": "LmFnl",
+                              "name": "leftAccent",
+                              "fill": "$--accent-red",
+                              "width": 3,
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "6jJVC",
+                              "name": "noteSelContent",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "3eUuB",
+                                  "name": "noteSelRow",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "HwQTu",
+                                      "name": "titleGroup",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "oh0Nx",
+                                          "name": "noteSelTitle",
+                                          "fill": "$--foreground",
+                                          "content": "Laputa App",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "92t6N",
+                                          "name": "ico",
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "wrench",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "iapFF",
+                                  "name": "noteSelSnip",
+                                  "fill": "$--foreground",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Personal knowledge and life management desktop app...",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "dbFN3",
+                                  "name": "noteSelTime",
+                                  "fill": "$--accent-red",
+                                  "content": "2m ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "-5PW8",
+                      "name": "Related Notes Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IkgDl",
+                          "name": "Related Notes Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "el34m",
+                              "name": "rnLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ffLM0",
+                                  "name": "rnLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "RELATED NOTES",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "A7jbI",
+                                  "name": "rnCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "6Cw-D",
+                              "name": "rnRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "EkBrm",
+                                  "name": "rnFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "OiAPI",
+                                  "name": "rnPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "IFfVO",
+                                  "name": "rnChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XG9Tg",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ibW95",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "_MlWz",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "MZJ5r",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Portfolio Rewrite",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "_qdsw",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "2liVx",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Redesigning portfolio site with modern stack and updated visual language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "TCQuI",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "43UHB",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "DSC7W",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "fjSDQ",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "wTu8C",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Sample note 2",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "1QPiQ",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "leaf",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-green"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "43L7m",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Lorem ipsum dolor sit amet consequetur with modern stack and updated language...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "RcKQy",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GnvhS",
+                      "name": "Events Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "D_Dxu",
+                          "name": "Events Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "vDIey",
+                              "name": "evLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "q7YSK",
+                                  "name": "evLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "EVENTS",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "HrCep",
+                                  "name": "evCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "KC4JY",
+                              "name": "evRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "8Bqzc",
+                                  "name": "evFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "Ncjba",
+                                  "name": "evPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "wVeQy",
+                                  "name": "evChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LLaDT",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "dk5T8",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "yq1MX",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "azv9n",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Grant",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "bzPbO",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "W2zQX",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "yiflh",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qpVBh",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "H2GoU",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "jUxXL",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "zlSrF",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Matteo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "QFA7g",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "S7tfE",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "84akW",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "kqcSS",
+              "name": "Resize Handle 2",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "yI94h",
+              "name": "Panel: Editor",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$--background",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IbaLP",
+                  "name": "Tab Bar",
+                  "width": "fill_container",
+                  "height": 45,
+                  "fill": "$--sidebar",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--sidebar-border"
+                  },
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "WFTLH",
+                      "name": "Tab Active",
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "5qYgu",
+                          "name": "tab1Txt",
+                          "fill": "$--foreground",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "TG1oa",
+                          "name": "tab1Close",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s3CbP",
+                      "name": "Tab Inactive",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1,
+                          "bottom": 1
+                        },
+                        "fill": "$--sidebar-border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "LJqW3",
+                          "name": "tab2Txt",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "9u2Lp",
+                          "name": "tab2Close",
+                          "opacity": 0,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "beMtf",
+                      "name": "tabSpacer",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "$--border"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2jnhM",
+                      "name": "tabControls",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1,
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_around",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "DB5oM",
+                          "name": "iconPlus",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "aD6Zp",
+                          "name": "iconSplit",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "columns",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "jOY8N",
+                          "name": "iconExpand",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrows-out-simple",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RIloA",
+                  "name": "Editor Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xQh-S",
+                      "name": "Search Scrim",
+                      "x": 0,
+                      "y": 0,
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#00000008"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "O1H0q",
+                      "name": "Editor Left",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yVgkY",
+                          "name": "Info Bar",
+                          "width": "fill_container",
+                          "height": 45,
+                          "fill": "$--background",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "6R_ol",
+                              "name": "infoLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "hqrF6",
+                                  "name": "breadcrumbType",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Project",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wri-y",
+                                  "name": "breadcrumbSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "›",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "aJ9Ij",
+                                  "name": "breadcrumbName",
+                                  "fill": "$--foreground",
+                                  "content": "Laputa App",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "PXDzs",
+                                  "name": "dotSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Y7ORU",
+                                  "name": "modifiedTxt",
+                                  "fill": "$--accent-yellow",
+                                  "content": "M",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "3mw5a",
+                              "name": "infoRight",
+                              "gap": 12,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "TLrxL",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "magnifying-glass",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "3qqRK",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "git-branch",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "k_wJK",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cursor-text",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "l1J1b",
+                                  "name": "iconAI",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sparkle",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "OYxYL",
+                                  "name": "iconMore",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "dots-three",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "L5ga1",
+                          "name": "Editor Content",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": [
+                            32,
+                            64
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "31dfV",
+                              "name": "editorP1",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Personal knowledge and life management desktop app, built with Tauri v2 + React + TypeScript + CodeMirror 6. It reads a vault of markdown files with YAML frontmatter and presents them in a four-panel UI inspired by Bear Notes.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hT17f",
+                              "name": "editorH2",
+                              "fill": "$--foreground",
+                              "content": "Architecture",
+                              "lineHeight": 1.3,
+                              "fontFamily": "Inter",
+                              "fontSize": 24,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "rhk-8",
+                              "name": "editorP2",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The app uses a four-panel layout: Sidebar for navigation, NoteList for browsing, Editor for content, and Inspector for metadata. All data lives in markdown files with YAML frontmatter, git-versioned.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GmAF6",
+                      "name": "Inspector",
+                      "clip": true,
+                      "width": 260,
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "x_zWw",
+                          "name": "Inspector Header",
+                          "width": "fill_container",
+                          "height": 45,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "jusHS",
+                              "name": "leftGroup",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "jAvXS",
+                                  "name": "propIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sliders-horizontal",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "2DFD2",
+                                  "name": "inspTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Properties",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "h3_LP",
+                              "name": "sidebarIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "x",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fAW8G",
+                          "name": "Inspector Body",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "6kMFv",
+                              "name": "Properties Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "o0GPt",
+                                  "name": "addPropBtn",
+                                  "width": "fill_container",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$--border"
+                                  },
+                                  "padding": [
+                                    6,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "nFYSs",
+                                      "name": "addPropTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "+ Add property",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Lix0z",
+                                  "name": "propType",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ui6BQ",
+                                      "name": "propTypeLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TYPE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "xvb_A",
+                                      "name": "propTypeVal",
+                                      "fill": "$--foreground",
+                                      "content": "Project",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "EoxR3",
+                                  "name": "propStatus",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "mhPbZ",
+                                      "name": "propStatusLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "STATUS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "V8dLb",
+                                      "name": "propStatusBadge",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 16,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "transparent"
+                                      },
+                                      "gap": 8,
+                                      "padding": [
+                                        1,
+                                        6
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "HklId",
+                                          "name": "Badge Text",
+                                          "fill": "$--accent-green",
+                                          "content": "ACTIVE",
+                                          "lineHeight": 1.33,
+                                          "textAlign": "center",
+                                          "textAlignVertical": "middle",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 1.2
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xWWeV",
+                              "name": "Relationships Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 16,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "faCRJ",
+                                  "name": "relGroup1",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "e4hku",
+                                      "name": "relGrp1Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "BELONGS TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Ucmgk",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "HP94T",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Laputa",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "VCM1s",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "NKNrl",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "7Fgue",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Building",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "ot-0i",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "p85Ij",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "twL0t",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "L799V",
+                                  "name": "relGroup2",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "hT1h0",
+                                      "name": "relGrp2Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "RELATED TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "D_WgI",
+                                      "name": "relMigrationBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-red-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "ec81_",
+                                          "name": "migrationTxt",
+                                          "fill": "$--accent-red",
+                                          "content": "Shadcn Migration",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "S-vxq",
+                                          "name": "expIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "flask",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "qiAMM",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "ny0XL",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "EW804",
+                              "name": "Backlinks Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "iakOI",
+                                  "name": "blTitle",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "mIh0h",
+                                      "name": "blTitleTxt",
+                                      "rotation": -0.5285936385085725,
+                                      "fill": "$--muted-foreground",
+                                      "content": "BACKLINKS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qRWB3",
+                                  "name": "blItem1",
+                                  "fill": "$--primary",
+                                  "content": "Portfolio Rewrite",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "W5Kbo",
+                                  "name": "blItem2",
+                                  "fill": "$--primary",
+                                  "content": "Meeting with Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "74gGV",
+                                  "name": "blItem3",
+                                  "fill": "$--primary",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "MGyob",
+                              "name": "History Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "yQzzw",
+                                  "name": "histTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "HISTORY",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "D4Tgg",
+                                  "name": "histItem1",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "WGiuL",
+                                      "name": "histItem1Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "a089f44 · feat: migrate to shadcn/ui",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "it7Kq",
+                                      "name": "histItem1Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 16, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "q_JXB",
+                                  "name": "histItem2",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "FvrLg",
+                                      "name": "histItem2Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "5a4b4ac · feat: emoji favicon",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "kDCXM",
+                                      "name": "histItem2Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 15, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iCeGZ",
+                      "name": "Search Panel",
+                      "x": 80,
+                      "y": 60,
+                      "width": 480,
+                      "fill": "$--card",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$--border"
+                      },
+                      "shadow": [
+                        {
+                          "x": 0,
+                          "y": 8,
+                          "blur": 32,
+                          "spread": -4,
+                          "fill": "#00000020"
+                        }
+                      ],
+                      "layout": "vertical",
+                      "clip": true,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CF2zr",
+                          "name": "searchInputRow",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "O_fof",
+                              "name": "searchIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "magnifying-glass",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "iLTe7",
+                              "name": "searchQuery",
+                              "fill": "$--foreground",
+                              "content": "time management",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Ouy78",
+                              "name": "searchClearBtn",
+                              "width": 20,
+                              "height": 20,
+                              "fill": "$--muted",
+                              "cornerRadius": 10,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "mI1q5",
+                                  "name": "clearX",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "x",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fGvPp",
+                          "name": "resultsHeader",
+                          "width": "fill_container",
+                          "padding": [
+                            8,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "h0VR7",
+                              "name": "resultsCount",
+                              "fill": "$--muted-foreground",
+                              "content": "3 results",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "8NV5p",
+                          "name": "searchResult1",
+                          "width": "fill_container",
+                          "fill": "$--accent-blue-light",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            10,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "nGwMG",
+                              "name": "sr1Row",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "fselJ",
+                                  "name": "sr1Title",
+                                  "fill": "$--foreground",
+                                  "content": "Time Management Strategies",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "6BhB1",
+                                  "name": "sr1Icon",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--accent-green"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "mrzGz",
+                              "name": "sr1Snippet",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Effective time management requires clear priorities and consistent review cycles...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uGf_u",
+                          "name": "searchResult2",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            10,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "M3Z_b",
+                              "name": "sr2Row",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "_afkK",
+                                  "name": "sr2Title",
+                                  "fill": "$--foreground",
+                                  "content": "Weekly Review Process",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "f9OL0",
+                                  "name": "sr2Icon",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--accent-purple"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Rn89e",
+                              "name": "sr2Snippet",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Every Sunday: review tasks, update time blocks, plan the week ahead...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "D4qLW",
+                          "name": "searchResult3",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            10,
+                            16,
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "dXBPc",
+                              "name": "sr3Row",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "7eWQ_",
+                                  "name": "sr3Title",
+                                  "fill": "$--foreground",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "0KeJ1",
+                                  "name": "sr3Icon",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--accent-yellow"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "UcByL",
+                              "name": "sr3Snippet",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Allocated time management focus blocks in Q1 for deep work sessions...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "IMqpw",
+                          "name": "searchFooter",
+                          "width": "fill_container",
+                          "fill": "$--muted",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "top": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 16,
+                          "padding": [
+                            8,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "6gOIh",
+                              "name": "footerHint1",
+                              "fill": "$--muted-foreground",
+                              "content": "↑↓ Navigate",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "LHkSK",
+                              "name": "footerHint2",
+                              "fill": "$--muted-foreground",
+                              "content": "↵ Open",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qqfIt",
+                              "name": "footerHint3",
+                              "fill": "$--muted-foreground",
+                              "content": "Esc Close",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "L0KqX",
+          "name": "lightStatusBar",
+          "width": "fill_container",
+          "height": 30,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            8
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Np9m-",
+              "name": "Status Left",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "V3HFi",
+                  "name": "versionIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "box",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "YkNbh",
+                  "name": "versionText",
+                  "fill": "$--muted-foreground",
+                  "content": "v0.4.2",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "JH56P",
+                  "name": "sep1",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "qL-f2",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "yro7z",
+                  "name": "branchText",
+                  "fill": "$--muted-foreground",
+                  "content": "main",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "CXGWw",
+                  "name": "sep2",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "xOHNm",
+                  "name": "syncIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-green"
+                },
+                {
+                  "type": "text",
+                  "id": "j4lBc",
+                  "name": "syncText",
+                  "fill": "$--muted-foreground",
+                  "content": "Synced 2m ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ihq0v",
+              "name": "Status Right",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "kz722",
+                  "name": "aiIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-purple"
+                },
+                {
+                  "type": "text",
+                  "id": "qzFAM",
+                  "name": "aiText",
+                  "fill": "$--muted-foreground",
+                  "content": "Claude Sonnet 4",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "stI-S",
+                  "name": "sep3",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "DXxdw",
+                  "name": "notesCount",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "OehL-",
+                  "name": "notesText",
+                  "fill": "$--muted-foreground",
+                  "content": "1,247 notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "ZNpGu",
+                  "name": "sep4",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "g-Zfe",
+                  "name": "bellIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "bell",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "nUudo",
+                  "name": "settingsIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "6DhJh",
+      "x": 0,
+      "y": 2100,
+      "name": "Full Layout — Rich Properties + Autocomplete",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "U52CB",
+          "name": "macOS Title Bar",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "9xPhv",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "xK0i1",
+                  "name": "closeBtn",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "W-zEa",
+                  "name": "minimizeBtn",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "Lz9Ly",
+                  "name": "maximizeBtn",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "-eZ2Q",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "qWB0S",
+              "name": "Panel: Sidebar",
+              "clip": true,
+              "width": 250,
+              "height": "fill_container",
+              "fill": "$--sidebar",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--sidebar-border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "MJJ3h",
+                  "name": "Filters",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "gap": 1,
+                  "padding": [
+                    8,
+                    8,
+                    16,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Apugb",
+                      "name": "filterAll",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "MRMwA",
+                          "name": "leftAll",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "bF9xl",
+                              "name": "iconAll",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tray-fill",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vDABp",
+                              "name": "fAllTxt",
+                              "fill": "$--foreground",
+                              "content": "Untagged",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uMV2b",
+                          "name": "countAll",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "5CjlO",
+                              "name": "badgeAllTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nYVMy",
+                      "name": "filterUntagged",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "y2a7H",
+                          "name": "leftUntagged",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "GTbCN",
+                              "name": "untaggedIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "MyPei",
+                              "name": "untaggedTxt",
+                              "fill": "$--foreground",
+                              "content": "All Notes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Jq-_7",
+                          "name": "countUntagged",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "sq-ni",
+                              "name": "untaggedBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "6",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OwWRW",
+                      "name": "filterTrash",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "nEDEe",
+                          "name": "leftTrash",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "q71pa",
+                              "name": "trashIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "trash",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ycx_R",
+                              "name": "trashTxt",
+                              "fill": "$--foreground",
+                              "content": "Archive",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "q1o3f",
+                          "name": "countTrash",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "JDhNE",
+                              "name": "trashBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1cNey",
+                      "name": "filterChanges",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "3Zjt9",
+                          "name": "leftChanges",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "HwG_w",
+                              "name": "iconChanges",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "git-branch",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hsvfN",
+                              "name": "fChangesTxt",
+                              "fill": "$--foreground",
+                              "content": "Changes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "3iQa3",
+                          "name": "countChanges",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "IpnSM",
+                              "name": "badgeChangesTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4zVQn",
+                  "name": "Sections",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    8,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "2KL00",
+                      "name": "projGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6,
+                        8,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "60D7x",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Ns0Uw",
+                              "name": "leftProj",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "TlBFF",
+                                  "name": "projIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "wrench",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-red"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DU0f7",
+                                  "name": "projLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Projects",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "LhRc1",
+                              "name": "projChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XpysB",
+                          "name": "projItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "EHkKO",
+                              "name": "proj1Txt",
+                              "fill": "$--accent-red",
+                              "content": "Laputa App",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "PY1Qz",
+                          "name": "projItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lklgj",
+                              "name": "proj2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Portfolio Rewrite",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uDbn3",
+                          "name": "projItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "4p5Tw",
+                              "name": "proj3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "AI Habit Tracker",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lTCT0",
+                      "name": "respGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "lNMXl",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Sifl6",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Lzww_",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "medal",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "MDzfV",
+                                  "name": "respLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Responsibilities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "nIT14",
+                              "name": "respChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jxdL-",
+                      "name": "procGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "K6ZYE",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "0yx1-",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "q8gWU",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "UFUbg",
+                                  "name": "Procedures",
+                                  "fill": "$--foreground",
+                                  "content": "Procedures",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "znhle",
+                              "name": "procChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sVqwB",
+                      "name": "peopleGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "x5bql",
+                          "name": "peopleHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "rT7Sw",
+                              "name": "leftPeople",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "EdWKN",
+                                  "name": "peopleIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "users",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "IeV1X",
+                                  "name": "peopleLbl",
+                                  "fill": "$--foreground",
+                                  "content": "People",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "ijXZt",
+                              "name": "peopleChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jJrjZ",
+                          "name": "personItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-yellow-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "2qK41",
+                              "name": "person1Txt",
+                              "fill": "$--accent-yellow",
+                              "content": "Grant",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "RhLex",
+                          "name": "personItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "o6wg_",
+                              "name": "person2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Matteo",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "_tP3q",
+                          "name": "personItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tLGQc",
+                              "name": "person3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Sarah",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HNWez",
+                      "name": "eventsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "4TSY6",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "esbbT",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "6v9eG",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Gbmba",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Events",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "4HZQC",
+                              "name": "eventsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k8Qek",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ZJKIA",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "aOgWv",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "4uMpd",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "tag",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "55-Jj",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Topics",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "C5q2c",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Dl7QT",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zssYh",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "XuI_M",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "hKKJ2",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "HJ6Sg",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Notes",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "R9E3Y",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "KyUdZ",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "7E72I",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                0
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "akfbn",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "NUGRe",
+                                  "name": "eventsLbl",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Create new type",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "uAgKJ",
+                  "name": "Commit Area",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "0zA0z",
+                      "name": "commitBtn",
+                      "width": "fill_container",
+                      "fill": "$--primary",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "w07m8",
+                          "name": "commitIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "git-commit-horizontal",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary-foreground"
+                        },
+                        {
+                          "type": "text",
+                          "id": "4D-Y_",
+                          "name": "commitTxt",
+                          "fill": "$--primary-foreground",
+                          "content": "Commit & Push",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vWH8M",
+                          "name": "commitBadge",
+                          "height": 18,
+                          "fill": "#ffffff40",
+                          "cornerRadius": 9,
+                          "padding": [
+                            0,
+                            5
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "969L9",
+                              "name": "commitBadgeTxt",
+                              "fill": "$--white",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "UYNhO",
+              "name": "Resize Handle",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "m93C0",
+              "name": "Panel: NoteList",
+              "clip": true,
+              "width": 300,
+              "height": "fill_container",
+              "fill": "$--card",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "978jd",
+                  "name": "NoteList Header",
+                  "width": "fill_container",
+                  "height": 45,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hSxft",
+                      "name": "nlTitle",
+                      "fill": "$--foreground",
+                      "content": "People",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vOlfM",
+                      "name": "nlActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "8oc-r",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "magnifying-glass",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "oF9bA",
+                          "name": "plusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e99_i",
+                  "name": "Note Items",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "3lYpU",
+                      "name": "Backlinks Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "lmika",
+                          "name": "Note Item Selected",
+                          "width": "fill_container",
+                          "fill": "$--accent-yellow-light",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E9E9E7"
+                          },
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "id": "B3XPh",
+                              "name": "leftAccent",
+                              "fill": "$--accent-yellow",
+                              "width": 3,
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "_6k8_",
+                              "name": "noteSelContent",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "3aPer",
+                                  "name": "noteSelRow",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "CKtmP",
+                                      "name": "titleGroup",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "4sDfy",
+                                          "name": "noteSelTitle",
+                                          "fill": "$--foreground",
+                                          "content": "Grant",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "C_5rR",
+                                          "name": "ico",
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "users",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "$--accent-yellow"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "2j16A",
+                                  "name": "noteSelSnip",
+                                  "fill": "$--foreground",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Engineering lead at Acme Corp, focused on infrastructure and platform...",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "4aybL",
+                                  "name": "noteSelTime",
+                                  "fill": "$--accent-yellow",
+                                  "content": "3h ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "-2gWn",
+                      "name": "Related Notes Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ZDyjn",
+                          "name": "Related Notes Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "C3498",
+                              "name": "rnLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "L6f44",
+                                  "name": "rnLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "RELATED NOTES",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "SP2mP",
+                                  "name": "rnCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "VUxRC",
+                              "name": "rnRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "K0u69",
+                                  "name": "rnFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "5I6Q6",
+                                  "name": "rnPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "nWc9j",
+                                  "name": "rnChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "0g78J",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "UYt-3",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "UHgKQ",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "I3Kzu",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Matteo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "2SrYa",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "users",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "u9IDo",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Product manager working on growth initiatives and user research...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "bIgVf",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZCkrg",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "2HTTQ",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "lpW_m",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Yjt0e",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Sarah",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "n8Bdp",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "users",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "sBpy_",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Designer specializing in design systems and component libraries...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "SfEiI",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "1h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UjKyN",
+                      "name": "Events Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "1ieBk",
+                          "name": "Events Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "jL0Cn",
+                              "name": "evLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "WPdoU",
+                                  "name": "evLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "EVENTS",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "begIt",
+                                  "name": "evCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "unj5n",
+                              "name": "evRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "96nxy",
+                                  "name": "evFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "anHN8",
+                                  "name": "evPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "51Def",
+                                  "name": "evChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "1Y6r5",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "NtQjv",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "AGbrd",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "xla4h",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Grant",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "_FbgU",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "0VoCK",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "6Xbdy",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "KazQF",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "1_Cz1",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "s4GwN",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "U3H8E",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Meeting with Matteo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "gqOjx",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "calendar",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "-o6br",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Discussed Q1 goals and hiring priorities with the engineering team leads...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "N4dE4",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Yesterday",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "hli5_",
+              "name": "Resize Handle 2",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "OSNm1",
+              "name": "Panel: Editor",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$--background",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "0bMNp",
+                  "name": "Tab Bar",
+                  "width": "fill_container",
+                  "height": 45,
+                  "fill": "$--sidebar",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--sidebar-border"
+                  },
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MIU7l",
+                      "name": "Tab Active",
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "08oJY",
+                          "name": "tab1Txt",
+                          "fill": "$--foreground",
+                          "content": "Grant",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "Nb4TP",
+                          "name": "tab1Close",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "x41zt",
+                      "name": "Tab Inactive",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1,
+                          "bottom": 1
+                        },
+                        "fill": "$--sidebar-border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OeJUm",
+                          "name": "tab2Txt",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "j0rhL",
+                          "name": "tab2Close",
+                          "opacity": 0,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JSjRx",
+                      "name": "tabSpacer",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "$--border"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "K33DX",
+                      "name": "tabControls",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1,
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_around",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "cvEPw",
+                          "name": "iconPlus",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "l33JZ",
+                          "name": "iconSplit",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "columns",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "CnxJJ",
+                          "name": "iconExpand",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrows-out-simple",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "2tTb3",
+                  "name": "Editor Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VvcZt",
+                      "name": "Editor Left",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FS1KF",
+                          "name": "Info Bar",
+                          "width": "fill_container",
+                          "height": 45,
+                          "fill": "$--background",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "IRSz3",
+                              "name": "infoLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "CPWzB",
+                                  "name": "breadcrumbType",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Person",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "vGAbj",
+                                  "name": "breadcrumbSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "›",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "3UmsD",
+                                  "name": "breadcrumbName",
+                                  "fill": "$--foreground",
+                                  "content": "Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DN8so",
+                                  "name": "dotSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "kXgl0",
+                                  "name": "modifiedTxt",
+                                  "fill": "$--accent-yellow",
+                                  "content": "M",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "3wpHS",
+                              "name": "infoRight",
+                              "gap": 12,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "MDVCo",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "magnifying-glass",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "N_aAh",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "git-branch",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "3BBMe",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cursor-text",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "tKvI2",
+                                  "name": "iconAI",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sparkle",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "D88o2",
+                                  "name": "iconMore",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "dots-three",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vlazI",
+                          "name": "Editor Content",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": [
+                            32,
+                            64
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gabKY",
+                              "name": "editorP1",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Grant is an engineering lead at Acme Corp, focused on infrastructure, Kubernetes, and platform reliability. He drives the technical roadmap for backend systems and mentors junior engineers.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "rZOkl",
+                              "name": "editorH2",
+                              "fill": "$--foreground",
+                              "content": "Key Responsibilities",
+                              "lineHeight": 1.3,
+                              "fontFamily": "Inter",
+                              "fontSize": 24,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "VqiRL",
+                              "name": "editorP2",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Leads the infrastructure team. Oversees Kubernetes cluster management, CI/CD pipelines, and service mesh. Reports to CTO. Weekly 1:1 on Thursdays.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "B_y3t",
+                      "name": "Inspector",
+                      "clip": true,
+                      "width": 260,
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IY9fD",
+                          "name": "Inspector Header",
+                          "width": "fill_container",
+                          "height": 45,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "w2rRY",
+                              "name": "leftGroup",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "rCy6H",
+                                  "name": "propIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sliders-horizontal",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "74Es2",
+                                  "name": "inspTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Properties",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "pRO4e",
+                              "name": "sidebarIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "x",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iSZtX",
+                          "name": "Inspector Body",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "FGspn",
+                              "name": "Properties Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "9Cl0d",
+                                  "name": "addPropBtn",
+                                  "width": "fill_container",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$--border"
+                                  },
+                                  "padding": [
+                                    6,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "qqk-x",
+                                      "name": "addPropTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "+ Add property",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "10Rpz",
+                                  "name": "propType",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "BCqzK",
+                                      "name": "propTypeLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TYPE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "l7rGQ",
+                                      "name": "propTypeVal",
+                                      "fill": "$--foreground",
+                                      "content": "Person",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "X-DIV",
+                                  "name": "propCompany",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "_jYqg",
+                                      "name": "propCompanyLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "COMPANY",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "hBEEy",
+                                      "name": "propCompanyVal",
+                                      "fill": "$--foreground",
+                                      "content": "Acme Corp",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "DplyA",
+                                  "name": "propRole",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Artv7",
+                                      "name": "propRoleLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "ROLE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "ZtdR4",
+                                      "name": "propRoleVal",
+                                      "fill": "$--foreground",
+                                      "content": "Eng Lead",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "kr9yE",
+                                  "name": "propStatus",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "lCQ2c",
+                                      "name": "propStatusLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "STATUS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "UktKt",
+                                      "name": "propStatusBadge",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 16,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "transparent"
+                                      },
+                                      "gap": 8,
+                                      "padding": [
+                                        1,
+                                        6
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "PZMuf",
+                                          "name": "Badge Text",
+                                          "fill": "$--accent-green",
+                                          "content": "ACTIVE",
+                                          "lineHeight": 1.33,
+                                          "textAlign": "center",
+                                          "textAlignVertical": "middle",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 1.2
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "uq-Ch",
+                                  "name": "propTags",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "9-GAi",
+                                      "name": "propTagsLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TAGS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "um9TH",
+                                      "name": "tagsList",
+                                      "width": "fill_container",
+                                      "gap": 4,
+                                      "flexWrap": "wrap",
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "pAZPG",
+                                          "name": "tag1",
+                                          "fill": "$--accent-green-light",
+                                          "cornerRadius": 4,
+                                          "padding": [
+                                            2,
+                                            6
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "LxWxl",
+                                              "name": "tag1Txt",
+                                              "fill": "$--accent-green",
+                                              "content": "infrastructure",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 11,
+                                              "fontWeight": "500"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "uu7oj",
+                                          "name": "tag2",
+                                          "fill": "$--accent-blue-light",
+                                          "cornerRadius": 4,
+                                          "padding": [
+                                            2,
+                                            6
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "F3Ono",
+                                              "name": "tag2Txt",
+                                              "fill": "$--accent-blue",
+                                              "content": "kubernetes",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 11,
+                                              "fontWeight": "500"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "oII4d",
+                              "name": "Relationships Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 16,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "LxgzI",
+                                  "name": "relGroup1",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "M1hqt",
+                                      "name": "relGrp1Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "WORKS AT",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "1axQn",
+                                      "name": "relAcmeBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-red-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "VKyg3",
+                                          "name": "acmeTxt",
+                                          "fill": "$--accent-red",
+                                          "content": "Acme Corp",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "GG63z",
+                                          "name": "companyIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "wrench",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "kpHDy",
+                                      "name": "linkExistingActive",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--primary"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Q7UgS",
+                                          "name": "linkTxt",
+                                          "fill": "$--foreground",
+                                          "content": "Infra",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "RBm2-",
+                                          "name": "searchIco",
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "magnifying-glass",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--muted-foreground"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "X_w5s",
+                                      "name": "autocompleteDropdown",
+                                      "width": "fill_container",
+                                      "fill": "$--card",
+                                      "cornerRadius": 8,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "shadow": [
+                                        {
+                                          "x": 0,
+                                          "y": 4,
+                                          "blur": 16,
+                                          "spread": -2,
+                                          "fill": "#00000015"
+                                        }
+                                      ],
+                                      "layout": "vertical",
+                                      "clip": true,
+                                      "children": [
+                                        {
+                                          "type": "frame",
+                                          "id": "3Pxkn",
+                                          "name": "acItem1",
+                                          "width": "fill_container",
+                                          "fill": "$--accent-blue-light",
+                                          "gap": 8,
+                                          "padding": [
+                                            8,
+                                            10
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "BgVut",
+                                              "name": "acIcon1",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "medal",
+                                              "iconFontFamily": "phosphor",
+                                              "fill": "$--accent-purple"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "RPfuk",
+                                              "name": "acTxt1",
+                                              "fill": "$--foreground",
+                                              "content": "Infrastructure Team",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "500"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "sxoEV",
+                                          "name": "acItem2",
+                                          "width": "fill_container",
+                                          "gap": 8,
+                                          "padding": [
+                                            8,
+                                            10
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "7ikv0",
+                                              "name": "acIcon2",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "tag",
+                                              "iconFontFamily": "phosphor",
+                                              "fill": "$--accent-green"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "gVVyY",
+                                              "name": "acTxt2",
+                                              "fill": "$--foreground",
+                                              "content": "Infrastructure",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "r85eA",
+                                          "name": "acItem3",
+                                          "width": "fill_container",
+                                          "gap": 8,
+                                          "padding": [
+                                            8,
+                                            10
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "icon_font",
+                                              "id": "_BaES",
+                                              "name": "acIcon3",
+                                              "width": 14,
+                                              "height": 14,
+                                              "iconFontName": "wrench",
+                                              "iconFontFamily": "phosphor",
+                                              "fill": "$--accent-red"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "x-wlM",
+                                              "name": "acTxt3",
+                                              "fill": "$--foreground",
+                                              "content": "Infra Migration",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "N5Sll",
+                              "name": "Backlinks Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "imLWJ",
+                                  "name": "blTitle",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Y-UG1",
+                                      "name": "blTitleTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "BACKLINKS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6K6Bd",
+                                  "name": "blItem1",
+                                  "fill": "$--primary",
+                                  "content": "Meeting with Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6EGhq",
+                                  "name": "blItem2",
+                                  "fill": "$--primary",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "FCfBL",
+                                  "name": "blItem3",
+                                  "fill": "$--primary",
+                                  "content": "Hiring Pipeline",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WAxYr",
+          "name": "lightStatusBar",
+          "width": "fill_container",
+          "height": 30,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            8
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "q_a9K",
+              "name": "Status Left",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Mlziz",
+                  "name": "versionIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "box",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "gzUtx",
+                  "name": "versionText",
+                  "fill": "$--muted-foreground",
+                  "content": "v0.4.2",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "3x0kF",
+                  "name": "sep1",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "hY-Is",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "k9Hay",
+                  "name": "branchText",
+                  "fill": "$--muted-foreground",
+                  "content": "main",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "WKBM-",
+                  "name": "sep2",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "lhY_1",
+                  "name": "syncIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-green"
+                },
+                {
+                  "type": "text",
+                  "id": "uELg8",
+                  "name": "syncText",
+                  "fill": "$--muted-foreground",
+                  "content": "Synced 2m ago",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "c38hL",
+              "name": "Status Right",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "leRDx",
+                  "name": "aiIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-purple"
+                },
+                {
+                  "type": "text",
+                  "id": "W6In1",
+                  "name": "aiText",
+                  "fill": "$--muted-foreground",
+                  "content": "Claude Sonnet 4",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "rxqIt",
+                  "name": "sep3",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "B0jTr",
+                  "name": "notesCount",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "01ygw",
+                  "name": "notesText",
+                  "fill": "$--muted-foreground",
+                  "content": "1,247 notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "BeA6T",
+                  "name": "sep4",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "yNSZ0",
+                  "name": "bellIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "bell",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "RbzrU",
+                  "name": "settingsIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "cDqLP",
+      "x": 0,
+      "y": 3150,
+      "name": "Full Layout — Changes View",
+      "theme": {
+        "Mode": "Light"
+      },
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "2HK9s",
+          "name": "macOS Title Bar",
+          "width": "fill_container",
+          "height": 38,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "AiPEP",
+              "name": "trafficLights",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "X3X_h",
+                  "name": "closeBtn",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "P1J0D",
+                  "name": "minimizeBtn",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "3zuNz",
+                  "name": "maximizeBtn",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "-ekXq",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "M2KC-",
+              "name": "Panel: Sidebar",
+              "clip": true,
+              "width": 250,
+              "height": "fill_container",
+              "fill": "$--sidebar",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--sidebar-border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZulZE",
+                  "name": "Filters",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "gap": 1,
+                  "padding": [
+                    8,
+                    8,
+                    16,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "IS4Fm",
+                      "name": "filterAll",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vPb76",
+                          "name": "leftAll",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "yuOG7",
+                              "name": "iconAll",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "tray-fill",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "XsyTZ",
+                              "name": "fAllTxt",
+                              "fill": "$--foreground",
+                              "content": "Untagged",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XP413",
+                          "name": "countAll",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jwZW-",
+                              "name": "badgeAllTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nJQFj",
+                      "name": "filterUntagged",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "rYzZ5",
+                          "name": "leftUntagged",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "rOyw2",
+                              "name": "untaggedIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "cardholder",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "y-u3E",
+                              "name": "untaggedTxt",
+                              "fill": "$--foreground",
+                              "content": "All Notes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "kQQSy",
+                          "name": "countUntagged",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "-He5A",
+                              "name": "untaggedBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "6",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z-rwa",
+                      "name": "filterTrash",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "EZw96",
+                          "name": "leftTrash",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "yFQYH",
+                              "name": "trashIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "trash",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--foreground"
+                            },
+                            {
+                              "type": "text",
+                              "id": "zgVFp",
+                              "name": "trashTxt",
+                              "fill": "$--foreground",
+                              "content": "Archive",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2ZVsp",
+                          "name": "countTrash",
+                          "height": 20,
+                          "fill": "$--secondary",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "6KjzA",
+                              "name": "trashBadgeTxt",
+                              "fill": "$--muted-foreground",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Jz98b",
+                      "name": "filterChanges",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hCAhH",
+                          "name": "leftChanges",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "zut43",
+                              "name": "iconChanges",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "git-branch",
+                              "iconFontFamily": "phosphor",
+                              "weight": 700,
+                              "fill": "$--accent-orange"
+                            },
+                            {
+                              "type": "text",
+                              "id": "eNZE_",
+                              "name": "fChangesTxt",
+                              "fill": "$--accent-orange",
+                              "content": "Changes",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Vd1IP",
+                          "name": "countChanges",
+                          "height": 20,
+                          "fill": "$--accent-orange",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            0,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "WQevI",
+                              "name": "badgeChangesTxt",
+                              "fill": "$--primary-foreground",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ],
+                      "fill": "#D9730D18"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iZGMX",
+                  "name": "Sections",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    8,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "K9kps",
+                      "name": "projGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6,
+                        8,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "NqU-g",
+                          "name": "projHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "l4Db7",
+                              "name": "leftProj",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "UH57P",
+                                  "name": "projIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "wrench",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-red"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qhWRv",
+                                  "name": "projLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Projects",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "2z0Fc",
+                              "name": "projChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "hZaR_",
+                          "name": "projItem1",
+                          "width": "fill_container",
+                          "fill": "$--accent-red-light",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "KMKlm",
+                              "name": "proj1Txt",
+                              "fill": "$--accent-red",
+                              "content": "Laputa App",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "4auYC",
+                          "name": "projItem2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "-h_S-",
+                              "name": "proj2Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "Portfolio Rewrite",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Xby4k",
+                          "name": "projItem3",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            16,
+                            6,
+                            28
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "zflkU",
+                              "name": "proj3Txt",
+                              "fill": "$--muted-foreground",
+                              "content": "AI Habit Tracker",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yOvdh",
+                      "name": "respGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "9NVPP",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "KLgB7",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "_RJw9",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "medal",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "P2TLS",
+                                  "name": "respLabel",
+                                  "fill": "$--foreground",
+                                  "content": "Responsibilities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "FMkvu",
+                              "name": "respChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jdhEx",
+                      "name": "procGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yNxrB",
+                          "name": "respHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ZbG_K",
+                              "name": "leftResp",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Lrz9B",
+                                  "name": "respIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "arrows-clockwise",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-purple"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "JYP7R",
+                                  "name": "Procedures",
+                                  "fill": "$--foreground",
+                                  "content": "Procedures",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "cuKa1",
+                              "name": "procChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "9ZtV7",
+                      "name": "peopleGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "bqUk7",
+                          "name": "peopleHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "GDmNS",
+                              "name": "leftPeople",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "4N-jT",
+                                  "name": "peopleIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "users",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "eYxow",
+                                  "name": "peopleLbl",
+                                  "fill": "$--foreground",
+                                  "content": "People",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "zxTf-",
+                              "name": "peopleChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oO2nv",
+                      "name": "eventsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "01fhT",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "BpjDl",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "WNSv4",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "calendar-blank",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-yellow"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Z-BdI",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Events",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "VtYYq",
+                              "name": "eventsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QB60u",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dr3Dy",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "gip-z",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "YWJHr",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "tag",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "M4fMh",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Topics",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "be_vU",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jtFdo",
+                      "name": "topicsGroup",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": {
+                          "type": "color",
+                          "color": "$--border",
+                          "enabled": false
+                        }
+                      },
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "t051Q",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "CSC3E",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "wt2dG",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "leaf",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--accent-green"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qqxUQ",
+                                  "name": "eventsLbl",
+                                  "fill": "$--foreground",
+                                  "content": "Notes",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "OyEhu",
+                              "name": "topicsChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "b0y4m",
+                          "name": "eventsHeader",
+                          "width": "fill_container",
+                          "cornerRadius": 4,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "XKefw",
+                              "name": "leftEvents",
+                              "gap": 8,
+                              "padding": [
+                                8,
+                                0
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "5MMXe",
+                                  "name": "eventsIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "phosphor",
+                                  "weight": 700,
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "yJWsr",
+                                  "name": "eventsLbl",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Create new type",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wTdWJ",
+                  "name": "Commit Area",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "layout": "vertical",
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "alvR1",
+                      "name": "commitBtn",
+                      "width": "fill_container",
+                      "fill": "$--primary",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "OZpvZ",
+                          "name": "commitIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "git-commit-horizontal",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary-foreground"
+                        },
+                        {
+                          "type": "text",
+                          "id": "vye-W",
+                          "name": "commitTxt",
+                          "fill": "$--primary-foreground",
+                          "content": "Commit & Push",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "M_lH9",
+                          "name": "commitBadge",
+                          "height": 18,
+                          "fill": "#ffffff40",
+                          "cornerRadius": 9,
+                          "padding": [
+                            0,
+                            5
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "kTQAa",
+                              "name": "commitBadgeTxt",
+                              "fill": "$--white",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "aBuSJ",
+              "name": "Resize Handle",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "5CXKO",
+              "name": "Panel: NoteList",
+              "clip": true,
+              "width": 300,
+              "height": "fill_container",
+              "fill": "$--card",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UhLWn",
+                  "name": "NoteList Header",
+                  "width": "fill_container",
+                  "height": 45,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "jyxqb",
+                      "name": "nlTitle",
+                      "fill": "$--foreground",
+                      "content": "Changes",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "0eL1W",
+                      "name": "nlActions",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "XsWjG",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "magnifying-glass",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "bBObW",
+                          "name": "plusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TK7b7",
+                  "name": "Note Items",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dri89",
+                      "name": "Backlinks Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "9mLoL",
+                          "name": "Note Item Selected",
+                          "width": "fill_container",
+                          "fill": "$--accent-yellow-light",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E9E9E7"
+                          },
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "id": "lmpZx",
+                              "name": "leftAccent",
+                              "fill": "$--accent-yellow",
+                              "width": 3,
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "CkBEU",
+                              "name": "noteSelContent",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                14,
+                                16
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "0KzHG",
+                                  "name": "noteSelRow",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "ScgZY",
+                                      "name": "titleGroup",
+                                      "width": "fill_container",
+                                      "gap": 6,
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "3mYfY",
+                                          "name": "noteSelTitle",
+                                          "fill": "$--foreground",
+                                          "content": "Laputa App",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "jqZDh",
+                                          "name": "modBadge",
+                                          "width": 18,
+                                          "height": 18,
+                                          "fill": "$--accent-yellow-light",
+                                          "cornerRadius": 4,
+                                          "justifyContent": "center",
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "v8EXM",
+                                              "name": "modBadgeTxt",
+                                              "fill": "$--accent-yellow",
+                                              "content": "M",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 10,
+                                              "fontWeight": "700"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "mCaj6",
+                                  "name": "noteSelSnip",
+                                  "fill": "$--foreground",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Personal knowledge and life management desktop app...",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "mi4c4",
+                                  "name": "noteSelTime",
+                                  "fill": "$--accent-yellow",
+                                  "content": "Modified",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MYwXd",
+                      "name": "Related Notes Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fKL4E",
+                          "name": "Related Notes Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "eCRui",
+                              "name": "rnLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "UEtOs",
+                                  "name": "rnLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "MODIFIED",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "geohb",
+                                  "name": "rnCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vW3Ux",
+                              "name": "rnRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "8-7YX",
+                                  "name": "rnFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "rJ2Qt",
+                                  "name": "rnPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "Agecx",
+                                  "name": "rnChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Ef8xK",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ikmO0",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "DgJzU",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "0SmlX",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Weekly Review Process",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "Ipmvo",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "pencil-simple",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "6-aLC",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Every Sunday: review tasks, update time blocks, plan the week ahead...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "35sd_",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Modified",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "D1PDV",
+                          "name": "Note Item",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "m3Yy9",
+                              "name": "note2Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "G7YLm",
+                                  "name": "leafGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "VeAEm",
+                                      "name": "note2Title",
+                                      "fill": "$--foreground",
+                                      "content": "Q1 Planning",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "rXUE_",
+                                      "name": "leafIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "pencil-simple",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "1G-GA",
+                              "name": "note2Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Allocated focus blocks in Q1 for deep work sessions on infrastructure...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "p_rqw",
+                              "name": "note2Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Modified",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "3o8WQ",
+                      "name": "Events Group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "G7UWp",
+                          "name": "Events Header",
+                          "width": "fill_container",
+                          "height": 32,
+                          "fill": "$--muted",
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "msMtG",
+                              "name": "evLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "SGt7e",
+                                  "name": "evLabel",
+                                  "fill": "$--muted-foreground",
+                                  "content": "MODIFIED",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "1PVP7",
+                                  "name": "evCount",
+                                  "fill": "$--muted-foreground",
+                                  "content": "2",
+                                  "fontFamily": "IBM Plex Sans",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "FCzPr",
+                              "name": "evRight",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "UYR0D",
+                                  "name": "evFilter",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "funnel",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "4jbCj",
+                                  "name": "evPlus",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "plus",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "WRN9r",
+                                  "name": "evChev",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "RiDwJ",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Rvp4A",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "bnvDp",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "QjRDJ",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Time Management Strategies",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "LeQCT",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "pencil-simple",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "vwDsc",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Effective time management requires clear priorities and consistent review...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "OPKF_",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Modified",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "PsBeq",
+                          "name": "Note Item 2",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "layout": "vertical",
+                          "gap": 4,
+                          "padding": [
+                            14,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "sPOHy",
+                              "name": "note3Row",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "1Ecj7",
+                                  "name": "calGroup",
+                                  "width": "fill_container",
+                                  "gap": 6,
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "DlZRH",
+                                      "name": "note3Title",
+                                      "fill": "$--foreground",
+                                      "content": "Time Management Strategies",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "yi-xp",
+                                      "name": "calIco",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "pencil-simple",
+                                      "iconFontFamily": "phosphor",
+                                      "fill": "$--accent-yellow"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "CJPuv",
+                              "name": "note3Snip",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Effective time management requires clear priorities and consistent review...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "6MtFY",
+                              "name": "note3Time",
+                              "fill": "$--muted-foreground",
+                              "content": "Modified",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "0kPjR",
+              "name": "Resize Handle 2",
+              "fill": "$--border",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "XRb-G",
+              "name": "Panel: Editor",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$--background",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GMRdK",
+                  "name": "Tab Bar",
+                  "width": "fill_container",
+                  "height": 45,
+                  "fill": "$--sidebar",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--sidebar-border"
+                  },
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "iXash",
+                      "name": "Tab Active",
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eo9dK",
+                          "name": "tab1Txt",
+                          "fill": "$--foreground",
+                          "content": "Laputa App",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "6MLT7",
+                          "name": "tab1Close",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "0UmLQ",
+                      "name": "Tab Inactive",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "right": 1,
+                          "bottom": 1
+                        },
+                        "fill": "$--sidebar-border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "1JK8S",
+                          "name": "tab2Txt",
+                          "fill": "$--muted-foreground",
+                          "content": "Portfolio Rewrite",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "k2PZa",
+                          "name": "tab2Close",
+                          "opacity": 0,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "x",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bM7NZ",
+                      "name": "tabSpacer",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "$--border"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "G6gUe",
+                      "name": "tabControls",
+                      "height": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1,
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_around",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "oVC29",
+                          "name": "iconPlus",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "XwYxq",
+                          "name": "iconSplit",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "columns",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "8z4xd",
+                          "name": "iconExpand",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrows-out-simple",
+                          "iconFontFamily": "phosphor",
+                          "fill": "$--muted-foreground"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZIoKq",
+                  "name": "Editor Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tJCEQ",
+                      "name": "Editor Left",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "L9_bR",
+                          "name": "Info Bar",
+                          "width": "fill_container",
+                          "height": 45,
+                          "fill": "$--background",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "padding": [
+                            6,
+                            16
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "7YAl6",
+                              "name": "infoLeft",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8RsE6",
+                                  "name": "breadcrumbType",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Project",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "aPIWW",
+                                  "name": "breadcrumbSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "›",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Hko61",
+                                  "name": "breadcrumbName",
+                                  "fill": "$--foreground",
+                                  "content": "Laputa App",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "UgLju",
+                                  "name": "dotSep",
+                                  "fill": "$--muted-foreground",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "atZy3",
+                                  "name": "modifiedTxt",
+                                  "fill": "$--accent-yellow",
+                                  "content": "M",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "i_O9Q",
+                              "name": "infoRight",
+                              "gap": 12,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "mATmR",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "magnifying-glass",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "7-BlR",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "git-branch",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "hggOM",
+                                  "name": "iconSearch",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cursor-text",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "lKS8-",
+                                  "name": "iconAI",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sparkle",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "etlhz",
+                                  "name": "iconMore",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "dots-three",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "n-cpK",
+                          "name": "Editor Content",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": [
+                            32,
+                            64
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jnGoo",
+                              "name": "editorP1",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Personal knowledge and life management desktop app, built with Tauri v2 + React + TypeScript + CodeMirror 6. It reads a vault of markdown files with YAML frontmatter and presents them in a four-panel UI inspired by Bear Notes.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "fwFRq",
+                              "name": "editorH2",
+                              "fill": "$--foreground",
+                              "content": "Architecture",
+                              "lineHeight": 1.3,
+                              "fontFamily": "Inter",
+                              "fontSize": 24,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qK0e0",
+                              "name": "editorP2",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The app uses a four-panel layout: Sidebar for navigation, NoteList for browsing, Editor for content, and Inspector for metadata. All data lives in markdown files with YAML frontmatter, git-versioned.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RkIhR",
+                      "name": "Inspector",
+                      "clip": true,
+                      "width": 260,
+                      "height": "fill_container",
+                      "fill": "$--background",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 1
+                        },
+                        "fill": "$--border"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "0CJaZ",
+                          "name": "Inspector Header",
+                          "width": "fill_container",
+                          "height": 45,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$--border"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "TPquS",
+                              "name": "leftGroup",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "AVtUy",
+                                  "name": "propIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "sliders-horizontal",
+                                  "iconFontFamily": "phosphor",
+                                  "fill": "$--muted-foreground"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Lgi69",
+                                  "name": "inspTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "Properties",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "uWuxn",
+                              "name": "sidebarIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "x",
+                              "iconFontFamily": "phosphor",
+                              "fill": "$--muted-foreground"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "u6jJ2",
+                          "name": "Inspector Body",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 16,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "MRZfg",
+                              "name": "Properties Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "qC-P7",
+                                  "name": "addPropBtn",
+                                  "width": "fill_container",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$--border"
+                                  },
+                                  "padding": [
+                                    6,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "HBg9i",
+                                      "name": "addPropTxt",
+                                      "fill": "$--muted-foreground",
+                                      "content": "+ Add property",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "oHFVh",
+                                  "name": "propType",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Mk9GH",
+                                      "name": "propTypeLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "TYPE",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "NUS5u",
+                                      "name": "propTypeVal",
+                                      "fill": "$--foreground",
+                                      "content": "Project",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "EAnqI",
+                                  "name": "propStatus",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "YZlCv",
+                                      "name": "propStatusLbl",
+                                      "fill": "$--muted-foreground",
+                                      "content": "STATUS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "khF0Y",
+                                      "name": "propStatusBadge",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 16,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "transparent"
+                                      },
+                                      "gap": 8,
+                                      "padding": [
+                                        1,
+                                        6
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "H3X2o",
+                                          "name": "Badge Text",
+                                          "fill": "$--accent-green",
+                                          "content": "ACTIVE",
+                                          "lineHeight": 1.33,
+                                          "textAlign": "center",
+                                          "textAlignVertical": "middle",
+                                          "fontFamily": "IBM Plex Mono",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 1.2
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "F0I-7",
+                              "name": "Relationships Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 16,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "10XXp",
+                                  "name": "relGroup1",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "qh7dI",
+                                      "name": "relGrp1Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "BELONGS TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ovNo_",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "u6cth",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Laputa",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "911p5",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "TwrqD",
+                                      "name": "relLaputaBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-green-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "R02qX",
+                                          "name": "laputaTxt",
+                                          "fill": "$--accent-green",
+                                          "content": "Building",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "URmQn",
+                                          "name": "topicIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "tag",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-green"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "y-RCD",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Sohlo",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "NON3K",
+                                  "name": "relGroup2",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "PRmP1",
+                                      "name": "relGrp2Title",
+                                      "fill": "$--muted-foreground",
+                                      "content": "RELATED TO",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ZORAR",
+                                      "name": "relMigrationBtn",
+                                      "width": "fill_container",
+                                      "fill": "$--accent-red-light",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "zBinS",
+                                          "name": "migrationTxt",
+                                          "fill": "$--accent-red",
+                                          "content": "Shadcn Migration",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        },
+                                        {
+                                          "type": "icon_font",
+                                          "id": "fmvl7",
+                                          "name": "expIcon",
+                                          "opacity": 0.5,
+                                          "width": 14,
+                                          "height": 14,
+                                          "iconFontName": "flask",
+                                          "iconFontFamily": "phosphor",
+                                          "fill": "$--accent-red"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "rk_6m",
+                                      "name": "linkExisting",
+                                      "width": "fill_container",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "$--border"
+                                      },
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "space_between",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "0BiPL",
+                                          "name": "laputaTxt",
+                                          "fill": "$--muted-foreground",
+                                          "content": "+ Link existing",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "4CbGG",
+                              "name": "Backlinks Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "bYwPw",
+                                  "name": "blTitle",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "FXmIm",
+                                      "name": "blTitleTxt",
+                                      "rotation": -0.5285936385085725,
+                                      "fill": "$--muted-foreground",
+                                      "content": "BACKLINKS",
+                                      "fontFamily": "IBM Plex Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "QkxSV",
+                                  "name": "blItem1",
+                                  "fill": "$--primary",
+                                  "content": "Portfolio Rewrite",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "5GEwY",
+                                  "name": "blItem2",
+                                  "fill": "$--primary",
+                                  "content": "Meeting with Grant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "JjS06",
+                                  "name": "blItem3",
+                                  "fill": "$--primary",
+                                  "content": "Q1 Planning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "-AVRp",
+                              "name": "History Section",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "s2sCa",
+                                  "name": "histTitle",
+                                  "fill": "$--muted-foreground",
+                                  "content": "HISTORY",
+                                  "fontFamily": "IBM Plex Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Wh7sL",
+                                  "name": "histItem1",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "WJkad",
+                                      "name": "histItem1Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "a089f44 · feat: migrate to shadcn/ui",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "tdi_I",
+                                      "name": "histItem1Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 16, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "LM_vp",
+                                  "name": "histItem2",
+                                  "width": "fill_container",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": {
+                                      "left": 2
+                                    },
+                                    "fill": "$--border"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "padding": [
+                                    0,
+                                    0,
+                                    0,
+                                    10
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "FAnJW",
+                                      "name": "histItem2Hash",
+                                      "fill": "$--accent-blue",
+                                      "content": "5a4b4ac · feat: emoji favicon",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "9bpmf",
+                                      "name": "histItem2Date",
+                                      "fill": "$--muted-foreground",
+                                      "content": "Feb 15, 2026",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "gH1Q6",
+          "name": "lightStatusBar",
+          "width": "fill_container",
+          "height": 30,
+          "fill": "$--sidebar",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            8
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "8q9j3",
+              "name": "Status Left",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "HoLpj",
+                  "name": "versionIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "box",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "k-eWA",
+                  "name": "versionText",
+                  "fill": "$--muted-foreground",
+                  "content": "v0.4.2",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "Y-wAn",
+                  "name": "sep1",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "gtv6Y",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "xnDxG",
+                  "name": "branchText",
+                  "fill": "$--muted-foreground",
+                  "content": "main",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "qpDn7",
+                  "name": "sep2",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "NUI5N",
+                  "name": "syncIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "pencil-simple",
+                  "iconFontFamily": "phosphor",
+                  "fill": "$--accent-yellow"
+                },
+                {
+                  "type": "text",
+                  "id": "sDa8O",
+                  "name": "syncText",
+                  "fill": "$--muted-foreground",
+                  "content": "3 modified",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4RcrW",
+              "name": "Status Right",
+              "height": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "5g3ye",
+                  "name": "aiIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--accent-purple"
+                },
+                {
+                  "type": "text",
+                  "id": "D1hG8",
+                  "name": "aiText",
+                  "fill": "$--muted-foreground",
+                  "content": "Claude Sonnet 4",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "l4igr",
+                  "name": "sep3",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "2uctj",
+                  "name": "notesCount",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "uv6xG",
+                  "name": "notesText",
+                  "fill": "$--muted-foreground",
+                  "content": "1,247 notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "tViOI",
+                  "name": "sep4",
+                  "fill": "$--border",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "i4ZVl",
+                  "name": "bellIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "bell",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "-T7ch",
+                  "name": "settingsIcon",
+                  "width": 13,
+                  "height": 13,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "--accent": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#252545",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-blue": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-green": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#0F7B6C"
+        },
+        {
+          "value": "#4caf50",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#00B38B"
+        },
+        {
+          "value": "#00B38B",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-orange": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#D9730D"
+        },
+        {
+          "value": "#ff9800",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-purple": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#9065B0"
+        },
+        {
+          "value": "#9c72ff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#A932FF"
+        },
+        {
+          "value": "#A932FF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-red": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E"
+        },
+        {
+          "value": "#f44336",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--background": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#0f0f1a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--black": {
+      "type": "color",
+      "value": "#000000"
+    },
+    "--border": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--card": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#16162a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--card-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--destructive": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E"
+        },
+        {
+          "value": "#f44336",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--destructive-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--font-primary": {
+      "type": "string",
+      "value": [
+        {
+          "value": "Inter"
+        },
+        {
+          "value": "-apple-system, BlinkMacSystemFont, Inter, sans-serif"
+        },
+        {
+          "value": "Inter"
+        }
+      ]
+    },
+    "--font-system": {
+      "type": "string",
+      "value": "-apple-system, BlinkMacSystemFont, sans-serif"
+    },
+    "--foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--input": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--muted": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0F0EF"
+        },
+        {
+          "value": "#1e1e3a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--muted-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#787774"
+        },
+        {
+          "value": "#888888",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--popover": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#1e1e3a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--popover-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--primary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--primary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--radius-lg": {
+      "type": "number",
+      "value": 8
+    },
+    "--radius-md": {
+      "type": "number",
+      "value": 6
+    },
+    "--radius-sm": {
+      "type": "number",
+      "value": 4
+    },
+    "--ring": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--secondary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--secondary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F7F6F3"
+        },
+        {
+          "value": "#1a1a2e",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-accent": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EBEBEA"
+        },
+        {
+          "value": "#252545",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-accent-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-border": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E9E9E7"
+        },
+        {
+          "value": "#2a2a4a",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#37352F"
+        },
+        {
+          "value": "#e0e0e0",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-primary": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-primary-foreground": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFFFFF"
+        },
+        {
+          "value": "#ffffff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--sidebar-ring": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#2383E2"
+        },
+        {
+          "value": "#4a9eff",
+          "theme": {
+            "Mode": "Dark"
+          }
+        },
+        {
+          "value": "#155DFF"
+        },
+        {
+          "value": "#155DFF",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "--accent-yellow": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0B100"
+        },
+        {
+          "value": "#F0B100",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-blue-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#155DFF14"
+        },
+        {
+          "value": "#155DFF20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-green-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#00B38B14"
+        },
+        {
+          "value": "#00B38B20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-purple-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#A932FF14"
+        },
+        {
+          "value": "#A932FF20",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-red-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E03E3E14"
+        },
+        {
+          "value": "#f4433620",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    },
+    "--accent-yellow-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F0B10014"
+        },
+        {
+          "value": "#F0B10020",
+          "theme": {
+            "Mode": "Dark"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds 4 full-layout frames in design/design-full-layouts.pen showing the complete Laputa app in different states: editor focused, search panel active, rich properties + autocomplete, and changes view.