### PR TITLE
fix: AI agent CLIs reliably surface errors and accept tilde vault paths

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'src-tauri/resources/', 'src-tauri/target/', 'src-tauri/gen/', 'tools/']),
+  globalIgnores(['dist', 'coverage', 'src-tauri/resources/', 'src-tauri/target/', 'src-tauri/gen/', 'tools/', '.claude/']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src-tauri/src/ai_agents.rs
+++ b/src-tauri/src/ai_agents.rs
@@ -287,6 +287,20 @@ where
                 });
             }
         }
+        "error" => {
+            if let Some(message) = json["message"].as_str() {
+                emit(AiAgentStreamEvent::Error {
+                    message: message.to_string(),
+                });
+            }
+        }
+        "turn.failed" => {
+            if let Some(message) = json["error"]["message"].as_str() {
+                emit(AiAgentStreamEvent::Error {
+                    message: message.to_string(),
+                });
+            }
+        }
         "item.started" => emit_codex_item_event(json, false, emit),
         "item.completed" => emit_codex_item_event(json, true, emit),
         _ => {}
@@ -471,6 +485,39 @@ mod tests {
         assert!(matches!(
             &events[0],
             AiAgentStreamEvent::TextDelta { text } if text == "All set"
+        ));
+    }
+
+    #[test]
+    fn dispatch_codex_error_event_maps_to_error() {
+        let mut events = Vec::new();
+        let error = serde_json::json!({
+            "type": "error",
+            "message": "The configured model requires a newer Codex CLI."
+        });
+
+        dispatch_codex_event(&error, &mut |event| events.push(event));
+
+        assert!(matches!(
+            &events[0],
+            AiAgentStreamEvent::Error { message }
+                if message == "The configured model requires a newer Codex CLI."
+        ));
+    }
+
+    #[test]
+    fn dispatch_codex_turn_failed_event_maps_to_error() {
+        let mut events = Vec::new();
+        let failed = serde_json::json!({
+            "type": "turn.failed",
+            "error": { "message": "unexpected status 400 Bad Request" }
+        });
+
+        dispatch_codex_event(&failed, &mut |event| events.push(event));
+
+        assert!(matches!(
+            &events[0],
+            AiAgentStreamEvent::Error { message } if message == "unexpected status 400 Bad Request"
         ));
     }
 

--- a/src-tauri/src/ai_agents.rs
+++ b/src-tauri/src/ai_agents.rs
@@ -66,10 +66,18 @@ pub fn get_ai_agents_status() -> AiAgentsStatus {
     }
 }
 
-pub fn run_ai_agent_stream<F>(request: AiAgentStreamRequest, mut emit: F) -> Result<String, String>
+fn normalize_ai_agent_request(request: &mut AiAgentStreamRequest) {
+    request.vault_path = crate::commands::expand_tilde(&request.vault_path).into_owned();
+}
+
+pub fn run_ai_agent_stream<F>(
+    mut request: AiAgentStreamRequest,
+    mut emit: F,
+) -> Result<String, String>
 where
     F: FnMut(AiAgentStreamEvent),
 {
+    normalize_ai_agent_request(&mut request);
     match request.agent {
         AiAgentId::ClaudeCode => {
             let mapped = crate::claude_cli::AgentStreamRequest {
@@ -404,6 +412,34 @@ mod tests {
         let status = get_ai_agents_status();
         assert!(matches!(status.claude_code.installed, true | false));
         assert!(matches!(status.codex.installed, true | false));
+    }
+
+    #[test]
+    fn normalize_ai_agent_request_expands_tilde_vault_path() {
+        let home = dirs::home_dir().expect("home dir available in test env");
+        let mut request = AiAgentStreamRequest {
+            agent: AiAgentId::ClaudeCode,
+            message: "ignored".into(),
+            system_prompt: None,
+            vault_path: "~/Vaults/work".into(),
+        };
+        normalize_ai_agent_request(&mut request);
+        assert_eq!(
+            request.vault_path,
+            home.join("Vaults").join("work").to_string_lossy(),
+        );
+    }
+
+    #[test]
+    fn normalize_ai_agent_request_leaves_absolute_paths_intact() {
+        let mut request = AiAgentStreamRequest {
+            agent: AiAgentId::Codex,
+            message: "ignored".into(),
+            system_prompt: None,
+            vault_path: "/var/data/vault".into(),
+        };
+        normalize_ai_agent_request(&mut request);
+        assert_eq!(request.vault_path, "/var/data/vault");
     }
 
     #[test]

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -440,10 +440,16 @@ where
                 state.session_id = sid.clone();
             }
             let text = json["result"].as_str().unwrap_or("").to_string();
-            emit(ClaudeStreamEvent::Result {
-                text,
-                session_id: sid,
-            });
+            if json["is_error"].as_bool() == Some(true) {
+                emit(ClaudeStreamEvent::Error {
+                    message: format_claude_result_error(json, &text),
+                });
+            } else {
+                emit(ClaudeStreamEvent::Result {
+                    text,
+                    session_id: sid,
+                });
+            }
         }
 
         // --- Complete assistant message (fallback for text when no partials) ---
@@ -467,6 +473,25 @@ where
         }
 
         _ => {} // ignore other event types
+    }
+}
+
+fn format_claude_result_error(json: &serde_json::Value, result_text: &str) -> String {
+    let trimmed = result_text.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+
+    if let Some(error) = json["error"]
+        .as_str()
+        .filter(|error| !error.trim().is_empty())
+    {
+        return error.trim().to_string();
+    }
+
+    match json["api_error_status"].as_i64() {
+        Some(status) => format!("Claude CLI API request failed with status {status}"),
+        None => "Claude CLI request failed".into(),
     }
 }
 
