### PR TITLE
fix: insert file/folder paths dropped from Finder into AI chat input

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "backgroundColor": "#F7F6F3",
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/src/components/InlineWikilinkInput.test.tsx
+++ b/src/components/InlineWikilinkInput.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { InlineWikilinkInput } from './InlineWikilinkInput'
+
+let tauriMode = false
+
+// JSDOM does not implement elementFromPoint — install a configurable stub.
+const elementFromPointMock = vi.fn<[number, number], Element | null>(() => null)
+beforeAll(() => {
+  Object.defineProperty(document, 'elementFromPoint', {
+    value: elementFromPointMock,
+    writable: true,
+    configurable: true,
+  })
+})
+
+vi.mock('../mock-tauri', () => ({
+  isTauri: () => tauriMode,
+}))
+
+type DropPayload = { paths: string[]; position: { x: number; y: number } }
+type DropCallback = (event: { payload: DropPayload }) => void
+let capturedDropHandler: DropCallback | undefined
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    listen: vi.fn((_eventName: string, cb: DropCallback) => {
+      capturedDropHandler = cb
+      return Promise.resolve(() => { capturedDropHandler = undefined })
+    }),
+  }),
+}))
+
+function renderInput(onChange = vi.fn()) {
+  render(
+    <InlineWikilinkInput
+      entries={[]}
+      value=""
+      onChange={onChange}
+      dataTestId="test-input"
+    />,
+  )
+  return { onChange }
+}
+
+describe('InlineWikilinkInput — Tauri file drop', () => {
+  beforeEach(() => {
+    tauriMode = true
+    capturedDropHandler = undefined
+  })
+
+  afterEach(() => {
+    tauriMode = false
+    capturedDropHandler = undefined
+  })
+
+  it('registers a tauri://drag-drop listener when running in Tauri', async () => {
+    renderInput()
+    await waitFor(() => expect(capturedDropHandler).toBeDefined())
+  })
+
+  it('inserts a dropped folder path into the input', async () => {
+    const onChange = vi.fn()
+    renderInput(onChange)
+    await waitFor(() => expect(capturedDropHandler).toBeDefined())
+
+    const input = screen.getByTestId('test-input')
+    // Simulate the drop landing on the input element
+    elementFromPointMock.mockReturnValue(input)
+
+    act(() => {
+      capturedDropHandler!({
+        payload: { paths: ['/Users/alice/Projects/my-folder'], position: { x: 100, y: 200 } },
+      })
+    })
+
+    expect(onChange).toHaveBeenCalledWith('/Users/alice/Projects/my-folder')
+  })
+
+  it('inserts multiple dropped paths joined by newlines', async () => {
+    const onChange = vi.fn()
+    renderInput(onChange)
+    await waitFor(() => expect(capturedDropHandler).toBeDefined())
+
+    const input = screen.getByTestId('test-input')
+    elementFromPointMock.mockReturnValue(input)
+
+    act(() => {
+      capturedDropHandler!({
+        payload: {
+          paths: ['/Users/alice/a', '/Users/alice/b'],
+          position: { x: 100, y: 200 },
+        },
+      })
+    })
+
+    expect(onChange).toHaveBeenCalledWith('/Users/alice/a\n/Users/alice/b')
+  })
+
+  it('ignores drops that land outside the input element', async () => {
+    const onChange = vi.fn()
+    renderInput(onChange)
+    await waitFor(() => expect(capturedDropHandler).toBeDefined())
+
+    // Simulate drop landing elsewhere (e.g. the editor)
+    const otherEl = document.createElement('div')
+    elementFromPointMock.mockReturnValue(otherEl)
+
+    act(() => {
+      capturedDropHandler!({
+        payload: { paths: ['/Users/alice/folder'], position: { x: 50, y: 50 } },
+      })
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when paths array is empty', async () => {
+    const onChange = vi.fn()
+    renderInput(onChange)
+    await waitFor(() => expect(capturedDropHandler).toBeDefined())
+
+    act(() => {
+      capturedDropHandler!({ payload: { paths: [], position: { x: 100, y: 200 } } })
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('does not register a listener when not running in Tauri', async () => {
+    tauriMode = false
+    renderInput()
+    // Give the effect time to run
+    await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+    expect(capturedDropHandler).toBeUndefined()
+  })
+})

--- a/src/components/InlineWikilinkInput.tsx
+++ b/src/components/InlineWikilinkInput.tsx
@@ -1,9 +1,13 @@
 import {
+  useEffect,
   useMemo,
   useRef,
   useState,
   type ReactNode,
 } from 'react'
+import type { UnlistenFn } from '@tauri-apps/api/event'
+import type { DragDropEvent as TauriDragDropPayload } from '@tauri-apps/api/webview'
+import { isTauri } from '../mock-tauri'
 import type { VaultEntry } from '../types'
 import type { NoteReference } from '../utils/ai-context'
 import { buildTypeEntryMap } from '../utils/typeColors'
@@ -280,6 +284,55 @@ export function InlineWikilinkInput({
   }
   const submitValue = () =>
     submitInlineValue({ onSubmit, submitOnEmpty, value, references })
+  const insertTextRef = useRef(insertText)
+  insertTextRef.current = insertText
+
+  useEffect(() => {
+    if (!isTauri()) return
+
+    let unlisten: UnlistenFn | null = null
+    let mounted = true
+
+    void (async () => {
+      try {
+        const { getCurrentWebview } = await import('@tauri-apps/api/webview')
+        // The runtime payload in Tauri v2 is { paths, position } without a type
+        // discriminant, so we don't check event.payload.type here.
+        const fn = await getCurrentWebview().listen<TauriDragDropPayload>(
+          'tauri://drag-drop',
+          (event) => {
+            const paths: string[] = Array.isArray(
+              (event.payload as unknown as { paths?: unknown }).paths,
+            )
+              ? (event.payload as unknown as { paths: string[] }).paths
+              : []
+            if (paths.length === 0) return
+
+            const pos = (event.payload as unknown as { position?: { x: number; y: number } })
+              .position
+            if (pos) {
+              const input = editorRef.current
+              if (!input) return
+              const el = document.elementFromPoint(pos.x, pos.y)
+              if (!el || (!input.contains(el) && el !== input)) return
+            }
+
+            insertTextRef.current(paths.join('\n'))
+          },
+        )
+        if (mounted) unlisten = fn
+        else void Promise.resolve().then(fn).catch(() => {})
+      } catch {
+        // Tauri webview API unavailable
+      }
+    })()
+
+    return () => {
+      mounted = false
+      if (unlisten) void Promise.resolve().then(unlisten).catch(() => {})
+      unlisten = null
+    }
+  }, [])
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) =>
     handleInlineWikilinkKeyDown({
       event,

--- a/src/components/InlineWikilinkParts.tsx
+++ b/src/components/InlineWikilinkParts.tsx
@@ -164,6 +164,8 @@ export function InlineWikilinkEditorField({
   onInput,
   onKeyDown,
   onPaste,
+  onDrop,
+  onDragOver,
   onSelectionChange,
   segments,
   typeEntryMap,
@@ -180,6 +182,8 @@ export function InlineWikilinkEditorField({
   onInput: () => void
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
   onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
+  onDrop?: (event: React.DragEvent<HTMLDivElement>) => void
+  onDragOver?: (event: React.DragEvent<HTMLDivElement>) => void
   onSelectionChange: () => void
   segments: InlineWikilinkSegment[]
   typeEntryMap: Record<string, VaultEntry>
@@ -216,6 +220,8 @@ export function InlineWikilinkEditorField({
         onInput={onInput}
         onKeyDown={onKeyDown}
         onPaste={onPaste}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
         onClick={onSelectionChange}
         onKeyUp={onSelectionChange}
         onMouseUp={onSelectionChange}

--- a/src/hooks/useImageDrop.ts
+++ b/src/hooks/useImageDrop.ts
@@ -150,16 +150,26 @@ export function useImageDrop({ containerRef, onImageUrl, vaultPath }: UseImageDr
     void (async () => {
       try {
         const nextUnlisteners = await registerNativeDropListeners((event) => {
-          if (event.payload.type === 'drop') {
-            setIsDragOver(false)
-            insertDroppedImages(
-              event.payload.paths.filter(isImagePath),
-              vaultPathRef.current,
-              onImageUrlRef.current,
-            )
-            return
-          }
           setIsDragOver(false)
+          // Runtime payload in Tauri v2 is { paths, position } without a type field.
+          const paths: string[] = Array.isArray(
+            (event.payload as unknown as { paths?: unknown }).paths,
+          )
+            ? (event.payload as unknown as { paths: string[] }).paths
+            : []
+          if (paths.length === 0) return
+          const pos = (event.payload as unknown as { position?: { x: number; y: number } })
+            .position
+          const container = containerRef.current
+          if (container && pos) {
+            try {
+              const el = document.elementFromPoint(pos.x, pos.y)
+              if (!el || (!container.contains(el) && el !== container)) return
+            } catch {
+              // elementFromPoint unavailable (e.g. JSDOM); skip position check
+            }
+          }
+          insertDroppedImages(paths.filter(isImagePath), vaultPathRef.current, onImageUrlRef.current)
         })
         if (mounted) unlisteners = nextUnlisteners
         else cleanupNativeDropListeners(nextUnlisteners)


### PR DESCRIPTION
  Dragging a file or folder from macOS Finder into the AI chat composer
  now inserts its filesystem path as text. Enables Tauri's native drag-drop
  event system (dragDropEnabled: true) to access real filesystem paths, adds
  a tauri://drag-drop listener to the AI input with position-checking so
  drops only apply to the input, and fixes a broken type-discriminant check
  in useImageDrop that was silently swallowing all Tauri drop events.

  Fixes #302