### PR TITLE
refactor: extract useEditorSaveWithLinks and useNavigationGestures from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,6 @@ import { useMcpRegistration } from './hooks/useMcpRegistration'
 import { useVaultLoader } from './hooks/useVaultLoader'
 import { useSettings } from './hooks/useSettings'
 import { useNoteActions } from './hooks/useNoteActions'
-import { useEditorSave } from './hooks/useEditorSave'
 import { useCommitFlow } from './hooks/useCommitFlow'
 import { useViewMode } from './hooks/useViewMode'
 import { useEntryActions } from './hooks/useEntryActions'
@@ -34,11 +33,12 @@ import { useZoom } from './hooks/useZoom'
 import { useBuildNumber } from './hooks/useBuildNumber'
 import { useOnboarding } from './hooks/useOnboarding'
 import { useThemeManager } from './hooks/useThemeManager'
+import { useEditorSaveWithLinks } from './hooks/useEditorSaveWithLinks'
+import { useNavigationGestures } from './hooks/useNavigationGestures'
 import { ConflictResolverModal } from './components/ConflictResolverModal'
 import { UpdateBanner } from './components/UpdateBanner'
 import { invoke } from '@tauri-apps/api/core'
 import { isTauri, mockInvoke } from './mock-tauri'
-import { extractOutgoingLinks } from './utils/wikilinks'
 import type { SidebarSelection } from './types'
 import './App.css'
 
@@ -80,34 +80,6 @@ function useLayoutPanels() {
 }
 
 /** Wraps useEditorSave to also keep outgoingLinks in sync on save and on content change. */
-function useEditorSaveWithLinks(config: {
-  updateContent: (path: string, content: string) => void
-  updateEntry: (path: string, patch: Partial<import('./types').VaultEntry>) => void
-  setTabs: Parameters<typeof useEditorSave>[0]['setTabs']
-  setToastMessage: (msg: string | null) => void
-  onAfterSave: () => void
-  onNotePersisted?: (path: string) => void
-}) {
-  const { updateContent, updateEntry } = config
-  const saveContent = useCallback((path: string, content: string) => {
-    updateContent(path, content)
-    updateEntry(path, { outgoingLinks: extractOutgoingLinks(content) })
-  }, [updateContent, updateEntry])
-  const editor = useEditorSave({ updateVaultContent: saveContent, setTabs: config.setTabs, setToastMessage: config.setToastMessage, onAfterSave: config.onAfterSave, onNotePersisted: config.onNotePersisted })
-  const { handleContentChange: rawOnChange } = editor
-  const prevLinksKeyRef = useRef('')
-  const handleContentChange = useCallback((path: string, content: string) => {
-    rawOnChange(path, content)
-    const links = extractOutgoingLinks(content)
-    const key = links.join('\0')
-    if (key !== prevLinksKeyRef.current) {
-      prevLinksKeyRef.current = key
-      updateEntry(path, { outgoingLinks: links })
-    }
-  }, [rawOnChange, updateEntry])
-  return { ...editor, handleContentChange }
-}
-
 function App() {
   const [selection, setSelection] = useState<SidebarSelection>(DEFAULT_SELECTION)
   const layout = useLayoutPanels()
@@ -217,45 +189,7 @@ function App() {
     }
   }, [navHistory, isEntryExists, vault.entries, notes])
 
