### PR TITLE
fix: dedup search results by path (keyword + semantic)

### DIFF
--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -84,6 +84,24 @@ fn extract_clean_snippet(raw_snippet: &str) -> String {
     }
 }
 
+/// Deduplicate search results by path, keeping the entry with the highest score.
+/// Preserves the order of first occurrence.
+fn dedup_by_path(results: impl Iterator<Item = SearchResult>) -> Vec<SearchResult> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut out: Vec<SearchResult> = Vec::new();
+    for r in results {
+        if let Some(&idx) = seen.get(&r.path) {
+            if r.score > out[idx].score {
+                out[idx] = r;
+            }
+        } else {
+            seen.insert(r.path.clone(), out.len());
+            out.push(r);
+        }
+    }
+    out
+}
+
 static COLLECTION_CACHE: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
 
 fn detect_collection_name(vault_path: &str) -> String {
@@ -183,20 +201,17 @@ pub fn search_vault(
     let qmd_results: Vec<QmdResult> =
         serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse qmd output: {}", e))?;
 
-    let results: Vec<SearchResult> = qmd_results
-        .into_iter()
-        .map(|r| {
-            let path = qmd_uri_to_vault_path(&r.file, vault_path);
-            let snippet = extract_clean_snippet(&r.snippet);
-            SearchResult {
-                title: r.title,
-                path,
-                snippet,
-                score: r.score,
-                note_type: None,
-            }
-        })
-        .collect();
+    let results = dedup_by_path(qmd_results.into_iter().map(|r| {
+        let path = qmd_uri_to_vault_path(&r.file, vault_path);
+        let snippet = extract_clean_snippet(&r.snippet);
+        SearchResult {
+            title: r.title,
+            path,
+            snippet,
+            score: r.score,
+            note_type: None,
+        }
+    }));
 
     let elapsed_ms = start.elapsed().as_millis() as u64;
 
@@ -241,6 +256,60 @@ mod tests {
         let clean = extract_clean_snippet(&raw);
         assert!(clean.len() <= 203); // 200 + "..."
         assert!(clean.ends_with("..."));
+    }
+
+    #[test]
+    fn test_dedup_by_path_keeps_highest_score() {
+        let results = vec![
+            SearchResult {
+                title: "Note A".into(),
+                path: "/vault/a.md".into(),
+                snippet: "keyword match".into(),
+                score: 0.7,
+                note_type: None,
+            },
+            SearchResult {
+                title: "Note B".into(),
+                path: "/vault/b.md".into(),
+                snippet: "only once".into(),
+                score: 0.6,
+                note_type: None,
+            },
+            SearchResult {
+                title: "Note A".into(),
+                path: "/vault/a.md".into(),
+                snippet: "semantic match".into(),
+                score: 0.9,
+                note_type: None,
+            },
+        ];
+        let deduped = dedup_by_path(results.into_iter());
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].path, "/vault/a.md");
+        assert_eq!(deduped[0].score, 0.9);
+        assert_eq!(deduped[1].path, "/vault/b.md");
+    }
+
+    #[test]
+    fn test_dedup_by_path_no_duplicates() {
+        let results = vec![
+            SearchResult {
+                title: "A".into(),
+                path: "/vault/a.md".into(),
+                snippet: "".into(),
+                score: 0.8,
+                note_type: None,
+            },
+            SearchResult {
+                title: "B".into(),
+                path: "/vault/b.md".into(),
+                snippet: "".into(),
+                score: 0.7,
+                note_type: None,
+            },
+        ];
+        let deduped = dedup_by_path(results.into_iter());
+        assert_eq!(deduped.len(), 2);
     }
 
     #[test]

--- a/src/components/SearchPanel.test.tsx
+++ b/src/components/SearchPanel.test.tsx
@@ -371,6 +371,32 @@ describe('SearchPanel', () => {
     expect(screen.getByText('Keyword Only')).toBeInTheDocument()
   })
 
