### PR TITLE
feat: add dark mode with system/light/dark theme selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import { useUpdater, restartApp } from './hooks/useUpdater'
 import { useAutoSync } from './hooks/useAutoSync'
 import { useConflictResolver } from './hooks/useConflictResolver'
 import { useZoom } from './hooks/useZoom'
+import { useAppTheme } from './hooks/useAppTheme'
 import { useVaultConfig } from './hooks/useVaultConfig'
 import { useBuildNumber } from './hooks/useBuildNumber'
 import { useOnboarding } from './hooks/useOnboarding'
@@ -1017,6 +1018,7 @@ function App() {
 
   const { setViewMode, sidebarVisible, noteListVisible } = useViewMode(noteWindowParams ? 'editor-only' : undefined)
   const zoom = useZoom()
+  const appTheme = useAppTheme()
   const buildNumber = useBuildNumber()
 
   const updateMainWindowConstraints = useCallback((
@@ -1533,7 +1535,7 @@ function App() {
           onCommit={conflictResolver.commitResolution}
           onClose={conflictFlow.handleCloseConflictResolver}
         />
-        <SettingsPanel open={dialogs.showSettings} settings={settings} aiAgentsStatus={aiAgentsStatus} isGitVault={isGitVault} onSave={saveSettings} explicitOrganizationEnabled={explicitOrganizationEnabled} onSaveExplicitOrganization={handleSaveExplicitOrganization} onClose={dialogs.closeSettings} />
+        <SettingsPanel open={dialogs.showSettings} settings={settings} aiAgentsStatus={aiAgentsStatus} isGitVault={isGitVault} onSave={saveSettings} explicitOrganizationEnabled={explicitOrganizationEnabled} onSaveExplicitOrganization={handleSaveExplicitOrganization} onClose={dialogs.closeSettings} theme={appTheme.theme} onThemeChange={appTheme.setTheme} />
         <FeedbackDialog open={showFeedback} onClose={closeFeedback} />
         <McpSetupDialog open={showMcpSetupDialog} status={mcpStatus} busyAction={mcpDialogAction} onClose={closeMcpSetupDialog} onConnect={handleConnectMcp} onDisconnect={handleDisconnectMcp} />
         <CloneVaultModal key={dialogs.showCloneVault ? 'clone-open' : 'clone-closed'} open={dialogs.showCloneVault} onClose={dialogs.closeCloneVault} onVaultCloned={vaultSwitcher.handleVaultCloned} />

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -30,6 +30,7 @@ import {
   SelectValue,
 } from './ui/select'
 import { Switch } from './ui/switch'
+import type { AppTheme } from '../hooks/useAppTheme'
 
 interface SettingsPanelProps {
   open: boolean
@@ -40,6 +41,8 @@ interface SettingsPanelProps {
   explicitOrganizationEnabled?: boolean
   onSaveExplicitOrganization?: (enabled: boolean) => void
   onClose: () => void
+  theme?: AppTheme
+  onThemeChange?: (theme: AppTheme) => void
 }
 
 interface SettingsDraft {
@@ -81,6 +84,8 @@ interface SettingsBodyProps {
   setCrashReporting: (value: boolean) => void
   analytics: boolean
   setAnalytics: (value: boolean) => void
+  theme?: AppTheme
+  onThemeChange?: (theme: AppTheme) => void
 }
 
 const PULL_INTERVAL_OPTIONS = [1, 2, 5, 10, 15, 30] as const
@@ -169,6 +174,8 @@ export function SettingsPanel({
   explicitOrganizationEnabled = true,
   onSaveExplicitOrganization,
   onClose,
+  theme,
+  onThemeChange,
 }: SettingsPanelProps) {
   if (!open) return null
 
@@ -181,6 +188,8 @@ export function SettingsPanel({
       explicitOrganizationEnabled={explicitOrganizationEnabled}
       onSaveExplicitOrganization={onSaveExplicitOrganization}
       onClose={onClose}
+      theme={theme}
+      onThemeChange={onThemeChange}
     />
   )
 }
@@ -199,6 +208,8 @@ function SettingsPanelInner({
   explicitOrganizationEnabled,
   onSaveExplicitOrganization,
   onClose,
+  theme = 'system',
+  onThemeChange,
 }: SettingsPanelInnerProps) {
   const [draft, setDraft] = useState(() => createSettingsDraft(settings, explicitOrganizationEnabled))
   const panelRef = useRef<HTMLDivElement>(null)
@@ -287,6 +298,8 @@ function SettingsPanelInner({
           setCrashReporting={(value) => updateDraft('crashReporting', value)}
           analytics={draft.analytics}
           setAnalytics={(value) => updateDraft('analytics', value)}
+          theme={theme}
+          onThemeChange={onThemeChange}
         />
         <SettingsFooter onClose={onClose} onSave={handleSave} />
       </div>
@@ -339,10 +352,16 @@ function SettingsBody({
   setCrashReporting,
   analytics,
   setAnalytics,
+  theme,
+  onThemeChange,
 }: SettingsBodyProps) {
   return (
     <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 0, overflow: 'auto' }}>
       <SettingsSection showDivider={false}>
+        <AppearanceSection theme={theme} onThemeChange={onThemeChange} />
+      </SettingsSection>
+
+      <SettingsSection>
         <SyncAndUpdatesSection
           pullInterval={pullInterval}
           setPullInterval={setPullInterval}
@@ -396,6 +415,33 @@ function SettingsBody({
         />
       </SettingsSection>
     </div>
+  )
+}
+
+function AppearanceSection({
+  theme = 'system',
+  onThemeChange,
+}: Pick<SettingsBodyProps, 'theme' | 'onThemeChange'>) {
+  return (
+    <>
+      <SectionHeading
+        title="Appearance"
+        description="Choose how Tolaria looks. System follows your OS dark/light mode setting."
+      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <label style={{ fontSize: 12, fontWeight: 500, color: 'var(--foreground)' }}>Theme</label>
+        <Select value={theme} onValueChange={(v) => onThemeChange?.(v as AppTheme)}>
+          <SelectTrigger className="w-full bg-transparent" data-testid="settings-theme">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent position="popper" data-anchor-strategy="popper">
+            <SelectItem value="system">System</SelectItem>
+            <SelectItem value="light">Light</SelectItem>
+            <SelectItem value="dark">Dark</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </>
   )
 }
 

--- a/src/components/SingleEditorView.tsx
+++ b/src/components/SingleEditorView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo, useRef, useContext } from 'react'
+import { useEffect, useCallback, useMemo, useRef, useContext, useState } from 'react'
 import { trackEvent } from '../lib/telemetry'
 import {
   useCreateBlockNote,
@@ -323,6 +323,18 @@ export function SingleEditorView({ editor, entries, onNavigateWikilink, onChange
 }) {
   const { cssVars } = useEditorTheme()
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // Track whether the app is in dark mode by watching the <html> class
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains('dark')
+  )
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
   const handleContainerClick = useEditorContainerClickHandler({ editable, editor })
   const handleEditorChange = useCompositionAwareEditorChange({ containerRef, onChange })
   const onImageUrl = useInsertImageCallback(editor)
@@ -360,7 +372,7 @@ export function SingleEditorView({ editor, entries, onNavigateWikilink, onChange
       )}
       <SharedContextBlockNoteView
         editor={editor}
-        theme="light"
+        theme={isDark ? 'dark' : 'light'}
         onChange={handleEditorChange}
         editable={editable}
         formattingToolbar={false}

--- a/src/hooks/useAppTheme.ts
+++ b/src/hooks/useAppTheme.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect, useCallback } from 'react'
+import { getAppStorageItem } from '../constants/appStorage'
+
+export type AppTheme = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'tolaria-theme'
+
+function getSystemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function loadPersistedTheme(): AppTheme {
+  const stored = getAppStorageItem('theme')
+  if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+  return 'system'
+}
+
+function resolveTheme(theme: AppTheme): 'light' | 'dark' {
+  return theme === 'system' ? getSystemTheme() : theme
+}
+
+function applyThemeToDocument(theme: AppTheme): void {
+  const resolved = resolveTheme(theme)
+  document.documentElement.classList.toggle('dark', resolved === 'dark')
+}
+
+function persistTheme(theme: AppTheme): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, theme)
+  } catch {
+    // ignore
+  }
+}
+
+export function useAppTheme() {
+  const [theme, setThemeState] = useState<AppTheme>(() => {
+    const t = loadPersistedTheme()
+    applyThemeToDocument(t)
+    return t
+  })
+
+  // Listen for OS-level theme changes when in 'system' mode
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => {
+      setThemeState(current => {
+        if (current === 'system') applyThemeToDocument('system')
+        return current
+      })
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const setTheme = useCallback((next: AppTheme) => {
+    applyThemeToDocument(next)
+    persistTheme(next)
+    setThemeState(next)
+  }, [])
+
+  const resolvedTheme = resolveTheme(theme)
+
+  return { theme, resolvedTheme, setTheme }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -94,7 +94,83 @@
   --shadow-dialog: rgba(0, 0, 0, 0.15);
 }
 
-/* Dark mode variables removed — light mode only for now */
+/* Dark mode variables — applied when <html class="dark"> */
+html.dark {
+  /* --- shadcn theme variables (dark mode) --- */
+  --background: #1A1A1A;
+  --foreground: #E8E6E1;
+  --card: #222222;
+  --card-foreground: #E8E6E1;
+  --popover: #222222;
+  --popover-foreground: #E8E6E1;
+  --primary: #4D8BFF;
+  --primary-foreground: #FFFFFF;
+  --secondary: #2E2E2E;
+  --secondary-foreground: #E8E6E1;
+  --muted: #2A2A2A;
+  --muted-foreground: #9B9894;
+  --accent: #2E2E2E;
+  --accent-foreground: #E8E6E1;
+  --destructive: #F56565;
+  --destructive-foreground: #FFFFFF;
+  --border: #333333;
+  --input: #333333;
+  --ring: #4D8BFF;
+  --sidebar: #161616;
+  --sidebar-foreground: #E8E6E1;
+  --sidebar-primary: #4D8BFF;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2E2E2E;
+  --sidebar-accent-foreground: #E8E6E1;
+  --sidebar-border: #2A2A2A;
+  --sidebar-ring: #4D8BFF;
+
+  /* --- App-specific variables (dark mode) --- */
+  color-scheme: dark;
+  --bg-primary: #1A1A1A;
+  --bg-sidebar: #161616;
+  --bg-card: #222222;
+  --bg-hover: #2E2E2E;
+  --bg-hover-subtle: #252525;
+  --bg-selected: #1A2D4A;
+  --bg-input: #222222;
+  --bg-button: #2E2E2E;
+  --bg-dialog: #222222;
+  --text-primary: #E8E6E1;
+  --text-secondary: #9B9894;
+  --text-tertiary: #9B9894;
+  --text-muted: #5E5C58;
+  --text-faint: #5E5C58;
+  --text-heading: #E8E6E1;
+  --accent-blue: #4D8BFF;
+  --accent-blue-bg: #4D8BFF18;
+  --accent-blue-hover: #6B9FFF;
+  --accent-green: #48BB78;
+  --accent-orange: #ED8936;
+  --accent-orange-light: rgba(237, 137, 54, 0.15);
+  --accent-red: #FC8181;
+  --accent-purple: #B794F4;
+  --accent-yellow: #F6E05E;
+  --accent-blue-light: #4D8BFF14;
+  --accent-green-light: rgba(72, 187, 120, 0.15);
+  --accent-purple-light: rgba(183, 148, 244, 0.15);
+  --accent-red-light: rgba(252, 129, 129, 0.15);
+  --accent-yellow-light: rgba(246, 224, 94, 0.15);
+  --accent-teal: #4FD1C5;
+  --accent-teal-light: rgba(79, 209, 197, 0.15);
+  --accent-pink: #F687B3;
+  --accent-pink-light: rgba(246, 135, 179, 0.15);
+  --accent-gray: #A0AEC0;
+  --accent-gray-light: rgba(160, 174, 192, 0.15);
+  --border-primary: #333333;
+  --border-subtle: #2A2A2A;
+  --border-input: #333333;
+  --border-dialog: #333333;
+  --link-color: #4D8BFF;
+  --link-hover: #6B9FFF;
+  --shadow-overlay: rgba(0, 0, 0, 0.6);
+  --shadow-dialog: rgba(0, 0, 0, 0.4);
+}
 
 /* --- Tailwind v4 theme inline: register colors + radii --- */
 @theme inline {
@@ -309,6 +385,26 @@
 .ai-markdown .hljs-attribute { color: #005cc5; }
 .ai-markdown .hljs-deletion { color: #b31d28; background: #ffeef0; }
 .ai-markdown .hljs-meta { color: #6a737d; }
+
+/* --- highlight.js dark theme (GitHub Dark-style) --- */
+html.dark .ai-markdown .hljs { color: #e8e6e1; }
+html.dark .ai-markdown .hljs-comment,
+html.dark .ai-markdown .hljs-quote { color: #8b949e; font-style: italic; }
+html.dark .ai-markdown .hljs-keyword,
+html.dark .ai-markdown .hljs-selector-tag { color: #ff7b72; }
+html.dark .ai-markdown .hljs-string,
+html.dark .ai-markdown .hljs-addition { color: #a5d6ff; }
+html.dark .ai-markdown .hljs-number,
+html.dark .ai-markdown .hljs-literal { color: #79c0ff; }
+html.dark .ai-markdown .hljs-title,
+html.dark .ai-markdown .hljs-section { color: #d2a8ff; }
+html.dark .ai-markdown .hljs-built_in,
+html.dark .ai-markdown .hljs-type { color: #ffa657; }
+html.dark .ai-markdown .hljs-attr,
+html.dark .ai-markdown .hljs-name,
+html.dark .ai-markdown .hljs-attribute { color: #79c0ff; }
+html.dark .ai-markdown .hljs-deletion { color: #ffa198; background: #3d1a1a; }
+html.dark .ai-markdown .hljs-meta { color: #8b949e; }
 
 /* --- AI panel working border animation --- */
 


### PR DESCRIPTION
- Add html.dark CSS variable overrides for all app-wide tokens (backgrounds, text, borders, shadows, accents) in src/index.css
- Add dark hljs syntax highlight theme for AI chat code blocks
- Add useAppTheme hook (light/dark/system) persisted to localStorage, applies class to <html>, listens for OS preference changes
- Wire useAppTheme into App.tsx and pass theme/onThemeChange to SettingsPanel
- Add Appearance section to SettingsPanel with Light/Dark/System selector
- Fix BlockNote editor to follow dark mode via MutationObserver on <html>