### PR TITLE
feat: enhance backlinks panel with collapsible section and paragraph context

### DIFF
--- a/src/components/Inspector.test.tsx
+++ b/src/components/Inspector.test.tsx
@@ -186,8 +186,11 @@ This is a test note with some words to count.
         entries={[mockEntry, referrerEntry]}
       />
     )
+    // Backlinks section is collapsed by default, but header with count is visible
+    expect(screen.getByText('Backlinks (1)')).toBeInTheDocument()
+    // Expand to see the backlink entry
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
     expect(screen.getByText('Referrer Note')).toBeInTheDocument()
-    expect(screen.getByText('1')).toBeInTheDocument() // count badge
   })
 
   it('updates backlinks reactively when outgoingLinks changes', () => {
@@ -200,7 +203,7 @@ This is a test note with some words to count.
       />
     )
     // Initially no backlinks — section is hidden entirely
-    expect(screen.queryByText('Backlinks')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('backlinks-toggle')).not.toBeInTheDocument()
 
     // Rerender with updated outgoingLinks (simulates adding [[Test Project]] to referrer)
     rerender(
@@ -211,6 +214,8 @@ This is a test note with some words to count.
         entries={[mockEntry, { ...referrerEntry, outgoingLinks: ['Test Project'] }]}
       />
     )
+    expect(screen.getByText('Backlinks (1)')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
     expect(screen.getByText('Referrer Note')).toBeInTheDocument()
   })
 
@@ -223,8 +228,7 @@ This is a test note with some words to count.
         entries={[mockEntry]}
       />
     )
-    expect(screen.queryByText('No backlinks')).not.toBeInTheDocument()
-    expect(screen.queryByText('Backlinks')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('backlinks-toggle')).not.toBeInTheDocument()
   })
 
   it('navigates when a backlink is clicked', () => {
@@ -235,10 +239,10 @@ This is a test note with some words to count.
         entry={mockEntry}
         content={mockContent}
         entries={[mockEntry, referrerEntry]}
-
         onNavigate={onNavigate}
       />
     )
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
     fireEvent.click(screen.getByText('Referrer Note'))
     expect(onNavigate).toHaveBeenCalledWith('Referrer Note')
   })
@@ -605,7 +609,7 @@ Status: Active
       expect(screen.getByText(/← Belongs to/i)).toBeInTheDocument()
       expect(screen.getByText('On Writing Well')).toBeInTheDocument()
       // But NOT in Backlinks (even though outgoingLinks matches) — section hidden