@@ -687,6 +712,35 @@ mod tests {
         assert_eq!(sid, "sess-456");
         assert!(
             matches!(&events[0], ClaudeStreamEvent::Result { text, session_id } if text == "All done!" && session_id == "sess-456")
+        );
+    }
+
+    #[test]
+    fn dispatch_event_handles_error_result() {
+        let (sid, events) = run_dispatch(serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": true,
+            "api_error_status": 400,
+            "result": "Credit balance is too low",
+            "session_id": "sess-err"
+        }));
+        assert_eq!(sid, "sess-err");
+        assert!(
+            matches!(&events[0], ClaudeStreamEvent::Error { message } if message == "Credit balance is too low")
+        );
+    }
+
+    #[test]
+    fn dispatch_event_error_result_falls_back_to_status() {
+        let (_, events) = run_dispatch(serde_json::json!({
+            "type": "result",
+            "is_error": true,
+            "api_error_status": 429,
+            "result": ""
+        }));
+        assert!(
+            matches!(&events[0], ClaudeStreamEvent::Error { message } if message.contains("429"))
         );
     }
 

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -226,13 +226,18 @@ fn build_chat_args(req: &ChatStreamRequest) -> Vec<String> {
 }
 
 /// Spawn `claude -p` with full tool access and MCP vault tools for an agent task.
-pub fn run_agent_stream<F>(req: AgentStreamRequest, mut emit: F) -> Result<String, String>
+pub fn run_agent_stream<F>(mut req: AgentStreamRequest, mut emit: F) -> Result<String, String>
 where
     F: FnMut(ClaudeStreamEvent),
 {
+    normalize_agent_request(&mut req);
     let bin = find_claude_binary()?;
     let args = build_agent_args(&req)?;
     run_claude_subprocess(&bin, &args, Some(&req.vault_path), &mut emit)
+}
+
+fn normalize_agent_request(req: &mut AgentStreamRequest) {
+    req.vault_path = crate::commands::expand_tilde(&req.vault_path).into_owned();
 }
 
 /// Build CLI arguments for an agent stream request.
@@ -1199,6 +1204,32 @@ mod tests {
         let result = run_claude_subprocess(&fake_bin, &[], None, &mut |e| events.push(e));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Failed to spawn"));
+    }
+
+    #[test]
+    fn normalize_agent_request_expands_tilde_vault_path() {
+        let home = dirs::home_dir().expect("home dir available in test env");
+        let mut req = AgentStreamRequest {
+            message: "ignored".into(),
+            system_prompt: None,
+            vault_path: "~/Documents/vault".into(),
+        };
+        normalize_agent_request(&mut req);
+        assert_eq!(
+            req.vault_path,
+            home.join("Documents").join("vault").to_string_lossy(),
+        );
+    }
+
+    #[test]
+    fn normalize_agent_request_leaves_absolute_paths_intact() {
+        let mut req = AgentStreamRequest {
+            message: "ignored".into(),
+            system_prompt: None,
+            vault_path: "/var/data/vault".into(),
+        };
+        normalize_agent_request(&mut req);
+        assert_eq!(req.vault_path, "/var/data/vault");
     }
 
     #[cfg(unix)]

