### PR TITLE
feat: open standalone image files in a preview pane

### DIFF
--- a/src/components/ImagePreviewView.tsx
+++ b/src/components/ImagePreviewView.tsx
@@ -1,0 +1,38 @@
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { isTauri } from '../mock-tauri'
+
+interface ImagePreviewViewProps {
+  /** Absolute path to the vault root */
+  vaultPath: string
+  /** Vault-relative path to the image file */
+  path: string
+}
+
+/**
+ * Full-area image viewer for standalone image files (PNG, JPG, SVG, etc.).
+ * Renders the image centered with natural dimensions, scrollable if larger than the pane.
+ */
+export function ImagePreviewView({ vaultPath, path }: ImagePreviewViewProps) {
+  const absolutePath = `${vaultPath}/${path}`
+  const src = isTauri() ? convertFileSrc(absolutePath) : path
+
+  return (
+    <div
+      className="flex flex-1 items-center justify-center overflow-auto"
+      style={{ padding: '2rem', minHeight: 0 }}
+      data-testid="image-preview-view"
+    >
+      <img
+        src={src}
+        alt=""
+        style={{
+          maxWidth: '100%',
+          maxHeight: '100%',
+          objectFit: 'contain',
+          borderRadius: '0.375rem',
+          display: 'block',
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/NoteItem.test.tsx
+++ b/src/components/NoteItem.test.tsx
@@ -19,11 +19,11 @@ describe('NoteItem', () => {
     openExternalUrl.mockClear()
   })
 
-  it('renders binary files as non-clickable muted rows', () => {
+  it('renders non-image binary files as non-clickable muted rows', () => {
     const binaryEntry = makeEntry({
-      path: '/vault/photo.png',
-      filename: 'photo.png',
-      title: 'photo.png',
+      path: '/vault/data.bin',
+      filename: 'data.bin',
+      title: 'data.bin',
       fileKind: 'binary',
     })
     const onClickNote = vi.fn()
@@ -36,6 +36,22 @@ describe('NoteItem', () => {
 
     fireEvent.click(item)
     expect(onClickNote).not.toHaveBeenCalled()
+  })
+
+  it('renders image files as clickable rows', () => {
+    const imageEntry = makeEntry({
+      path: '/vault/photo.png',
+      filename: 'photo.png',
+      title: 'photo.png',
+      fileKind: 'binary',
+    })
+    const onClickNote = vi.fn()
+
+    render(<NoteItem entry={imageEntry} isSelected={false} typeEntryMap={{}} onClickNote={onClickNote} />)
+
+    const item = screen.getByText('photo.png').closest('div')!
+    fireEvent.click(item)
+    expect(onClickNote).toHaveBeenCalled()
   })
 
   it('renders text files as clickable rows', () => {

--- a/src/components/NoteItem.tsx
+++ b/src/components/NoteItem.tsx
@@ -4,8 +4,9 @@ import { cn } from '@/lib/utils'
 import {
   Wrench, Flask, Target, ArrowsClockwise,
   Users, CalendarBlank, Tag, FileText, StackSimple,
-  File, FileDashed,
+  File, FileDashed, Image,
 } from '@phosphor-icons/react'
+import { isImagePath } from '../utils/fileKind'
 import { getTypeColor, getTypeLightColor } from '../utils/typeColors'
 import { resolveIcon } from '../utils/iconRegistry'
 import { relativeDate, getDisplayDate } from '../utils/noteListHelpers'
@@ -190,7 +191,7 @@ function InteractiveNoteDetails({
 }
 
 function resolveNoteTypeIcon(entry: VaultEntry, customIcon?: string | null): ComponentType<SVGAttributes<SVGSVGElement>> {
-  if (entry.fileKind && entry.fileKind !== 'markdown') return getFileKindIcon(entry.fileKind)
+  if (entry.fileKind && entry.fileKind !== 'markdown') return getFileKindIcon(entry.path, entry.fileKind)
   return getTypeIcon(entry.isA, customIcon)
 }
 
@@ -287,9 +288,9 @@ function noteItemStyle(isSelected: boolean, isMultiSelected: boolean, typeColor:
   return base
 }
 
-function getFileKindIcon(fileKind: string | undefined): ComponentType<SVGAttributes<SVGSVGElement>> {
+function getFileKindIcon(path: string, fileKind: string | undefined): ComponentType<SVGAttributes<SVGSVGElement>> {
   if (fileKind === 'text') return File
-  if (fileKind === 'binary') return FileDashed
+  if (fileKind === 'binary') return isImagePath(path) ? Image : FileDashed
   return FileText
 }
 
@@ -439,7 +440,7 @@ function NoteItemContent({
 }
 
 export function NoteItem({ entry, isSelected, isMultiSelected = false, isHighlighted = false, noteStatus = 'clean', changeStatus, typeEntryMap, allEntries, displayPropsOverride, onClickNote, onPrefetch, onContextMenu }: NoteItemProps) {
-  const isBinary = entry.fileKind === 'binary'
+  const isBinary = entry.fileKind === 'binary' && !isImagePath(entry.path)
   const te = typeEntryMap[entry.isA ?? '']
   const displayProps = resolveDisplayProps(entry, typeEntryMap, displayPropsOverride)
   const typeColor = isBinary ? 'var(--muted-foreground)' : getTypeColor(entry.isA ?? 'Note', te?.color)

--- a/src/components/editor-content/EditorContentLayout.tsx
+++ b/src/components/editor-content/EditorContentLayout.tsx
@@ -6,6 +6,7 @@ import { ArchivedNoteBanner } from '../ArchivedNoteBanner'
 import { ConflictNoteBanner } from '../ConflictNoteBanner'
 import { RawEditorView } from '../RawEditorView'
 import { SingleEditorView } from '../SingleEditorView'
+import { ImagePreviewView } from '../ImagePreviewView'
 import type { useEditorContentModel } from './useEditorContentModel'
 
 type EditorContentModel = ReturnType<typeof useEditorContentModel>
@@ -218,6 +219,7 @@ export function EditorContentLayout(model: EditorContentModel) {
     onRawContentChange,
     onSave,
     showEditor,
+    isImageFile,
     isArchived,
     onUnarchiveNote,
     path,
@@ -298,16 +300,21 @@ export function EditorContentLayout(model: EditorContentModel) {
         rawLatestContentRef={rawLatestContentRef}
         vaultPath={vaultPath}
       />
-      <EditorCanvas
-        showEditor={showEditor}
-        cssVars={cssVars}
-        vaultPath={vaultPath}
-        editor={editor}
-        entries={entries}
-        onNavigateWikilink={onNavigateWikilink}
-        onEditorChange={onEditorChange}
-        isDeletedPreview={isDeletedPreview}
-      />
+      {isImageFile && vaultPath
+        ? <ImagePreviewView vaultPath={vaultPath} path={path} />
+        : (
+          <EditorCanvas
+            showEditor={showEditor}
+            cssVars={cssVars}
+            vaultPath={vaultPath}
+            editor={editor}
+            entries={entries}
+            onNavigateWikilink={onNavigateWikilink}
+            onEditorChange={onEditorChange}
+            isDeletedPreview={isDeletedPreview}
+          />
+        )
+      }
       {isLoadingNewTab && showEditor && <EditorLoadingSkeleton />}
     </div>
   )

--- a/src/components/editor-content/useEditorContentModel.ts
+++ b/src/components/editor-content/useEditorContentModel.ts
@@ -4,6 +4,7 @@ import type { useCreateBlockNote } from '@blocknote/react'
 import type { NoteLayout, NoteStatus, VaultEntry } from '../../types'
 import { useEditorTheme } from '../../hooks/useTheme'
 import { deriveEditorContentState } from './editorContentState'
+import { isImagePath } from '../../utils/fileKind'
 
 export interface Tab {
   entry: VaultEntry
@@ -70,7 +71,8 @@ export function useEditorContentModel(props: EditorContentProps) {
     rawMode,
     activeStatus: props.activeStatus,
   })
-  const showEditor = !diffMode && showContentEditor
+  const isImageFile = activeTab ? isImagePath(activeTab.entry.path) : false
+  const showEditor = !diffMode && showContentEditor && !isImageFile
 
   const breadcrumbBarRef = useRef<HTMLDivElement | null>(null)
 
@@ -81,6 +83,7 @@ export function useEditorContentModel(props: EditorContentProps) {
     isDeletedPreview,
     effectiveRawMode,
     forceRawMode: isNonMarkdownText || isDeletedPreview,
+    isImageFile,
     showEditor,
     path,
     breadcrumbBarRef,

--- a/src/hooks/useTabManagement.ts
+++ b/src/hooks/useTabManagement.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { isTauri, mockInvoke } from '../mock-tauri'
 import type { VaultEntry } from '../types'
+import { isImagePath } from '../utils/fileKind'
 import {
   beginNoteOpenTrace,
   failNoteOpenTrace,
@@ -457,12 +458,20 @@ async function navigateToEntry(options: {
     onUnreadableNoteContent,
   } = options
 
-  if (entry.fileKind === 'binary') {
+  if (entry.fileKind === 'binary' && !isImagePath(entry.path)) {
     failNoteOpenTrace(entry.path, 'binary-entry')
     return
   }
   if (!forceReload && isAlreadyViewingPath(tabsRef, activeTabPathRef, entry.path)) {
     syncActiveTabPath(activeTabPathRef, setActiveTabPath, entry.path)
+    finishNoteOpenTrace(entry.path)
+    return
+  }
+
+  // Image files need no text content — skip disk read and display directly.
+  if (isImagePath(entry.path)) {
+    syncActiveTabPath(activeTabPathRef, setActiveTabPath, entry.path)
+    setSingleTab(tabsRef, setTabs, { entry, content: '' })
     finishNoteOpenTrace(entry.path)
     return
   }

--- a/src/utils/fileKind.ts
+++ b/src/utils/fileKind.ts
@@ -1,0 +1,12 @@
+const IMAGE_EXTENSIONS = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif', 'bmp', 'ico', 'tiff', 'tif',
+])
+
+/**
+ * Returns true if the path's extension is a viewable image format.
+ * Used to unlock binary image files for preview instead of blocking them.
+ */
+export function isImagePath(path: string): boolean {
+  const ext = path.split('.').pop()?.toLowerCase() ?? ''
+  return IMAGE_EXTENSIONS.has(ext)
+}


### PR DESCRIPTION
## Summary

- Image files (png, jpg, jpeg, gif, webp, svg, avif, bmp, ico, tiff) in the folder view are now clickable instead of greyed-out
- Clicking an image opens it in a full-pane centered preview instead of the markdown editor
- Images are served via Tauri's existing asset:// protocol — no new permissions needed

## Implementation

- `src/utils/fileKind.ts` — new isImagePath() helper (extension-based)
- `useTabManagement.ts` — image paths bypass the binary guard; content load skipped, tab set with empty string
- `NoteItem.tsx` — image files get Image icon instead of FileDashed, fully clickable
- `useEditorContentModel.ts` — derives isImageFile flag, suppresses editor when image is active
- `EditorContentLayout.tsx` — routes to ImagePreviewView instead of EditorCanvas when isImageFile
- `ImagePreviewView.tsx` — full-pane centered img with object-fit: contain, scrollable if oversized

## Test plan

- [ ] Click a PNG/JPG/SVG in folder view → image opens in preview pane
- [ ] Non-image binary (.bin, .pdf) → still greyed out and unclickable
- [ ] Image icon appears in sidebar instead of dashed-file icon
- [ ] BreadcrumbBar shows filename
- [ ] Oversized image → scrollable, not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)