-  // Mouse button 3/4 (back/forward) and macOS trackpad two-finger swipe
-  useEffect(() => {
-    const handleMouseBack = (e: MouseEvent) => {
-      if (e.button === 3) { e.preventDefault(); handleGoBack() }
-      if (e.button === 4) { e.preventDefault(); handleGoForward() }
-    }
-    window.addEventListener('mouseup', handleMouseBack)
-
-    // Trackpad swipe: accumulate horizontal wheel delta and trigger on threshold
-    let accumulatedDeltaX = 0
-    let resetTimer: ReturnType<typeof setTimeout> | null = null
-    const SWIPE_THRESHOLD = 120
-
-    const handleWheel = (e: WheelEvent) => {
-      // Only handle horizontal-dominant gestures (trackpad swipe)
-      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return
-      if (e.ctrlKey || e.metaKey) return // ignore pinch-zoom
-
-      accumulatedDeltaX += e.deltaX
-
-      if (resetTimer) clearTimeout(resetTimer)
-      resetTimer = setTimeout(() => { accumulatedDeltaX = 0 }, 300)
-
-      if (accumulatedDeltaX > SWIPE_THRESHOLD) {
-        accumulatedDeltaX = 0
-        handleGoForward()
-      } else if (accumulatedDeltaX < -SWIPE_THRESHOLD) {
-        accumulatedDeltaX = 0
-        handleGoBack()
-      }
-    }
-    window.addEventListener('wheel', handleWheel, { passive: true })
-
-    return () => {
-      window.removeEventListener('mouseup', handleMouseBack)
-      window.removeEventListener('wheel', handleWheel)
-      if (resetTimer) clearTimeout(resetTimer)
-    }
-  }, [handleGoBack, handleGoForward])
+  useNavigationGestures({ onGoBack: handleGoBack, onGoForward: handleGoForward })
 
   const { triggerIncrementalIndex } = indexing
   const onAfterSave = useCallback(() => {

--- a/src/hooks/useEditorSaveWithLinks.ts
+++ b/src/hooks/useEditorSaveWithLinks.ts
@@ -1,0 +1,32 @@
+import { useCallback, useRef } from 'react'
+import { useEditorSave } from './useEditorSave'
+import { extractOutgoingLinks } from '../utils/wikilinks'
+import type { VaultEntry } from '../types'
+
+export function useEditorSaveWithLinks(config: {
+  updateContent: (path: string, content: string) => void
+  updateEntry: (path: string, patch: Partial<VaultEntry>) => void
+  setTabs: Parameters<typeof useEditorSave>[0]['setTabs']
+  setToastMessage: (msg: string | null) => void
+  onAfterSave: () => void
+  onNotePersisted?: (path: string) => void
+}) {
+  const { updateContent, updateEntry } = config
+  const saveContent = useCallback((path: string, content: string) => {
+    updateContent(path, content)
+    updateEntry(path, { outgoingLinks: extractOutgoingLinks(content) })
+  }, [updateContent, updateEntry])
+  const editor = useEditorSave({ updateVaultContent: saveContent, setTabs: config.setTabs, setToastMessage: config.setToastMessage, onAfterSave: config.onAfterSave, onNotePersisted: config.onNotePersisted })
+  const { handleContentChange: rawOnChange } = editor
+  const prevLinksKeyRef = useRef('')
+  const handleContentChange = useCallback((path: string, content: string) => {
+    rawOnChange(path, content)
+    const links = extractOutgoingLinks(content)
+    const key = links.join('\0')
+    if (key !== prevLinksKeyRef.current) {
+      prevLinksKeyRef.current = key
+      updateEntry(path, { outgoingLinks: links })
+    }
+  }, [rawOnChange, updateEntry])
+  return { ...editor, handleContentChange }
+}

--- a/src/hooks/useNavigationGestures.ts
+++ b/src/hooks/useNavigationGestures.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+
+/**
+ * Registers mouse button 3/4 (back/forward) and macOS trackpad two-finger
+ * horizontal swipe gestures for navigation.
+ */
+export function useNavigationGestures({
+  onGoBack,
+  onGoForward,
+}: {
+  onGoBack: () => void
+  onGoForward: () => void
+}) {
+  useEffect(() => {
+    const handleMouseBack = (e: MouseEvent) => {
+      if (e.button === 3) { e.preventDefault(); onGoBack() }
+      if (e.button === 4) { e.preventDefault(); onGoForward() }
+    }
+    window.addEventListener('mouseup', handleMouseBack)
+
+    // Trackpad swipe: accumulate horizontal wheel delta and trigger on threshold
+    let accumulatedDeltaX = 0
+    let resetTimer: ReturnType<typeof setTimeout> | null = null
+    const SWIPE_THRESHOLD = 120
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only handle horizontal-dominant gestures (trackpad swipe)
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return
+      if (e.ctrlKey || e.metaKey) return // ignore pinch-zoom
+
+      accumulatedDeltaX += e.deltaX
+
+      if (resetTimer) clearTimeout(resetTimer)
+      resetTimer = setTimeout(() => { accumulatedDeltaX = 0 }, 300)
+
+      if (accumulatedDeltaX > SWIPE_THRESHOLD) {
+        accumulatedDeltaX = 0
+        onGoForward()
+      } else if (accumulatedDeltaX < -SWIPE_THRESHOLD) {
+        accumulatedDeltaX = 0
+        onGoBack()
+      }
+    }
+    window.addEventListener('wheel', handleWheel, { passive: true })
+
+    return () => {
+      window.removeEventListener('mouseup', handleMouseBack)
+      window.removeEventListener('wheel', handleWheel)
+      if (resetTimer) clearTimeout(resetTimer)
+    }
+  }, [onGoBack, onGoForward])
+}


### PR DESCRIPTION
## What

Extract two inline hooks from App.tsx into dedicated files:

- `useEditorSaveWithLinks` → `src/hooks/useEditorSaveWithLinks.ts`
- `useNavigationGestures` → `src/hooks/useNavigationGestures.ts`

## Why

App.tsx has 539 lines and 112 git touches in 30 days — the highest churn in the codebase. These hooks have no dependencies on App internals and belong in their own files where they can be independently tested and reused.

App.tsx shrinks from 539 → 473 lines (-66 lines).

## Changes

- `src/App.tsx`: -66 lines, imports two new hooks instead of defining them inline
- `src/hooks/useEditorSaveWithLinks.ts`: new file — wraps useEditorSave to track and update outgoing wikilinks on save
- `src/hooks/useNavigationGestures.ts`: new file — registers mouse button 3/4 and trackpad swipe handlers for back/forward navigation

## Checks

- ✅ TypeScript: zero errors
- ✅ ESLint: zero warnings  
- ✅ Tests: 1550/1550 passing (82 test files)
- ✅ Frontend coverage: 78% (>70% threshold)
- ✅ Rust tests: 418/418 passing
- ✅ Rust coverage: 89.7% (>85% threshold)