--- a/src/components/InlineWikilinkParts.tsx
+++ b/src/components/InlineWikilinkParts.tsx
@@ -189,10 +189,10 @@ export function InlineWikilinkEditorField({
   const needsTrailingCaretAnchor = segments[segments.length - 1]?.kind === 'chip'
 
   return (
-    <div className="relative">
+    <div className="relative group">
       {value.length === 0 && placeholder && (
         <div
-          className="pointer-events-none absolute inset-0 flex items-center text-muted-foreground"
+          className="pointer-events-none absolute inset-0 flex items-center text-muted-foreground group-focus-within:hidden"
           style={{ padding: '8px 10px', fontSize: 13 }}
         >
           {placeholder}

--- a/src/components/WikilinkChatInput.test.tsx
+++ b/src/components/WikilinkChatInput.test.tsx
@@ -148,6 +148,13 @@ describe('WikilinkChatInput', () => {
     expect(screen.getByTestId('agent-input')).toHaveAttribute('aria-placeholder', 'Ask something...')
   })
 
+  it('hides the placeholder overlay via group-focus-within when the editor is focused', () => {
+    render(<Controlled placeholder="Ask something..." />)
+    const overlay = screen.getByText('Ask something...')
+    expect(overlay).toHaveClass('group-focus-within:hidden')
+    expect(overlay.parentElement).toHaveClass('group')
+  })
+
   it('calls onChange when the draft changes', () => {
     const onChange = vi.fn()
     render(

--- a/src/lib/aiAgentStreamCallbacks.test.ts
+++ b/src/lib/aiAgentStreamCallbacks.test.ts
@@ -152,6 +152,52 @@ describe('aiAgentStreamCallbacks', () => {
     ])
   })
 
+  it('keeps the error message when the backend sends Done after Error', () => {
+    const messages = createMessageStore([
+      {
+        id: 'msg-1',
+        userMessage: 'Question',
+        actions: [{
+          tool: 'Bash',
+          toolId: 'tool-1',
+          label: 'Ran shell command',
+          status: 'pending',
+        }],
+        isStreaming: true,
+      },
+    ])
+    const status = createStatusStore('thinking')
+
+    const callbacks = createStreamCallbacks({
+      messageId: 'msg-1',
+      vaultPath: '/vault',
+      setMessages: messages.setMessages,
+      setStatus: status.setStatus,
+      abortRef: { current: { aborted: false } },
+      responseAccRef: { current: '' },
+      toolInputMapRef: { current: new Map() },
+      fileCallbacksRef: { current: undefined },
+    })
+
+    callbacks.onError('Credit balance is too low')
+    callbacks.onDone()
+
+    expect(status.getStatus()).toBe('error')
+    expect(messages.getMessages()[0]).toEqual({
+      id: 'msg-1',
+      userMessage: 'Question',
+      actions: [{
+        tool: 'Bash',
+        toolId: 'tool-1',
+        label: 'Ran shell command',
+        status: 'error',
+      }],
+      isStreaming: false,
+      reasoningDone: true,
+      response: 'Error: Credit balance is too low',
+    })
+  })
+
   it('finishes with a readable empty state when Claude exits without assistant text', () => {
     const messages = createMessageStore([
       {

--- a/src/lib/aiAgentStreamCallbacks.ts
+++ b/src/lib/aiAgentStreamCallbacks.ts
@@ -37,6 +37,7 @@ export function createStreamCallbacks(context: StreamMutationContext) {
     toolInputMapRef,
     fileCallbacksRef,
   } = context
+  let hasErrored = false
 
   return {
     onThinking: (chunk: string) => {
@@ -83,6 +84,8 @@ export function createStreamCallbacks(context: StreamMutationContext) {
 
     onError: (error: string) => {
       if (abortRef.current.aborted) return
+      if (hasErrored) return
+      hasErrored = true
 
       setStatus('error')
       const partial = responseAccRef.current
@@ -99,6 +102,7 @@ export function createStreamCallbacks(context: StreamMutationContext) {
 
     onDone: () => {
       if (abortRef.current.aborted) return
+      if (hasErrored) return
 
       setStatus('done')
       const finalResponse = finalResponseText(responseAccRef.current)

--- a/src/utils/propertyTypes.ts
+++ b/src/utils/propertyTypes.ts
@@ -116,7 +116,11 @@ export function getEffectiveDisplayMode(
 function resolveDateFromValue(value: string): Date | null {
   const isoMatch = value.match(ISO_DATE_RE)
   if (isoMatch) {
-    const date = new Date(isoMatch[0])
+    const matched = isoMatch[0]
+    const dateOnly = matched.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+    const date = dateOnly
+      ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+      : new Date(matched)
     return Number.isNaN(date.getTime()) ? null : date
   }
 


### PR DESCRIPTION
## Summary

Fixes a cluster of bugs that caused Tolaria's AI chat panel to silently fail with `"Claude Code finished without returning a reply."` regardless of what was actually wrong upstream.

### Root cause

When a user's `vaults.json` stored a vault path with a literal `~` (e.g. `~/Vaults/work-command-center`), the `stream_claude_agent` / `stream_ai_agent` Tauri commands passed it raw into `Command::current_dir(...)`. Rust's `Command` does not expand `~`, so spawn failed with `ENOENT`. The error then got swallowed because the frontend's `onDone` handler ran after `onError` and overwrote the error message with the empty-reply fallback. Net effect: every Claude/Codex run looked like it returned nothing, with no clue why.

This affected anyone whose vaults entry was added with a tilde — including the default in `vaults.json` for some setups.

### Fixes (in commit order)

1. **`chore: ignore .claude worktree paths in eslint`** — Claude Code worktrees live under `.claude/worktrees/<name>/` inside the repo and carry tracked `src-tauri/gen/` assets that the global `src-tauri/gen/` ignore (resolved relative to repo root) doesn't match. Adds `.claude/` to `globalIgnores` in `eslint.config.js` so `pnpm lint` succeeds when worktrees are present. Unblocks the lint gate for anyone using Claude Code worktrees during development.

2. **`fix: parse ISO date strings as local-timezone calendar dates`** — `formatDateValue('2026-03-31')` returned `'Mar 30, 2026'` for users west of UTC because `new Date('2026-03-31')` parses as UTC midnight. `resolveDateFromValue` now constructs date-only ISO inputs from local components. ISO datetimes with explicit time keep the existing parse path. Two pre-existing test-suite assertions (`propertyTypes.test.ts`, `DynamicPropertiesPanel.test.tsx`) start passing in EDT after this.

3. **`fix: surface real CLI errors instead of empty-reply fallback`** — Three coordinated changes so genuine CLI failures (rate limits, billing, model mismatch, auth, subprocess spawn) reach the chat panel:
   - `claude_cli.rs`: emit `Error` when the result event has `is_error: true`; fall back to `api_error_status` when the result text is empty.
   - `ai_agents.rs`: dispatch Codex `error` and `turn.failed` JSON events to `Error`.
   - `aiAgentStreamCallbacks.ts`: ignore trailing `Done` after `Error` so the error message is not overwritten.

4. **`fix: expand tilde in AI agent vault_path before subprocess spawn`** — The actual root cause. Both `run_agent_stream` (claude_cli.rs) and `run_ai_agent_stream` (ai_agents.rs) now normalize `vault_path` through `crate::commands::expand_tilde` before constructing the subprocess. Codex's run path inherits the same normalization since it reuses `request.vault_path` for cwd and MCP env.

5. **`fix: hide AI chat placeholder when editor is focused`** — The placeholder overlay in `InlineWikilinkEditorField` (`"Ask Claude Code about this note..."`) was an absolutely-positioned div whose only hide condition was a non-empty value. Clicking into the field with no text left the placeholder sitting on top of the caret. Adds `group` to the wrapper and `group-focus-within:hidden` to the overlay so the placeholder disappears the moment the contentEditable gets focus, while still re-appearing on blur.

## Verification

All five commits passed the local pre-commit gate (3243 vitest passing on the final commit). Focused tests added for each fix:

- Rust: `dispatch_event_handles_error_result`, `dispatch_event_error_result_falls_back_to_status`, `dispatch_codex_error_event_maps_to_error`, `dispatch_codex_turn_failed_event_maps_to_error`, `normalize_agent_request_expands_tilde_vault_path`, `normalize_agent_request_leaves_absolute_paths_intact`, `normalize_ai_agent_request_expands_tilde_vault_path`, `normalize_ai_agent_request_leaves_absolute_paths_intact`.
- TypeScript: new `aiAgentStreamCallbacks.test.ts` case for trailing-Done-after-Error; new `WikilinkChatInput.test.tsx` case for placeholder overlay class structure.

## Test plan

- [ ] Set a vault path with `~` (e.g. `~/Vaults/foo`) in `vaults.json` and confirm Claude Code chat returns a real response instead of the empty-reply message.
- [ ] Force a Claude rate-limit (e.g. with `ANTHROPIC_API_KEY` on a depleted account) and confirm the actual rate-limit error appears in chat instead of the empty-reply message.
- [ ] Click into the AI chat input on an empty draft and confirm the placeholder disappears immediately.
- [ ] Open a date property in EDT and confirm `2026-03-31` renders as `Mar 31, 2026`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)