### PR TITLE
fix: git status bar commit link now opens external URL

### DIFF
--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { StatusBar } from './StatusBar'
 import type { VaultOption } from './StatusBar'
+
+vi.mock('../utils/url', async () => {
+  const actual = await vi.importActual('../utils/url')
+  return { ...actual, openExternalUrl: vi.fn().mockResolvedValue(undefined) }
+})
+
+const { openExternalUrl } = await import('../utils/url') as typeof import('../utils/url') & { openExternalUrl: ReturnType<typeof vi.fn> }
 
 const vaults: VaultOption[] = [
   { label: 'Main Vault', path: '/Users/luca/Laputa' },
@@ -9,6 +16,10 @@ const vaults: VaultOption[] = [
 ]
 
 describe('StatusBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('displays note count', () => {
     render(<StatusBar noteCount={9200} vaultPath="/Users/luca/Laputa" vaults={vaults} onSwitchVault={vi.fn()} />)
     expect(screen.getByText('9,200 notes')).toBeInTheDocument()
@@ -24,7 +35,7 @@ describe('StatusBar', () => {
     expect(screen.queryByText('main')).not.toBeInTheDocument()
   })
 
-  it('shows clickable commit hash when commitUrl is available', () => {
+  it('shows clickable commit hash that opens URL via openExternalUrl', () => {
     render(
       <StatusBar
         noteCount={100}
@@ -36,10 +47,11 @@ describe('StatusBar', () => {
     )
     const link = screen.getByTestId('status-commit-link')
     expect(link).toBeInTheDocument()
-    expect(link.tagName).toBe('A')
-    expect(link).toHaveAttribute('href', 'https://github.com/owner/repo/commit/abc123')
-    expect(link).toHaveAttribute('target', '_blank')
+    expect(link.tagName).toBe('SPAN')
     expect(screen.getByText('a3f9b1c')).toBeInTheDocument()
+
+    fireEvent.click(link)
+    expect(openExternalUrl).toHaveBeenCalledWith('https://github.com/owner/repo/commit/abc123')
   })
 
   it('shows non-clickable commit hash when no commitUrl', () => {

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { Package, RefreshCw, Sparkles, FileText, Bell, Settings, FolderOpen, Check, Github, CircleDot, AlertTriangle, Loader2, GitCommitHorizontal } from 'lucide-react'
 import type { LastCommitInfo, SyncStatus } from '../types'
+import { openExternalUrl } from '../utils/url'
 
 export interface VaultOption {
   label: string
@@ -157,10 +158,9 @@ export function StatusBar({ noteCount, modifiedCount = 0, vaultPath, vaults, onS
         </span>
         {lastCommitInfo && (
           lastCommitInfo.commitUrl ? (
-            <a
-              href={lastCommitInfo.commitUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+            <span
+              role="button"
+              onClick={() => openExternalUrl(lastCommitInfo.commitUrl!)}
               style={{ ...ICON_STYLE, color: 'var(--muted-foreground)', textDecoration: 'none', cursor: 'pointer', padding: '2px 4px', borderRadius: 3 }}
               title={`Open commit ${lastCommitInfo.shortHash} on GitHub`}
               data-testid="status-commit-link"
@@ -168,7 +168,7 @@ export function StatusBar({ noteCount, modifiedCount = 0, vaultPath, vaults, onS
               onMouseLeave={e => { e.currentTarget.style.color = 'var(--muted-foreground)' }}
             >
               <GitCommitHorizontal size={13} />{lastCommitInfo.shortHash}
-            </a>
+            </span>
           ) : (
             <span style={ICON_STYLE} data-testid="status-commit-hash">
               <GitCommitHorizontal size={13} />{lastCommitInfo.shortHash}


### PR DESCRIPTION
Closes Todoist task 6g5RhJFWR2j2XXhM. Replaced <a href> with <span role='button' onClick> that calls openExternalUrl() from utils/url.ts, which uses Tauri opener plugin in native mode and window.open in browser mode.