### PR TITLE
fix: disable macOS native text suggestions across all inputs

### DIFF
--- a/src/components/ColorInput.tsx
+++ b/src/components/ColorInput.tsx
@@ -91,6 +91,10 @@ export function ColorEditableValue({ value, isEditing, onStartEdit, onSave, onCa
           onChange={(e) => setEditValue(e.target.value)}
           onKeyDown={handleKeyDown}
           onBlur={() => onSave(editValue)}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
           autoFocus
           data-testid="color-text-input"
         />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -131,6 +131,10 @@ function CommandPaletteInput({
       placeholder="Type a command..."
       value={query}
       onChange={(event) => onChange(event.target.value)}
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck={false}
     />
   )
 }

--- a/src/components/EditableValue.tsx
+++ b/src/components/EditableValue.tsx
@@ -59,6 +59,10 @@ export function UrlValue({
         onChange={(e) => setEditValue(e.target.value)}
         onKeyDown={handleKeyDown}
         onBlur={() => onSave(editValue)}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         autoFocus
       />
     )
@@ -119,6 +123,10 @@ export function EditableValue({
         onChange={(e) => setEditValue(e.target.value)}
         onKeyDown={handleKeyDown}
         onBlur={() => onSave(editValue)}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         autoFocus
       />
     )
@@ -208,6 +216,10 @@ export function TagPillList({
             onChange={(e) => setEditValue(e.target.value)}
             onKeyDown={(e) => handleKeyDown(e, 'edit')}
             onBlur={handleSaveEdit}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
             autoFocus
           />
         ) : (
@@ -250,6 +262,10 @@ export function TagPillList({
             else { setIsAddingNew(false); setNewValue('') }
           }}
           placeholder={`${label}...`}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
           autoFocus
         />
       ) : (

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -62,6 +62,10 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
           placeholder="Search emoji by name..."
           value={search}
           onChange={e => setSearch(e.target.value)}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
           data-testid="emoji-picker-search"
         />
       </div>

--- a/src/components/InlineWikilinkParts.tsx
+++ b/src/components/InlineWikilinkParts.tsx
@@ -205,6 +205,10 @@ export function InlineWikilinkEditorField({
         aria-disabled={disabled || undefined}
         aria-placeholder={placeholder}
         data-testid={dataTestId}
+        autoCorrect="off"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
         className={cn(
           'min-h-[34px] w-full rounded-lg border border-border bg-transparent px-[10px] py-[8px] text-[13px] text-foreground outline-none',
           disabled && 'cursor-not-allowed opacity-60',

--- a/src/components/InlineWikilinkParts.tsx
+++ b/src/components/InlineWikilinkParts.tsx
@@ -206,7 +206,6 @@ export function InlineWikilinkEditorField({
         aria-placeholder={placeholder}
         data-testid={dataTestId}
         autoCorrect="off"
-        autoComplete="off"
         autoCapitalize="off"
         spellCheck={false}
         className={cn(

--- a/src/components/NoteAutocomplete.tsx
+++ b/src/components/NoteAutocomplete.tsx
@@ -131,6 +131,10 @@ export function NoteAutocomplete({ entries, typeEntryMap, value, onChange, onSel
         onChange={handleChange}
         onFocus={() => setOpen(true)}
         onKeyDown={handleKeyDown}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         data-testid={testId}
       />
       {open && matches.length > 0 && (

--- a/src/components/QuickOpenPalette.tsx
+++ b/src/components/QuickOpenPalette.tsx
@@ -63,6 +63,10 @@ export function QuickOpenPalette({ open, entries, onSelect, onClose }: QuickOpen
           placeholder="Search notes..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
         />
         <NoteSearchList
           items={results}

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -140,6 +140,10 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={query}
           onChange={e => onChange(e.target.value)}
           onKeyDown={onKeyDown}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
         />
         {loading && (
           <svg

--- a/src/components/SidebarParts.tsx
+++ b/src/components/SidebarParts.tsx
@@ -329,6 +329,10 @@ function InlineRenameInput({ initialValue, onSubmit, onCancel }: {
       aria-label="Section name"
       className="flex-1 rounded border border-primary bg-background text-[13px] font-medium text-foreground outline-none"
       style={{ padding: '1px 4px' }}
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck={false}
     />
   )
 }

--- a/src/components/SingleEditorView.tsx
+++ b/src/components/SingleEditorView.tsx
@@ -420,6 +420,15 @@ export function SingleEditorView({ editor, entries, onNavigateWikilink, onChange
     _wikilinkEntriesRef.current = entries
   }, [entries])
 
+  useEffect(() => {
+    const el = containerRef.current?.querySelector<HTMLElement>('[contenteditable]')
+    if (!el) return
+    el.setAttribute('spellcheck', 'false')
+    el.setAttribute('autocorrect', 'off')
+    el.setAttribute('autocomplete', 'off')
+    el.setAttribute('autocapitalize', 'off')
+  }, [])
+
   useSeedBlockNoteTableBridge(editor)
 
   const typeEntryMap = useMemo(() => buildTypeEntryMap(entries), [entries])

--- a/src/components/StatusDropdown.tsx
+++ b/src/components/StatusDropdown.tsx
@@ -316,6 +316,10 @@ export function StatusDropdown({
                 value={query}
                 onChange={e => handleQueryChange(e.target.value)}
                 onKeyDown={handleKeyDown}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
                 data-testid="status-search-input"
               />
             </div>

--- a/src/components/TagsDropdown.tsx
+++ b/src/components/TagsDropdown.tsx
@@ -261,6 +261,10 @@ export function TagsDropdown({
                 value={query}
                 onChange={e => handleQueryChange(e.target.value)}
                 onKeyDown={handleKeyDown}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
                 data-testid="tags-search-input"
               />
             </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -13,6 +13,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck={false}
       {...props}
     />
   )

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -13,6 +13,10 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck={false}
       {...props}
     />
   ),

--- a/src/hooks/useCodeMirror.ts
+++ b/src/hooks/useCodeMirror.ts
@@ -149,6 +149,7 @@ export function useCodeMirror(
         frontmatterHighlightTheme(),
         frontmatterHighlightPlugin,
         zoomCursorFix(),
+        EditorView.contentAttributes.of({ spellcheck: 'false', autocorrect: 'off', autocomplete: 'off', autocapitalize: 'off' }),
         EditorView.updateListener.of((update) => {
           if (update.docChanged && !externalSyncRef.current) {
             callbacksRef.current.onDocChange(update.state.doc.toString())


### PR DESCRIPTION
Fixes #278

Adds spellcheck="false", autocorrect="off", autocapitalize="off", and autocomplete="off" to all text inputs, textareas, and contenteditable elements to suppress macOS native text prediction/autocorrect popups.

## Changes
- src/components/ui/input.tsx / textarea.tsx -- shared shadcn components (covers all consumers)
- src/components/CommandPalette.tsx, QuickOpenPalette.tsx, SearchPanel.tsx, EmojiPicker.tsx, NoteAutocomplete.tsx, SidebarParts.tsx -- search/inline inputs
- src/components/TagsDropdown.tsx, StatusDropdown.tsx -- property dropdowns
- src/components/EditableValue.tsx, ColorInput.tsx -- editable property fields
- src/components/InlineWikilinkParts.tsx -- AI composer contenteditable div
- src/hooks/useCodeMirror.ts -- CodeMirror contenteditable via EditorView.contentAttributes
- src/components/SingleEditorView.tsx -- BlockNote/ProseMirror contenteditable via useEffect + setAttribute