+  it('deduplicates results when backend returns same note twice', async () => {
+    mockInvokeFn.mockResolvedValue({
+      results: [
+        { title: 'How to Design AI-first APIs', path: '/vault/essay/ai-apis.md', snippet: 'keyword hit', score: 0.7, note_type: 'Essay' },
+        { title: 'Refactoring Retreat', path: '/vault/event/retreat.md', snippet: 'unique', score: 0.6, note_type: 'Event' },
+        { title: 'How to Design AI-first APIs', path: '/vault/essay/ai-apis.md', snippet: 'semantic hit', score: 0.9, note_type: 'Essay' },
+      ],
+      elapsed_ms: 48,
+    })
+
+    render(
+      <SearchPanel open={true} vaultPath="/vault" entries={MOCK_ENTRIES} onSelectNote={vi.fn()} onClose={vi.fn()} />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Search in all notes...'), { target: { value: 'api' } })
+
+    await waitFor(() => {
+      const titles = screen.getAllByText('How to Design AI-first APIs')
+      expect(titles).toHaveLength(1) // deduped — not 2
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 results/)).toBeInTheDocument()
+    })
+  })
+
   it('cancels inflight searches when panel closes', async () => {
     const resolvers: ((v: unknown) => void)[] = []
     mockInvokeFn.mockImplementation(

--- a/src/hooks/useUnifiedSearch.test.ts
+++ b/src/hooks/useUnifiedSearch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { dedupByPath } from './useUnifiedSearch'
+import type { SearchResult } from '../types'
+
+function result(path: string, score: number, title = 'Note'): SearchResult {
+  return { path, score, title, snippet: '', noteType: null }
+}
+
+describe('dedupByPath', () => {
+  it('keeps higher-scored entry when path appears twice', () => {
+    const input = [
+      result('/vault/a.md', 0.7),
+      result('/vault/b.md', 0.6),
+      result('/vault/a.md', 0.9),
+    ]
+    const out = dedupByPath(input)
+    expect(out).toHaveLength(2)
+    expect(out[0].path).toBe('/vault/a.md')
+    expect(out[0].score).toBe(0.9)
+    expect(out[1].path).toBe('/vault/b.md')
+  })
+
+  it('preserves order of first occurrence', () => {
+    const input = [
+      result('/vault/c.md', 0.5),
+      result('/vault/a.md', 0.8),
+      result('/vault/c.md', 0.9),
+    ]
+    const out = dedupByPath(input)
+    expect(out.map(r => r.path)).toEqual(['/vault/c.md', '/vault/a.md'])
+  })
+
+  it('returns same array when no duplicates', () => {
+    const input = [
+      result('/vault/a.md', 0.9),
+      result('/vault/b.md', 0.8),
+      result('/vault/c.md', 0.7),
+    ]
+    const out = dedupByPath(input)
+    expect(out).toHaveLength(3)
+  })
+
+  it('handles empty array', () => {
+    expect(dedupByPath([])).toEqual([])
+  })
+
+  it('handles triple duplicate — keeps best score', () => {
+    const input = [
+      result('/vault/a.md', 0.3),
+      result('/vault/a.md', 0.9),
+      result('/vault/a.md', 0.5),
+    ]
+    const out = dedupByPath(input)
+    expect(out).toHaveLength(1)
+    expect(out[0].score).toBe(0.9)
+  })
+})

--- a/src/hooks/useUnifiedSearch.ts
+++ b/src/hooks/useUnifiedSearch.ts
@@ -45,6 +45,22 @@ function mapResults(raw: SearchResultData[]): SearchResult[] {
   }))
 }
 
+/** Deduplicate results by path, keeping the entry with the higher score. */
+export function dedupByPath(results: SearchResult[]): SearchResult[] {
+  const seen = new Map<string, number>()
+  const out: SearchResult[] = []
+  for (const r of results) {
+    const idx = seen.get(r.path)
+    if (idx !== undefined) {
+      if (r.score > out[idx].score) out[idx] = r
+    } else {
+      seen.set(r.path, out.length)
+      out.push(r)
+    }
+  }
+  return out
+}
+
 export function useUnifiedSearch(vaultPath: string, active: boolean) {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
@@ -79,7 +95,7 @@ export function useUnifiedSearch(vaultPath: string, active: boolean) {
     try {
       const response = await searchCall({ vaultPath, query: q, mode: 'keyword', limit: 20 })
       if (gen !== searchGenRef.current) return
-      setResults(mapResults(response.results))
+      setResults(dedupByPath(mapResults(response.results)))
       setElapsedMs(response.elapsed_ms)
       setSelectedIndex(0)
     } catch {
@@ -93,7 +109,7 @@ export function useUnifiedSearch(vaultPath: string, active: boolean) {
         HYBRID_TIMEOUT_MS,
       )
       if (gen !== searchGenRef.current) return
-      setResults(mapResults(response.results))
+      setResults(dedupByPath(mapResults(response.results)))
       setElapsedMs(response.elapsed_ms)
       setSelectedIndex(prev => Math.min(prev, Math.max(response.results.length - 1, 0)))
     } catch { /* Hybrid timed out — keyword results remain */ } finally {


### PR DESCRIPTION
Closes Todoist task 6g5RhJC4rCqhHvGv. Added dedupByPath in Rust backend (search.rs) and frontend hook (useUnifiedSearch.ts) to deduplicate search results by note path, keeping highest-scored entry. Added unit tests for both layers plus integration test in SearchPanel.