### PR TITLE
fix: increase tab max-width and add ellipsis truncation

### DIFF
--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -156,12 +156,12 @@ export const BreadcrumbBar = memo(function BreadcrumbBar({
       }}
     >
       {/* Left: breadcrumb */}
-      <div className="flex items-center gap-1" style={{ fontSize: 12 }}>
-        <span className="text-muted-foreground">{entry.isA || 'Note'}</span>
-        <span className="text-muted-foreground" style={{ margin: '0 2px' }}>&rsaquo;</span>
-        <span className="font-medium text-foreground">{entry.title}</span>
-        <span className="text-muted-foreground" style={{ margin: '0 4px' }}>&middot;</span>
-        <span className="text-muted-foreground">{wordCount.toLocaleString()} words</span>
+      <div className="flex items-center gap-1 min-w-0 whitespace-nowrap" style={{ fontSize: 12 }}>
+        <span className="shrink-0 text-muted-foreground">{entry.isA || 'Note'}</span>
+        <span className="shrink-0 text-muted-foreground" style={{ margin: '0 2px' }}>&rsaquo;</span>
+        <span className="truncate font-medium text-foreground" style={{ maxWidth: '40vw' }}>{entry.title}</span>
+        <span className="shrink-0 text-muted-foreground" style={{ margin: '0 4px' }}>&middot;</span>
+        <span className="shrink-0 text-muted-foreground">{wordCount.toLocaleString()} words</span>
         {noteStatus === 'pendingSave' && (
           <>
             <span className="text-muted-foreground" style={{ margin: '0 4px' }}>&middot;</span>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -219,7 +219,7 @@ function TabItem({ tab, isActive, isEditing, noteStatus, isDragging, showDropBef
       draggable={!isEditing}
       {...dragProps}
       className={cn(
-        "group flex shrink-0 items-center gap-1.5 whitespace-nowrap max-w-[180px] transition-all relative",
+        "group flex shrink-0 items-center gap-1.5 whitespace-nowrap max-w-[360px] transition-all relative",
         isActive ? "text-foreground" : "text-muted-foreground hover:text-secondary-foreground"
       )}
       style={{


### PR DESCRIPTION
Fixes tab width constraints and long title overflow in the tab bar and breadcrumb.

## Changes
- Tab max-width increased from 180px → 360px
- Breadcrumb title now truncates with ellipsis at 40vw max-width (`truncate` class)
- Added `shrink-0` to non-title breadcrumb parts so they don't get squeezed