### PR TITLE
feat: enhance IME handling in InlineWikilinkInput

### DIFF
--- a/src/components/InlineWikilinkInput.tsx
+++ b/src/components/InlineWikilinkInput.tsx
@@ -1,4 +1,5 @@
 import {
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -16,7 +17,11 @@ import {
   extractInlineWikilinkReferences,
   findActiveWikilinkQuery,
 } from './inlineWikilinkText'
-import { serializeInlineNode } from './inlineWikilinkDom'
+import {
+  readSelectionRange,
+  serializeInlineNode,
+  type InlineSelectionRange,
+} from './inlineWikilinkDom'
 import {
   buildPendingPasteState,
   type PendingPasteState,
@@ -145,6 +150,7 @@ export function InlineWikilinkInput({
     [entries, value],
   )
   const typeEntryMap = useMemo(() => buildTypeEntryMap(entries), [entries])
+  const isComposingRef = useRef(false)
   const {
     editorRef,
     selectionRange,
@@ -158,10 +164,17 @@ export function InlineWikilinkInput({
     value,
     onChange,
     inputRef,
+    isComposingRef,
   })
   const pendingPasteRef = useRef<PendingPasteState | null>(null)
-  const isComposingRef = useRef(false)
   const pendingCompositionInputRef = useRef(false)
+  const pendingFocusAfterRemountRef = useRef<InlineSelectionRange | null>(null)
+  useLayoutEffect(() => {
+    const target = pendingFocusAfterRemountRef.current
+    if (!target) return
+    pendingFocusAfterRemountRef.current = null
+    focusSelectionRange(target)
+  }, [focusSelectionRange, renderVersion])
   const activeQuery = useMemo(
     () => selectionRange.start === selectionRange.end
       ? findActiveWikilinkQuery(value, selectionIndex)
@@ -260,7 +273,27 @@ export function InlineWikilinkInput({
   const flushPendingCompositionInput = () => {
     if (isComposingRef.current || !pendingCompositionInputRef.current) return
     pendingCompositionInputRef.current = false
-    syncValueFromEditor()
+
+    const editor = editorRef.current
+    if (!editor) return
+
+    if (containsUnsupportedInlineContent(editor)) {
+      recoverUnsupportedMutation()
+      return
+    }
+
+    const nextValue = normalizeInlineWikilinkValue(serializeInlineNode(editor))
+    const nextSelection = readSelectionRange(editor)
+    const clampedSelection: InlineSelectionRange = {
+      start: Math.min(nextSelection.start, nextValue.length),
+      end: Math.min(nextSelection.end, nextValue.length),
+    }
+
+    const shouldRestoreFocus = document.activeElement === editor
+    pendingFocusAfterRemountRef.current = shouldRestoreFocus ? clampedSelection : null
+    onChange(nextValue)
+    setSelectionRange(clampedSelection)
+    forceRender((current) => current + 1)
   }
   const handleCompositionStart = () => {
     isComposingRef.current = true

--- a/src/components/WikilinkChatInput.test.tsx
+++ b/src/components/WikilinkChatInput.test.tsx
@@ -211,6 +211,71 @@ describe('WikilinkChatInput', () => {
     expect(screen.getByTestId('wikilink-menu').textContent).toContain('Alpha')
   })
 
+  it('clears IME-injected stray text nodes after composition ends', async () => {
+    const onDraftChange = vi.fn()
+    render(<Controlled onDraftChange={onDraftChange} />)
+    const initialEditor = screen.getByTestId('agent-input') as HTMLDivElement
+    initialEditor.focus()
+
+    fireEvent.compositionStart(initialEditor)
+    initialEditor.appendChild(document.createTextNode('你'))
+    fireEvent.input(initialEditor)
+    fireEvent.compositionEnd(initialEditor)
+
+    await waitFor(() => {
+      expect(onDraftChange).toHaveBeenCalledWith('你')
+    })
+    await waitFor(() => {
+      const editor = screen.getByTestId('agent-input') as HTMLDivElement
+      expect(editor.textContent).toBe('你')
+    })
+  })
+
+  it('does not steal focus back if it was moved elsewhere during composition end', async () => {
+    const onDraftChange = vi.fn()
+    render(
+      <>
+        <Controlled onDraftChange={onDraftChange} />
+        <button data-testid="other-target">Other</button>
+      </>,
+    )
+    const initialEditor = screen.getByTestId('agent-input') as HTMLDivElement
+    const otherTarget = screen.getByTestId('other-target') as HTMLButtonElement
+    initialEditor.focus()
+
+    fireEvent.compositionStart(initialEditor)
+    initialEditor.appendChild(document.createTextNode('你'))
+    fireEvent.input(initialEditor)
+
+    otherTarget.focus()
+    fireEvent.compositionEnd(initialEditor)
+
+    await waitFor(() => {
+      expect(onDraftChange).toHaveBeenCalledWith('你')
+    })
+    expect(document.activeElement).toBe(otherTarget)
+  })
+
+  it('does not reset the DOM selection while IME composition is active', () => {
+    const removeAllRanges = vi.spyOn(Selection.prototype, 'removeAllRanges')
+    render(<Controlled />)
+    const editor = screen.getByTestId('agent-input') as HTMLDivElement
+    editor.focus()
+
+    fireEvent.compositionStart(editor)
+    editor.appendChild(document.createTextNode('ni'))
+    setSelection(editor, 2)
+
+    removeAllRanges.mockClear()
+    fireEvent.keyUp(editor)
+    fireEvent.click(editor)
+
+    expect(removeAllRanges).not.toHaveBeenCalled()
+    expect(editor.textContent).toContain('ni')
+
+    removeAllRanges.mockRestore()
+  })
+
   it('deletes an inline chip with a single Backspace', () => {
     render(<Controlled />)
     updateEditorText('edit my [[alp')

--- a/src/components/useInlineWikilinkSelection.ts
+++ b/src/components/useInlineWikilinkSelection.ts
@@ -16,12 +16,14 @@ interface UseInlineWikilinkSelectionArgs {
   value: string
   onChange: (value: string) => void
   inputRef?: React.RefObject<HTMLDivElement | null>
+  isComposingRef?: React.RefObject<boolean>
 }
 
 export function useInlineWikilinkSelection({
   value,
   onChange,
   inputRef,
+  isComposingRef,
 }: UseInlineWikilinkSelectionArgs) {
   const editorRef = useRef<HTMLDivElement | null>(null)
   const [selectionRange, setSelectionRange] = useState<InlineSelectionRange>({
@@ -38,8 +40,9 @@ export function useInlineWikilinkSelection({
 
   const syncSelectionRange = useCallback(() => {
     if (!editorRef.current) return
+    if (isComposingRef?.current) return
     setSelectionRange(readSelectionRange(editorRef.current))
-  }, [])
+  }, [isComposingRef])
 
   const focusSelectionRange = useCallback((nextSelectionRange: InlineSelectionRange) => {
     const editor = editorRef.current
@@ -65,8 +68,9 @@ export function useInlineWikilinkSelection({
     const editor = editorRef.current
     if (!editor) return
     if (document.activeElement !== editor) return
+    if (isComposingRef?.current) return
     applySelectionRange(editor, selectionRange)
-  }, [selectionRange, value])
+  }, [isComposingRef, selectionRange, value])
 
   return {
     editorRef,


### PR DESCRIPTION
## Problem

#<60554d0b> handled IME composition at the React-state layer (skipping `syncValueFromEditor` and keydown-driven business logic during composition). Three issues remain visible in long compositions like Pinyin / Wubi / Kana, where the IME holds an active session for many keystrokes:

1. **Selection sync bypasses `isComposing`.** `onKeyUp` / `onClick` / `onMouseUp` still call `syncSelectionRange` in `useInlineWikilinkSelection`, which runs `setSelectionRange` → re-render → `useLayoutEffect` → `selection.removeAllRanges()` + `addRange()`. That tears down the IME composition context on every keystroke, producing scrambled previews mixing pinyin letters, committed glyphs, and the temporary IME preview.
2. **Stray text nodes after `compositionend`.** WebKit/Blink commit the final glyphs as a sibling text node next to the React-rendered `<span>`. `serializeInlineNode` picks them up so React state ends up with the right value, but the orphan node is never removed by reconciliation. Visible result: every committed character is duplicated.
3. **Focus theft on flush.** If the user moves focus away mid-composition (e.g. clicks Send or a sidebar item), `compositionend` fires on the original element and the post-flush focus restore steals the focus back.

## Solution

- Plumb `isComposingRef` into `useInlineWikilinkSelection` and short-circuit both `syncSelectionRange` and the layout-effect selection application during composition.
- On `compositionend` flush, force a remount of the contenteditable subtree (via a `renderVersion` bump) so any IME-injected stray text nodes are dropped along with the old DOM.
- Capture the target selection in a ref and restore it in a layout effect after the remount, but only refocus when the editor still owned `document.activeElement` at flush time, to avoid stealing focus.

## Tests

New regressions in `src/components/WikilinkChatInput.test.tsx`:
- `does not reset the DOM selection while IME composition is active`
- `clears IME-injected stray text nodes after composition ends`
- `does not steal focus back if it was moved elsewhere during composition end`

Each test was reverse-verified by undoing the corresponding fix and confirming it failed. Full vitest suite green.

## Why this didn't show up before

The existing test suite asserts callback invocations (React semantics) and runs in jsdom, which doesn't simulate the two real-browser side effects above (the browser-driven `Selection.collapse()` and the orphan text node). The new regression tests inject those side effects manually.

## QA

Manual native QA on macOS WKWebView: typed Pinyin into `AiPanel` and `CommandPaletteAiMode`, confirmed no scrambling, no duplication, and no focus theft when clicking sidebar / Send mid-composition.