### PR TITLE
fix: add http:default capability for Anthropic API fetch (CORS)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "dialog:default",
     "updater:default",
     "process:default",
-    "opener:default"
+    "opener:default",
+    "http:default"
   ]
 }


### PR DESCRIPTION
## Problem
AI Agent panel shows 'Load failed' — Tauri's WebView blocks fetch to `https://api.anthropic.com` due to missing HTTP capability.

## Fix
Add `http:default` to `src-tauri/capabilities/default.json` to allow outbound fetch requests from the WebView.

## Test
1. Open Settings (Cmd+,), insert Anthropic API key
2. Open AI Agent panel
3. Send a message → should get a response instead of 'Load failed'