### PR TITLE
fix: use openExternalUrl for release notes link in Tauri app

### DIFF
--- a/src/hooks/useUpdater.test.ts
+++ b/src/hooks/useUpdater.test.ts
@@ -7,6 +7,12 @@ vi.mock('../mock-tauri', () => ({
   isTauri: vi.fn(() => false),
 }))
 
+// Mock openExternalUrl
+const mockOpenExternalUrl = vi.fn()
+vi.mock('../utils/url', () => ({
+  openExternalUrl: (...args: unknown[]) => mockOpenExternalUrl(...args),
+}))
+
 // Mock the dynamic imports
 const mockCheck = vi.fn()
 const mockRelaunch = vi.fn()
@@ -149,9 +155,8 @@ describe('useUpdater', () => {
     expect(result.current.status).toEqual({ state: 'idle' })
   })
 
-  it('openReleaseNotes opens the release notes URL', async () => {
+  it('openReleaseNotes opens the release notes URL via openExternalUrl', async () => {
     vi.mocked(isTauri).mockReturnValue(false)
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
     const { result } = renderHook(() => useUpdater())
 
@@ -159,9 +164,8 @@ describe('useUpdater', () => {
       result.current.actions.openReleaseNotes()
     })
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://refactoringhq.github.io/laputa-app/',
-      '_blank'
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith(
+      'https://refactoringhq.github.io/laputa-app/'
     )
   })
 

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { isTauri } from '../mock-tauri'
+import { openExternalUrl } from '../utils/url'
 
 const RELEASE_NOTES_URL = 'https://refactoringhq.github.io/laputa-app/'
 
@@ -80,7 +81,7 @@ export function useUpdater(): { status: UpdateStatus; actions: UpdateActions } {
   }, [])
 
   const openReleaseNotes = useCallback(() => {
-    window.open(RELEASE_NOTES_URL, '_blank')
+    openExternalUrl(RELEASE_NOTES_URL)
   }, [])
 
   const dismiss = useCallback(() => {


### PR DESCRIPTION
Fixes bug where the link to release notes in the update banner was not clickable in the native Tauri app. Uses `openExternalUrl` from tauri-plugin-opener to open the link in the system browser.