### PR TITLE
fix: resolve vault image rendering and add Cmd+click to open in viewer

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,10 @@
     "dialog:default",
     "updater:default",
     "process:default",
-    "opener:default"
+    "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [{ "path": "$HOME/**" }]
+    }
   ]
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -229,7 +229,7 @@ mod tests {
             .output()
             .unwrap();
 
-        let entries = list_vault(vault_path.into()).unwrap();
+        let entries = crate::vault::scan_vault_cached(vault_path).unwrap();
         assert!(!entries[0].archived);
 
         std::fs::write(

--- a/src-tauri/src/commands/vault/file_cmds.rs
+++ b/src-tauri/src/commands/vault/file_cmds.rs
@@ -160,8 +160,14 @@ pub fn copy_image_to_vault(vault_path: PathBuf, source_path: PathBuf) -> Result<
 }
 
 #[tauri::command]
-pub fn list_vault(path: PathBuf) -> Result<Vec<VaultEntry>, String> {
-    with_expanded_vault_root(path.as_path(), vault::scan_vault_cached)
+pub fn list_vault(
+    app_handle: tauri::AppHandle,
+    path: PathBuf,
+) -> Result<Vec<VaultEntry>, String> {
+    with_expanded_vault_root(path.as_path(), |expanded| {
+        crate::sync_vault_asset_scope(&app_handle, expanded)?;
+        vault::scan_vault_cached(expanded)
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,9 +161,23 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     {
         run_startup_tasks();
         spawn_ws_bridge(app);
+        prime_asset_scope_for_last_vault(app);
     }
 
     Ok(())
+}
+
+#[cfg(desktop)]
+fn prime_asset_scope_for_last_vault(app: &tauri::App) {
+    let Some(vault_path) = settings::get_last_vault() else { return };
+    let expanded = commands::expand_tilde(&vault_path).into_owned();
+    let path = Path::new(&expanded);
+    if !path.is_dir() {
+        return;
+    }
+    if let Err(e) = sync_vault_asset_scope(app.handle(), path) {
+        log::warn!("Failed to prime asset scope for {expanded}: {e}");
+    }
 }
 
 #[cfg(desktop)]

--- a/src/components/SingleEditorView.tsx
+++ b/src/components/SingleEditorView.tsx
@@ -25,6 +25,7 @@ import {
   TolariaFormattingToolbarController,
 } from './tolariaEditorFormatting'
 import { TolariaSideMenu } from './tolariaBlockNoteSideMenu'
+import { useEditorImageActivation } from './useEditorImageActivation'
 import { useEditorLinkActivation } from './useEditorLinkActivation'
 
 const TEST_TABLE_MARKDOWN = `| Head 1 | Head 2 | Head 3 |
@@ -329,6 +330,7 @@ export function SingleEditorView({ editor, entries, onNavigateWikilink, onChange
   const { isDragOver } = useImageDrop({ containerRef, onImageUrl, vaultPath })
   useBlockNoteSideMenuHoverGuard(containerRef)
   useEditorLinkActivation(containerRef, onNavigateWikilink)
+  useEditorImageActivation(containerRef)
 
   useEffect(() => {
     _wikilinkEntriesRef.current = entries

--- a/src/components/useEditorImageActivation.test.tsx
+++ b/src/components/useEditorImageActivation.test.tsx
@@ -1,0 +1,128 @@
+import { useRef } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../utils/url', async () => {
+  const actual = await vi.importActual('../utils/url') as typeof import('../utils/url')
+  return { ...actual, openLocalFile: vi.fn().mockResolvedValue(undefined) }
+})
+
+import { openLocalFile } from '../utils/url'
+import { useEditorImageActivation } from './useEditorImageActivation'
+
+const mockOpenLocalFile = vi.mocked(openLocalFile)
+
+function Harness() {
+  const containerRef = useRef<HTMLDivElement>(null)
+  useEditorImageActivation(containerRef)
+  return <div ref={containerRef} data-testid="editor-image-container" />
+}
+
+function renderHarness() {
+  render(<Harness />)
+  return screen.getByTestId('editor-image-container') as HTMLDivElement
+}
+
+function appendImage(container: HTMLElement, src: string) {
+  const img = document.createElement('img')
+  img.setAttribute('src', src)
+  container.appendChild(img)
+  return img
+}
+
+describe('useEditorImageActivation', () => {
+  beforeEach(() => {
+    mockOpenLocalFile.mockClear()
+  })
+
+  it('opens asset-protocol images on Cmd+click', () => {
+    const container = renderHarness()
+    const src = `asset://localhost/${encodeURIComponent('/vault/attachments/skazkoterapiya/IMAGE 2022-10-15 15:47:07.jpg')}`
+    const img = appendImage(container, src)
+
+    fireEvent.click(img, { metaKey: true })
+
+    expect(mockOpenLocalFile).toHaveBeenCalledWith('/vault/attachments/skazkoterapiya/IMAGE 2022-10-15 15:47:07.jpg')
+  })
+
+  it('opens http-asset-protocol images on Cmd+click', () => {
+    const container = renderHarness()
+    const src = `http://asset.localhost/${encodeURIComponent('/vault/attachments/legacy.png')}`
+    const img = appendImage(container, src)
+
+    fireEvent.click(img, { metaKey: true })
+
+    expect(mockOpenLocalFile).toHaveBeenCalledWith('/vault/attachments/legacy.png')
+  })
+
+  it('also opens on Ctrl+click', () => {
+    const container = renderHarness()
+    const src = `asset://localhost/${encodeURIComponent('/vault/attachments/file.png')}`
+    const img = appendImage(container, src)
+
+    fireEvent.click(img, { ctrlKey: true })
+
+    expect(mockOpenLocalFile).toHaveBeenCalledWith('/vault/attachments/file.png')
+  })
+
+  it('does nothing on a plain click', () => {
+    const container = renderHarness()
+    const src = `asset://localhost/${encodeURIComponent('/vault/attachments/file.png')}`
+    const img = appendImage(container, src)
+
+    fireEvent.click(img)
+
+    expect(mockOpenLocalFile).not.toHaveBeenCalled()
+  })
+
+  it('ignores Cmd+click on non-image elements', () => {
+    const container = renderHarness()
+    const div = document.createElement('div')
+    container.appendChild(div)
+
+    fireEvent.click(div, { metaKey: true })
+
+    expect(mockOpenLocalFile).not.toHaveBeenCalled()
+  })
+
+  it('ignores Cmd+click on images without an asset-protocol src', () => {
+    const container = renderHarness()
+    const img = appendImage(container, 'https://example.com/image.png')
+
+    fireEvent.click(img, { metaKey: true })
+
+    expect(mockOpenLocalFile).not.toHaveBeenCalled()
+  })
+
+  it('opens the image when Cmd+click lands on a BlockNote resize handle', () => {
+    const container = renderHarness()
+    const block = document.createElement('div')
+    block.setAttribute('data-content-type', 'image')
+    const wrapper = document.createElement('div')
+    wrapper.className = 'bn-visual-media-wrapper'
+    const img = document.createElement('img')
+    img.setAttribute('src', `asset://localhost/${encodeURIComponent('/vault/attachments/nested.png')}`)
+    wrapper.appendChild(img)
+    const resizeHandle = document.createElement('div')
+    resizeHandle.className = 'bn-resize-handle'
+    wrapper.appendChild(resizeHandle)
+    block.appendChild(wrapper)
+    container.appendChild(block)
+
+    fireEvent.click(resizeHandle, { metaKey: true })
+
+    expect(mockOpenLocalFile).toHaveBeenCalledWith('/vault/attachments/nested.png')
+  })
+
+  it('ignores Cmd+click on images outside the editor container', () => {
+    renderHarness()
+    const outsideImg = document.createElement('img')
+    outsideImg.setAttribute('src', `asset://localhost/${encodeURIComponent('/vault/outside.png')}`)
+    document.body.appendChild(outsideImg)
+
+    fireEvent.click(outsideImg, { metaKey: true })
+
+    expect(mockOpenLocalFile).not.toHaveBeenCalled()
+    outsideImg.remove()
+  })
+})

--- a/src/components/useEditorImageActivation.ts
+++ b/src/components/useEditorImageActivation.ts
@@ -1,0 +1,72 @@
+import { useEffect, type RefObject } from 'react'
+import { openLocalFile } from '../utils/url'
+
+const ASSET_URL_PREFIXES = ['asset://localhost/', 'http://asset.localhost/']
+const IMAGE_ANCESTOR_SELECTOR = [
+  '[data-content-type="image"]',
+  '.bn-visual-media-wrapper',
+  '.bn-file-block-content-wrapper',
+].join(', ')
+
+function resolveAssetPath(src: string): string | null {
+  const prefix = ASSET_URL_PREFIXES.find(candidate => src.startsWith(candidate))
+  if (!prefix) return null
+
+  try {
+    return decodeURIComponent(src.slice(prefix.length))
+  } catch {
+    return null
+  }
+}
+
+function findImageNear(target: EventTarget | null): HTMLImageElement | null {
+  if (!(target instanceof Element)) return null
+  const direct = target.closest('img')
+  if (direct) return direct as HTMLImageElement
+  const imageBlock = target.closest(IMAGE_ANCESTOR_SELECTOR)
+  return imageBlock?.querySelector('img') ?? null
+}
+
+function resolveImageTarget(target: EventTarget | null): string | null {
+  const img = findImageNear(target)
+  if (!img) return null
+  const src = img.getAttribute('src')
+  return src ? resolveAssetPath(src) : null
+}
+
+function hasFollowModifier(event: MouseEvent) {
+  return event.metaKey || event.ctrlKey
+}
+
+export function useEditorImageActivation(
+  containerRef: RefObject<HTMLDivElement | null>,
+) {
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const handleClick = (event: MouseEvent) => {
+      if (!hasFollowModifier(event)) return
+      const absolutePath = resolveImageTarget(event.target)
+      if (!absolutePath) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      openLocalFile(absolutePath).catch(() => {})
+    }
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!hasFollowModifier(event)) return
+      if (!resolveImageTarget(event.target)) return
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    container.addEventListener('click', handleClick, true)
+    container.addEventListener('mousedown', handleMouseDown, true)
+    return () => {
+      container.removeEventListener('click', handleClick, true)
+      container.removeEventListener('mousedown', handleMouseDown, true)
+    }
+  }, [containerRef])
+}

--- a/src/hooks/useEditorTabSwap.ts
+++ b/src/hooks/useEditorTabSwap.ts
@@ -146,7 +146,7 @@ async function resolveBlocksForTarget(
   if (cached?.sourceContent === content) return cached
 
   const body = extractEditorBody(content)
-  const withImages = vaultPath ? resolveImageUrls(body, vaultPath) : body
+  const withImages = vaultPath ? resolveImageUrls(body, vaultPath, targetPath) : body
   const preprocessed = preProcessWikilinks(withImages)
   const fastPathBlocks = buildFastPathBlocks({ preprocessed })
   if (fastPathBlocks) {
@@ -239,12 +239,13 @@ async function resolveEmptyHeadingHtml(
   editor: ReturnType<typeof useCreateBlockNote>,
   content: string,
   vaultPath?: string,
+  notePath?: string,
 ): Promise<string | null> {
   const remainder = extractBodyRemainderAfterEmptyH1({ content })
   if (remainder === null) return null
   if (!remainder.trim()) return '<h1></h1><p></p>'
 
-  const withImages = vaultPath ? resolveImageUrls(remainder, vaultPath) : remainder
+  const withImages = vaultPath ? resolveImageUrls(remainder, vaultPath, notePath) : remainder
   const parsed = normalizeParsedImageBlocks(
     await parseMarkdownBlocks(editor, preProcessWikilinks(withImages)),
   ) as EditorBlocks
@@ -762,7 +763,7 @@ function scheduleEmptyHeadingSwap(options: {
 
   if (extractBodyRemainderAfterEmptyH1({ content }) === null) return false
 
-  void resolveEmptyHeadingHtml(editor, content, vaultPath)
+  void resolveEmptyHeadingHtml(editor, content, vaultPath, targetPath)
     .then((html) => {
       if (prevActivePathRef.current !== targetPath || !html) return
       applyHtmlStateToEditor(editor, html, suppressChangeRef)

--- a/src/utils/vaultImages.test.ts
+++ b/src/utils/vaultImages.test.ts
@@ -43,6 +43,15 @@ describe('resolveImageUrls', () => {
     )
   })
 
+  it('decodes URL-encoded chars in relative attachment paths', () => {
+    tauriMode = true
+    const markdown = '![pic](attachments/sub/IMAGE%202022-10-15%2015%3A47%3A07.jpg)'
+
+    expect(resolveImageUrls(markdown, '/vault')).toBe(
+      `![pic](${assetUrl('/vault/attachments/sub/IMAGE 2022-10-15 15:47:07.jpg')})`,
+    )
+  })
+
   it('leaves already-correct asset URLs unchanged', () => {
     tauriMode = true
     const url = assetUrl('/vault/attachments/file.png')
@@ -101,6 +110,67 @@ describe('resolveImageUrls', () => {
     tauriMode = true
     const url = httpAssetUrl('/some/other/path/file.png')
     const markdown = `![alt](${url})`
+
+    expect(resolveImageUrls(markdown, '/vault')).toBe(markdown)
+  })
+
+  it('resolves ../-prefixed attachment paths against the note path', () => {
+    tauriMode = true
+    const notePath = '/vault/self+psy/apeiron/seminars/skazkoterapiya.md'
+    const markdown =
+      '![BlockNote image](../../../attachments/skazkoterapiya/IMAGE%202022-10-15%2015%3A47%3A07.jpg)'
+
+    expect(resolveImageUrls(markdown, '/vault', notePath)).toBe(
+      `![BlockNote image](${assetUrl('/vault/attachments/skazkoterapiya/IMAGE 2022-10-15 15:47:07.jpg')})`,
+    )
+  })
+
+  it('resolves ./-prefixed attachment paths against the note path', () => {
+    tauriMode = true
+    const notePath = '/vault/attachments/topic/note.md'
+    const markdown = '![pic](./image.png)'
+
+    expect(resolveImageUrls(markdown, '/vault', notePath)).toBe(
+      `![pic](${assetUrl('/vault/attachments/topic/image.png')})`,
+    )
+  })
+
+  it('leaves ../-prefixed paths that escape the vault unchanged', () => {
+    tauriMode = true
+    const notePath = '/vault/note.md'
+    const markdown = '![leak](../../../../etc/passwd)'
+
+    expect(resolveImageUrls(markdown, '/vault', notePath)).toBe(markdown)
+  })
+
+  it('leaves ../-prefixed paths that resolve outside the attachments folder unchanged', () => {
+    tauriMode = true
+    const notePath = '/vault/a/b/c.md'
+    const markdown = '![sibling](../other.md)'
+
+    expect(resolveImageUrls(markdown, '/vault', notePath)).toBe(markdown)
+  })
+
+  it('leaves ../-prefixed paths unchanged when notePath is not provided', () => {
+    tauriMode = true
+    const markdown = '![x](../../../attachments/file.png)'
+
+    expect(resolveImageUrls(markdown, '/vault')).toBe(markdown)
+  })
+
+  it('resolves leading-slash /attachments/ paths as vault-root-absolute', () => {
+    tauriMode = true
+    const markdown =
+      '![BlockNote image](/attachments/skazkoterapiya/IMAGE%202022-10-15%2015%3A47%3A07.jpg)'
+
+    expect(resolveImageUrls(markdown, '/vault')).toBe(
+      `![BlockNote image](${assetUrl('/vault/attachments/skazkoterapiya/IMAGE 2022-10-15 15:47:07.jpg')})`,
+    )
+  })
+
+  it('leaves other leading-slash paths unchanged', () => {
+    tauriMode = true
+    const markdown = '![etc](/etc/passwd)'
 
     expect(resolveImageUrls(markdown, '/vault')).toBe(markdown)
   })

--- a/src/utils/vaultImages.ts
+++ b/src/utils/vaultImages.ts
@@ -4,8 +4,8 @@ import { isTauri } from '../mock-tauri'
 const ASSET_URL_PREFIX = 'asset://localhost/'
 const HTTP_ASSET_URL_PREFIX = 'http://asset.localhost/'
 const ASSET_URL_PREFIXES = [ASSET_URL_PREFIX, HTTP_ASSET_URL_PREFIX]
-const ATTACHMENTS_SEGMENT = '/attachments/'
-const RELATIVE_ATTACHMENTS_PREFIX = 'attachments/'
+const ATTACHMENTS_PREFIX = 'attachments/'
+const ATTACHMENTS_ABSOLUTE_PREFIX = `/${ATTACHMENTS_PREFIX}`
 
 type Markdown = string
 type VaultPath = string
@@ -25,11 +25,11 @@ function vaultAttachmentPath(vaultPath: VaultPath, attachmentPath: AttachmentPat
 }
 
 function extractAttachmentPath(absolutePath: AbsolutePath): AttachmentPath | null {
-  const index = absolutePath.lastIndexOf(ATTACHMENTS_SEGMENT)
+  const index = absolutePath.lastIndexOf(ATTACHMENTS_ABSOLUTE_PREFIX)
   if (index === -1) return null
 
-  const filename = absolutePath.slice(index + ATTACHMENTS_SEGMENT.length)
-  return filename ? `${RELATIVE_ATTACHMENTS_PREFIX}${filename}` : null
+  const filename = absolutePath.slice(index + ATTACHMENTS_ABSOLUTE_PREFIX.length)
+  return filename ? `${ATTACHMENTS_PREFIX}${filename}` : null
 }
 
 function assetUrlPrefix(url: MarkdownImageUrl): string | null {
@@ -60,18 +60,35 @@ function rewriteMarkdownImages(
   })
 }
 
-export function resolveImageUrls(markdown: Markdown, vaultPath: VaultPath): Markdown {
+function resolveRelativeAgainstNote(url: MarkdownImageUrl, notePath: AbsolutePath): AbsolutePath | null {
+  try {
+    const noteDir = notePath.slice(0, notePath.lastIndexOf('/') + 1)
+    return decodeURIComponent(new URL(url, `file://${noteDir}`).pathname)
+  } catch {
+    return null
+  }
+}
+
+export function resolveImageUrls(
+  markdown: Markdown,
+  vaultPath: VaultPath,
+  notePath?: AbsolutePath,
+): Markdown {
   if (!isTauri() || !vaultPath) return markdown
 
   return rewriteMarkdownImages(markdown, (url) => {
-    if (url.startsWith(RELATIVE_ATTACHMENTS_PREFIX)) {
-      return assetUrl(vaultAttachmentPath(vaultPath, url))
+    const vaultRelative = url.startsWith('/') ? url.slice(1) : url
+    if (vaultRelative.startsWith(ATTACHMENTS_PREFIX)) {
+      return assetUrl(decodeURIComponent(vaultAttachmentPath(vaultPath, vaultRelative)))
     }
 
-    if (!isAssetUrl(url) || isCurrentVaultAsset(url, vaultPath)) {
-      return null
+    if ((url.startsWith('./') || url.startsWith('../')) && notePath) {
+      const resolved = resolveRelativeAgainstNote(url, notePath)
+      if (!resolved?.startsWith(`${vaultPath}/${ATTACHMENTS_PREFIX}`)) return null
+      return assetUrl(resolved)
     }
 
+    if (!isAssetUrl(url) || isCurrentVaultAsset(url, vaultPath)) return null
     const attachmentPath = extractAttachmentPath(decodeAssetPath(url))
     return attachmentPath ? assetUrl(vaultAttachmentPath(vaultPath, attachmentPath)) : null
   })
@@ -80,7 +97,7 @@ export function resolveImageUrls(markdown: Markdown, vaultPath: VaultPath): Mark
 export function portableImageUrls(markdown: Markdown, vaultPath: VaultPath): Markdown {
   if (!vaultPath) return markdown
 
-  const attachmentsPrefix = `${vaultPath}/${RELATIVE_ATTACHMENTS_PREFIX}`
+  const attachmentsPrefix = `${vaultPath}/${ATTACHMENTS_PREFIX}`
 
   return rewriteMarkdownImages(markdown, (url) => {
     if (!isAssetUrl(url)) return null
@@ -88,6 +105,6 @@ export function portableImageUrls(markdown: Markdown, vaultPath: VaultPath): Mar
     const absolutePath = decodeAssetPath(url)
     if (!absolutePath.startsWith(attachmentsPrefix)) return null
 
-    return `${RELATIVE_ATTACHMENTS_PREFIX}${absolutePath.slice(attachmentsPrefix.length)}`
+    return `${ATTACHMENTS_PREFIX}${absolutePath.slice(attachmentsPrefix.length)}`
   })
 }


### PR DESCRIPTION
## Summary

This PR fixes three independent but related problems with vault image handling, each in its own commit.

---

### 1. Resolve image attachment URLs across all vault note path forms (`7e4ea42`)

**Problem:** Images embedded in notes were rendering as broken depending on how the attachment path was written. Tolaria stores images as asset-protocol URLs (`asset://localhost/…`), but the rewrite pipeline in `resolveImageUrls` only handled the `attachments/` prefix form. Three other valid forms were silently dropped:

- **`../attachments/img.jpg`** — relative paths used by notes stored in subdirectories (e.g. `vault/notes/journal/today.md` referencing `../../attachments/img.jpg`). The rewriter had no `notePath` context, so it couldn't resolve the `../` traversal.
- **`/attachments/img.jpg`** — vault-root-absolute paths written by Obsidian and some other editors. The leading `/` caused the prefix match to fail.
- **`attachments/IMAGE%202022-10-15%2015%3A47%3A07.jpg`** — URL-encoded filenames (spaces encoded as `%20`, colons as `%3A`). The path was passed to `convertFileSrc` still encoded, which double-encoded it, producing a path that never existed on disk.

**Fix:**
- Added `notePath` parameter to `resolveImageUrls` so relative URLs can be resolved against the note's directory (using the browser's `URL` constructor).
- Added a branch for the leading-`/` form, stripping it before lookup.
- Wrapped paths in `decodeURIComponent` before handing them to `convertFileSrc`.
- Consolidated three near-identical attachment constants into two derived from a single base string to prevent this class of divergence from recurring.
- Both `useEditorTabSwap` call sites updated to pass `targetPath` as `notePath`.
- Full unit test coverage added for all four URL forms, including filenames with spaces and special characters.

---

### 2. Initialize Tauri asset protocol scope for vault images (`07b0762`)

**Problem:** Tauri's asset protocol requires the app to explicitly allow each directory before the webview can load files from it. The scope was only populated when `reload_vault` was called — but on a cold start (or when switching vaults for the first time), `reload_vault` is never invoked; `list_vault` is. This left the asset scope empty until the user triggered a manual reload, so every image request was rejected with *"asset protocol not configured to allow the path"*.

**Fix:**
- `list_vault` now calls `sync_vault_asset_scope` before scanning, so the scope is populated on the very first vault load.
- Added `prime_asset_scope_for_last_vault` called from `setup_app`: reads the persisted last-used vault path from settings and allows it before the webview even loads. This covers the common case where the user reopens the app to the same vault they had open before.
- Both additions are guarded with `#[cfg(desktop)]` so the mobile target is unaffected.

---

### 3. Open images in default viewer on Cmd+click (`0fae5c0`)

**Problem:** There was no way to inspect a high-resolution image at full size from the editor. BlockNote renders images scaled to fit the note column width, so photos and screenshots with fine detail (diagrams, dense text, high-DPI captures) are effectively unreadable inside the editor. Opening the file in the system viewer (Preview on macOS) lets the user zoom in, pan, and examine the image at its native resolution.

Double-click was attempted first but blocked by BlockNote: it re-renders the image block DOM on the first click (to show resize handles), which destroys the browser's double-click accumulation window.

**Fix:** Cmd+click (or Ctrl+click on Windows/Linux) on any image in the editor opens it in the system default viewer via `openPath`.

Implementation details:
- `useEditorImageActivation` hook attaches capture-phase `click` and `mousedown` listeners to the editor container. Capture phase is required to intercept before BlockNote's own handlers.
- `mousedown` with the modifier key calls `preventDefault` to suppress BlockNote's focus/selection changes on the target image.
- Path resolution handles both direct `<img>` clicks and clicks on BlockNote wrapper elements (resize handles, the visual media wrapper) by walking up to the nearest image ancestor via `IMAGE_ANCESTOR_SELECTOR`.
- Both `asset://localhost/` and `http://asset.localhost/` URL schemes are recognised and decoded to absolute filesystem paths.
- The Tauri `opener:allow-open-path` capability is scoped to `$HOME/**` — broad enough to cover any vault location under the user's home directory without granting unrestricted filesystem access. (The `opener:default` permission only covers URLs; `open_path` requires an explicit declaration.)
- Full test suite covers: both asset URL schemes, Cmd+click, Ctrl+click, plain click (no-op), non-image elements, images without asset-scheme src, clicks on BlockNote resize handles, and clicks on images outside the editor container.

## Test plan

- [ ] Open a note with images stored as `attachments/img.jpg`, `/attachments/img.jpg`, `../attachments/img.jpg`, and a filename with spaces — all should render without broken-image icons
- [ ] Cmd+click a high-resolution image in the editor — should open in Preview (macOS) at full native resolution for zooming
- [ ] Ctrl+click should do the same on Windows/Linux
- [ ] Plain click on an image should not open anything
- [ ] Cold-start the app (no prior `reload_vault` call) — images should load immediately without an asset-protocol error in the console
- [ ] `pnpm test` — all unit tests pass