### PR TITLE
fix: revert notelist subtitle to first 2 lines of content

### DIFF
--- a/src/components/NoteItem.tsx
+++ b/src/components/NoteItem.tsx
@@ -7,7 +7,7 @@ import {
 } from '@phosphor-icons/react'
 import { getTypeColor, getTypeLightColor } from '../utils/typeColors'
 import { resolveIcon } from '../utils/iconRegistry'
-import { relativeDate, formatSubtitle } from '../utils/noteListHelpers'
+import { relativeDate, getDisplayDate } from '../utils/noteListHelpers'
 
 const TYPE_ICON_MAP: Record<string, ComponentType<SVGAttributes<SVGSVGElement>>> = {
   Project: Wrench,
@@ -101,9 +101,12 @@ export function NoteItem({ entry, isSelected, noteStatus = 'clean', typeEntryMap
           )}
         </div>
       </div>
+      <div className="mt-0.5 text-[12px] leading-[1.5] text-muted-foreground" style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+        {entry.snippet}
+      </div>
       {entry.trashed && entry.trashedAt
         ? <TrashDateLine entry={entry} />
-        : <div className="mt-1 text-[11px] text-muted-foreground">{formatSubtitle(entry)}</div>
+        : <div className="mt-0.5 text-[10px] text-muted-foreground">{relativeDate(getDisplayDate(entry))}</div>
       }
     </div>
   )

--- a/src/components/NoteList.test.tsx
+++ b/src/components/NoteList.test.tsx
@@ -266,12 +266,12 @@ describe('NoteList', () => {
     expect(screen.getByText('Facebook Ads Strategy')).toBeInTheDocument()
   })
 
-  it('context view shows prominent card with metadata subtitle', () => {
+  it('context view shows prominent card with snippet subtitle', () => {
     render(
       <NoteList entries={mockEntries} selection={{ kind: 'entity', entry: mockEntries[0] }} selectedNote={null} onSelectNote={noopSelect} onReplaceActiveTab={noopReplace} allContent={{}} onCreateNote={vi.fn()} />
     )
-    // Metadata subtitle (date · word count) appears in the prominent card
-    expect(screen.getAllByText(/Empty/).length).toBeGreaterThan(0)
+    // Snippet text appears in the prominent card
+    expect(screen.getByText('Build a personal knowledge management app.')).toBeInTheDocument()
   })
 })
 

--- a/src/components/NoteList.tsx
+++ b/src/components/NoteList.tsx
@@ -13,7 +13,7 @@ import {
   type SortOption, type SortDirection, type SortConfig, type RelationshipGroup,
   getSortComparator,
   buildRelationshipGroups, filterEntries,
-  formatSubtitle,
+  relativeDate, getDisplayDate,
   loadSortPreferences, saveSortPreferences,
 } from '../utils/noteListHelpers'
 
@@ -29,10 +29,11 @@ interface NoteListProps {
   onCreateNote: () => void
 }
 
-function PinnedCard({ entry, typeEntryMap, onClickNote }: {
+function PinnedCard({ entry, typeEntryMap, onClickNote, showDate }: {
   entry: VaultEntry
   typeEntryMap: Record<string, VaultEntry>
   onClickNote: (entry: VaultEntry, e: React.MouseEvent) => void
+  showDate?: boolean
 }) {
   const te = typeEntryMap[entry.isA ?? '']
   const color = getTypeColor(entry.isA ?? '', te?.color)
@@ -43,7 +44,8 @@ function PinnedCard({ entry, typeEntryMap, onClickNote }: {
       {/* eslint-disable-next-line react-hooks/static-components */}
       <Icon width={16} height={16} className="absolute right-3 top-3.5" style={{ color }} data-testid="type-icon" />
       <div className="pr-6 text-[14px] font-bold" style={{ color }}>{entry.title}</div>
-      <div className="mt-1 text-[11px] opacity-60" style={{ color }}>{formatSubtitle(entry)}</div>
+      <div className="mt-1 text-[12px] leading-[1.5] opacity-80" style={{ color, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{entry.snippet}</div>
+      {showDate && <div className="mt-1 text-[11px] opacity-60" style={{ color }}>{relativeDate(getDisplayDate(entry))}</div>}
     </div>
   )
 }
@@ -118,7 +120,7 @@ function EntityView({ entity, groups, query, collapsedGroups, sortPrefs, onToggl
 }) {
   return (
     <div className="h-full overflow-y-auto">
-      <PinnedCard entry={entity} typeEntryMap={typeEntryMap} onClickNote={onClickNote} />
+      <PinnedCard entry={entity} typeEntryMap={typeEntryMap} onClickNote={onClickNote} showDate />
       {groups.length === 0
         ? <EmptyMessage text={query ? 'No matching items' : 'No related items'} />
         : groups.map((group) => (


### PR DESCRIPTION
Closes Todoist task 6g5RhJP23g85CQRv. Reverted NoteItem and PinnedCard from showing metadata (date + word count) back to showing first 2 lines of note content (snippet) with date underneath.