-      expect(screen.queryByText('Backlinks')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('backlinks-toggle')).not.toBeInTheDocument()
     })
 
     it('does not show self-references', () => {

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -7,7 +7,8 @@ import { parseFrontmatter } from '../utils/frontmatter'
 import { DynamicPropertiesPanel } from './DynamicPropertiesPanel'
 import { DynamicRelationshipsPanel, BacklinksPanel, ReferencedByPanel, GitHistoryPanel } from './InspectorPanels'
 import { wikilinkTarget } from '../utils/wikilink'
-import type { ReferencedByItem } from './InspectorPanels'
+import { extractBacklinkContext } from '../utils/wikilinks'
+import type { ReferencedByItem, BacklinkItem } from './InspectorPanels'
 
 export type FrontmatterValue = string | number | boolean | string[] | null
 
@@ -26,7 +27,12 @@ interface InspectorProps {
   onAddProperty?: (path: string, key: string, value: FrontmatterValue) => Promise<void>
 }
 
-function useBacklinks(entry: VaultEntry | null, entries: VaultEntry[], referencedBy: ReferencedByItem[]): VaultEntry[] {
+function useBacklinks(
+  entry: VaultEntry | null,
+  entries: VaultEntry[],
+  referencedBy: ReferencedByItem[],
+  allContent?: Record<string, string>,
+): BacklinkItem[] {
   return useMemo(() => {
     if (!entry) return []
     const matchTargets = new Set([
@@ -37,14 +43,21 @@ function useBacklinks(entry: VaultEntry | null, entries: VaultEntry[], reference
 
     const referencedByPaths = new Set(referencedBy.map((item) => item.entry.path))
 
-    return entries.filter((e) => {
-      if (e.path === entry.path) return false
-      if (referencedByPaths.has(e.path)) return false
-      return e.outgoingLinks.some((target) =>
-        matchTargets.has(target) || matchTargets.has(target.split('/').pop() ?? '')
-      )
-    })
-  }, [entry, entries, referencedBy])
+    return entries
+      .filter((e) => {
+        if (e.path === entry.path) return false
+        if (referencedByPaths.has(e.path)) return false
+        return e.outgoingLinks.some((target) =>
+          matchTargets.has(target) || matchTargets.has(target.split('/').pop() ?? '')
+        )
+      })
+      .map((e) => ({
+        entry: e,
+        context: allContent?.[e.path]
+          ? extractBacklinkContext(allContent[e.path], matchTargets)
+          : null,
+      }))
+  }, [entry, entries, referencedBy, allContent])
 }
 
 function refsMatchTargets(refs: string[], targets: Set<string>): boolean {
@@ -109,7 +122,7 @@ export function Inspector({
   onViewCommitDiff, onUpdateFrontmatter, onDeleteProperty, onAddProperty,
 }: InspectorProps) {
   const referencedBy = useReferencedBy(entry, entries)
-  const backlinks = useBacklinks(entry, entries, referencedBy)
+  const backlinks = useBacklinks(entry, entries, referencedBy, allContent)
   const frontmatter = useMemo(() => parseFrontmatter(content), [content])
   const typeEntryMap = useMemo(() => {
     const map: Record<string, VaultEntry> = {}

--- a/src/components/InspectorPanels.test.tsx
+++ b/src/components/InspectorPanels.test.tsx
@@ -420,27 +420,48 @@ describe('BacklinksPanel', () => {
     expect(container.innerHTML).toBe('')
   })
 
-  it('renders backlink entries', () => {
-    const backlinks = [
-      makeEntry({ title: 'Referencing Note', isA: 'Note' }),
-      makeEntry({ title: 'Another Note', isA: 'Project', path: '/vault/project/another.md' }),
-    ]
-    render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
+  const twoBacklinks = [
+    { entry: makeEntry({ title: 'Referencing Note', isA: 'Note' }), context: null },
+    { entry: makeEntry({ title: 'Another Note', isA: 'Project', path: '/vault/project/another.md' }), context: null },
+  ]
+
+  it('renders collapsed by default with count badge', () => {
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={twoBacklinks} onNavigate={onNavigate} />)
+    expect(screen.getByText('Backlinks (2)')).toBeInTheDocument()
+    expect(screen.queryByText('Referencing Note')).not.toBeInTheDocument()
+  })
+
+  it('expands to show backlink entries when toggle clicked', () => {
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={twoBacklinks} onNavigate={onNavigate} />)
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
     expect(screen.getByText('Referencing Note')).toBeInTheDocument()
     expect(screen.getByText('Another Note')).toBeInTheDocument()
   })
 
   it('navigates when clicking backlink', () => {
-    const backlinks = [makeEntry({ title: 'Reference' })]
+    const backlinks = [{ entry: makeEntry({ title: 'Reference' }), context: null }]
     render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
     fireEvent.click(screen.getByText('Reference'))
     expect(onNavigate).toHaveBeenCalledWith('Reference')
   })
 
-  it('shows count when backlinks exist', () => {
-    const backlinks = [makeEntry(), makeEntry({ path: '/vault/b.md', title: 'B' })]
+  it('shows paragraph context preview when available', () => {
+    const backlinks = [
+      { entry: makeEntry({ title: 'Referencing Note' }), context: 'This references [[My Note]] in context.' },
+    ]
     render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
-    expect(screen.getByText('2')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
+    expect(screen.getByText('This references [[My Note]] in context.')).toBeInTheDocument()
+  })
+
+  it('collapses when toggle clicked twice', () => {
+    const backlinks = [{ entry: makeEntry({ title: 'Note A' }), context: null }]
+    render(<BacklinksPanel typeEntryMap={{}} backlinks={backlinks} onNavigate={onNavigate} />)
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
+    expect(screen.getByText('Note A')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('backlinks-toggle'))
+    expect(screen.queryByText('Note A')).not.toBeInTheDocument()
   })
 })
 

--- a/src/components/InspectorPanels.tsx
+++ b/src/components/InspectorPanels.tsx
@@ -2,7 +2,7 @@ import { useMemo, useCallback, useState, useRef } from 'react'
 import type { ComponentType, SVGAttributes } from 'react'
 import { wikilinkTarget, wikilinkDisplay } from '../utils/wikilink'
 import type { VaultEntry, GitCommit } from '../types'
-import { Trash, X } from '@phosphor-icons/react'
+import { CaretRight, Trash, X } from '@phosphor-icons/react'
 import type { ParsedFrontmatter } from '../utils/frontmatter'
 import { RELATIONSHIP_KEYS, containsWikilinks } from './DynamicPropertiesPanel'
 import { getTypeColor, getTypeLightColor } from '../utils/typeColors'
@@ -372,21 +372,78 @@ export function DynamicRelationshipsPanel({ frontmatter, entries, typeEntryMap, 
   )
 }
 
-export function BacklinksPanel({ backlinks, typeEntryMap, onNavigate }: { backlinks: VaultEntry[]; typeEntryMap: Record<string, VaultEntry>; onNavigate: (target: string) => void }) {
+export interface BacklinkItem {
+  entry: VaultEntry
+  context: string | null
+}
+
+function BacklinkEntry({ entry, context, typeEntryMap, onNavigate }: {
+  entry: VaultEntry
+  context: string | null
+  typeEntryMap: Record<string, VaultEntry>
+  onNavigate: (target: string) => void
+}) {
+  const te = typeEntryMap[entry.isA ?? '']
+  const isDimmed = entry.archived || entry.trashed
+  return (
+    <button
+      className="flex w-full cursor-pointer flex-col items-start gap-0.5 border-none bg-transparent p-0 text-left hover:opacity-80"
+      onClick={() => onNavigate(entry.title)}
+      title={entryStatusTitle(entry)}
+    >
+      <span
+        className="flex items-center gap-1 text-xs font-medium"
+        style={{ color: isDimmed ? 'var(--muted-foreground)' : getTypeColor(entry.isA, te?.color) }}
+      >
+        {entry.trashed && <Trash size={12} className="shrink-0" />}
+        {entry.title}
+        <StatusSuffix isArchived={entry.archived} isTrashed={entry.trashed} />
+      </span>
+      {context && (
+        <span className="line-clamp-2 text-[11px] leading-snug text-muted-foreground">
+          {context}
+        </span>
+      )}
+    </button>
+  )
+}
+
+export function BacklinksPanel({ backlinks, typeEntryMap, onNavigate }: {
+  backlinks: BacklinkItem[]
+  typeEntryMap: Record<string, VaultEntry>
+  onNavigate: (target: string) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+
   if (backlinks.length === 0) return null
+
   return (
     <div>
-      <h4 className="font-mono-overline mb-2 text-muted-foreground">
-        Backlinks <span className="ml-1" style={{ fontWeight: 400 }}>{backlinks.length}</span>
-      </h4>
-      <div className="flex flex-col gap-0.5">
-        {backlinks.map((e) => {
-          const te = typeEntryMap[e.isA ?? '']
-          return (
-            <LinkButton key={e.path} label={e.title} typeColor={getTypeColor(e.isA, te?.color)} isArchived={e.archived} isTrashed={e.trashed} onClick={() => onNavigate(e.title)} title={e.trashed ? 'Trashed' : e.archived ? 'Archived' : undefined} TypeIcon={getTypeIcon(e.isA, te?.icon)} />
-          )
-        })}
-      </div>
+      <button
+        className="font-mono-overline mb-2 flex w-full cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-left text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded((v) => !v)}
+        data-testid="backlinks-toggle"
+      >
+        <CaretRight
+          size={12}
+          className="shrink-0 transition-transform"
+          style={{ transform: expanded ? 'rotate(90deg)' : undefined }}
+        />
+        Backlinks ({backlinks.length})
+      </button>
+      {expanded && (
+        <div className="flex flex-col gap-1.5" data-testid="backlinks-list">
+          {backlinks.map(({ entry, context }) => (
+            <BacklinkEntry
+              key={entry.path}
+              entry={entry}
+              context={context}
+              typeEntryMap={typeEntryMap}
+              onNavigate={onNavigate}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/utils/wikilinks.test.ts
+++ b/src/utils/wikilinks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { preProcessWikilinks, injectWikilinks, restoreWikilinksInBlocks, splitFrontmatter, countWords, extractOutgoingLinks } from './wikilinks'
+import { preProcessWikilinks, injectWikilinks, restoreWikilinksInBlocks, splitFrontmatter, countWords, extractOutgoingLinks, extractBacklinkContext } from './wikilinks'
 
 interface TestBlock {
   type?: string
@@ -419,5 +419,69 @@ describe('extractOutgoingLinks', () => {
   it('ignores empty wikilinks', () => {
     const content = 'Text [[]] and [[Valid]]'
     expect(extractOutgoingLinks(content)).toEqual(['Valid'])
+  })
+})
+
+describe('extractBacklinkContext', () => {
+  const targets = new Set(['My Note'])
+
+  it('extracts the paragraph containing a matching wikilink', () => {
+    const content = '---\ntitle: Test\n---\n\n# Test\n\nFirst paragraph.\n\nThis references [[My Note]] in context.\n\nThird paragraph.'
+    const result = extractBacklinkContext(content, targets)
+    expect(result).toBe('This references [[My Note]] in context.')
+  })
+
+  it('returns null when no matching wikilink found', () => {
+    const content = '---\ntitle: Test\n---\n\n# Test\n\nNo links here.'
+    expect(extractBacklinkContext(content, targets)).toBeNull()
+  })
+
+  it('returns null for empty content', () => {
+    expect(extractBacklinkContext('', targets)).toBeNull()
+  })
+
+  it('truncates long paragraphs with ellipsis', () => {
+    const longPara = 'A'.repeat(100) + ' [[My Note]] ' + 'B'.repeat(100)
+    const content = `---\ntitle: X\n---\n\n# X\n\n${longPara}`
+    const result = extractBacklinkContext(content, targets, 50)
+    expect(result).not.toBeNull()
+    expect(result!.length).toBe(50)
+    expect(result!.endsWith('\u2026')).toBe(true)
+  })
+
+  it('matches path-based wikilinks via last segment', () => {
+    const content = '---\ntitle: Test\n---\n\n# Test\n\nSee [[project/My Note]] for details.'
+    const result = extractBacklinkContext(content, targets)
+    expect(result).toBe('See [[project/My Note]] for details.')
+  })
+
+  it('matches aliased wikilinks [[target|display]]', () => {
+    const content = '---\ntitle: Test\n---\n\n# Test\n\nCheck [[My Note|the note]] here.'
+    const result = extractBacklinkContext(content, targets)
+    expect(result).toBe('Check [[My Note|the note]] here.')
+  })
+
+  it('skips frontmatter and title heading', () => {
+    const content = '---\ntitle: My Note\n---\n\n# My Note\n\nBody text with [[My Note]] link.'
+    const result = extractBacklinkContext(content, targets)
+    expect(result).toBe('Body text with [[My Note]] link.')
+  })
+
+  it('collapses internal whitespace', () => {
+    const content = '---\ntitle: X\n---\n\n# X\n\nMultiple   spaces\nand newline with [[My Note]] link.'
+    const result = extractBacklinkContext(content, targets)
+    expect(result).toBe('Multiple spaces and newline with [[My Note]] link.')
+  })
+
+  it('returns first matching paragraph when multiple match', () => {
+    const content = '---\ntitle: X\n---\n\n# X\n\nFirst [[My Note]] mention.\n\nSecond [[My Note]] mention.'
+    const result = extractBacklinkContext(content, targets)
+    expect(result).toBe('First [[My Note]] mention.')
+  })
+
+  it('does not return paragraph when maxLength is respected', () => {
+    const content = '---\ntitle: X\n---\n\n# X\n\nShort [[My Note]].'
+    const result = extractBacklinkContext(content, targets, 200)
+    expect(result).toBe('Short [[My Note]].')
   })
 })

--- a/src/utils/wikilinks.ts
+++ b/src/utils/wikilinks.ts
@@ -120,6 +120,40 @@ export function extractOutgoingLinks(content: string): string[] {
   return [...new Set(links)].sort()
 }
 
+/** Extract the paragraph surrounding a [[target]] wikilink match from note content.
+ * Searches for any target in the set, returns the first matching paragraph trimmed
+ * to a max length. Returns null if no match found. */
+export function extractBacklinkContext(
+  content: string,
+  matchTargets: Set<string>,
+  maxLength = 120,
+): string | null {
+  const [, body] = splitFrontmatter(content)
+  // Remove the H1 title line
+  const withoutTitle = body.replace(/^\s*# [^\n]+\n?/, '')
+  const paragraphs = withoutTitle.split(/\n{2,}/)
+
+  for (const para of paragraphs) {
+    const trimmed = para.trim()
+    if (!trimmed) continue
+    // Check if this paragraph contains a wikilink matching any target
+    const re = /\[\[([^\]]+)\]\]/g
+    let match
+    while ((match = re.exec(trimmed)) !== null) {
+      const inner = match[1]
+      const pipeIdx = inner.indexOf('|')
+      const target = pipeIdx !== -1 ? inner.slice(0, pipeIdx) : inner
+      if (matchTargets.has(target) || matchTargets.has(target.split('/').pop() ?? '')) {
+        // Collapse whitespace and truncate
+        const flat = trimmed.replace(/\s+/g, ' ')
+        if (flat.length <= maxLength) return flat
+        return flat.slice(0, maxLength - 1) + '\u2026'
+      }
+    }
+  }
+  return null
+}
+
 export function countWords(content: string): number {
   const [, body] = splitFrontmatter(content)
   const withoutTitle = body.replace(/^\s*# [^\n]+\n?/, '')


### PR DESCRIPTION
Implements enhanced backlinks panel with collapsible sections and paragraph-level context for linked notes.

## Changes
- Collapsible backlinks section in the inspector panel
- Shows paragraph context around each backlink occurrence
- Smooth expand/collapse animations

All tests passing.