### PR TITLE
feat: kanban agent (phase 3)

### DIFF
--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -3,6 +3,40 @@ use std::collections::HashMap;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
+use std::sync::{LazyLock, Mutex};
+
+/// PID of the Claude subprocess currently streaming for the kanban agent panel
+/// (or any other single-shot caller). Set right after spawn, cleared at exit.
+/// Used by `kill_active_agent` to terminate a running agent on user request.
+static ACTIVE_AGENT_PID: LazyLock<Mutex<Option<u32>>> = LazyLock::new(|| Mutex::new(None));
+
+fn set_active_agent_pid(pid: u32) {
+    if let Ok(mut guard) = ACTIVE_AGENT_PID.lock() {
+        *guard = Some(pid);
+    }
+}
+
+fn clear_active_agent_pid_if(pid: u32) {
+    if let Ok(mut guard) = ACTIVE_AGENT_PID.lock() {
+        if guard.as_ref() == Some(&pid) {
+            *guard = None;
+        }
+    }
+}
+
+/// Try to terminate the currently active Claude subprocess (if any).
+/// Sends SIGTERM via the system `kill` command for portability.
+/// Returns true if a process was targeted, false if nothing was running.
+pub fn kill_active_agent_subprocess() -> bool {
+    let pid_opt = match ACTIVE_AGENT_PID.lock() {
+        Ok(mut guard) => guard.take(),
+        Err(_) => return false,
+    };
+    let Some(pid) = pid_opt else { return false; };
+    log::info!("Killing active Claude agent subprocess pid={pid}");
+    let _ = Command::new("kill").arg("-TERM").arg(pid.to_string()).status();
+    true
+}
 
 /// Status returned by `check_claude_cli`.
 #[derive(Debug, Serialize, Clone)]
@@ -334,6 +368,8 @@ where
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn claude: {e}"))?;
+    let child_pid = child.id();
+    set_active_agent_pid(child_pid);
 
     let stdout = child.stdout.take().ok_or("No stdout handle")?;
     let reader = std::io::BufReader::new(stdout);
@@ -375,6 +411,7 @@ where
         .unwrap_or_default();
 
     let status = child.wait().map_err(|e| format!("Wait failed: {e}"))?;
+    clear_active_agent_pid_if(child_pid);
 
     if !status.success() && state.session_id.is_empty() {
         emit(ClaudeStreamEvent::Error {

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -150,6 +150,21 @@ pub async fn stream_ai_agent(
     Err("CLI AI agents are not available on mobile".into())
 }
 
+/// Kill the Claude subprocess currently streaming for the kanban agent panel
+/// (or any other single-shot caller). No-op if nothing is running. Returns
+/// `true` when a process was targeted, `false` otherwise.
+#[cfg(desktop)]
+#[tauri::command]
+pub fn kill_active_agent() -> Result<bool, String> {
+    Ok(crate::claude_cli::kill_active_agent_subprocess())
+}
+
+#[cfg(mobile)]
+#[tauri::command]
+pub fn kill_active_agent() -> Result<bool, String> {
+    Ok(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -56,6 +56,7 @@ mod tests {
             sort: None,
             list_properties_display: vec![],
             filters: crate::vault::FilterGroup::All(vec![]),
+            kind: crate::vault::ViewKind::default(),
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -315,6 +315,7 @@ macro_rules! app_invoke_handler {
             commands::stream_claude_chat,
             commands::stream_claude_agent,
             commands::stream_ai_agent,
+            commands::kill_active_agent,
             commands::reload_vault,
             commands::reload_vault_entry,
             commands::sync_vault_asset_scope_for_window,

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -35,7 +35,7 @@ pub use title_sync::{sync_title_on_open, SyncAction};
 pub use trash::{batch_delete_notes, delete_note};
 pub use views::{
     delete_view, evaluate_view, save_view, scan_views, FilterCondition, FilterGroup, FilterNode,
-    FilterOp, ViewDefinition, ViewFile,
+    FilterOp, ViewDefinition, ViewFile, ViewKind,
 };
 
 use file::read_file_metadata;

--- a/src-tauri/src/vault/views.rs
+++ b/src-tauri/src/vault/views.rs
@@ -8,6 +8,19 @@ use std::path::Path;
 
 use super::VaultEntry;
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ViewKind {
+    List,
+    Kanban,
+}
+
+impl Default for ViewKind {
+    fn default() -> Self {
+        ViewKind::List
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ViewDefinition {
     pub name: String,
@@ -24,6 +37,12 @@ pub struct ViewDefinition {
     )]
     pub list_properties_display: Vec<String>,
     pub filters: FilterGroup,
+    #[serde(default, skip_serializing_if = "is_default_view_kind")]
+    pub kind: ViewKind,
+}
+
+fn is_default_view_kind(kind: &ViewKind) -> bool {
+    *kind == ViewKind::default()
 }
 
 #[derive(Debug, Clone)]
@@ -694,7 +713,47 @@ mod tests {
                 value: Some(serde_yaml::Value::String("Project".to_string())),
                 regex: false,
             })]),
+            kind: ViewKind::default(),
         }
+    }
+
+    #[test]
+    fn view_kind_defaults_to_list_when_absent() {
+        let yaml = "name: Backlog\nfilters:\n  all: []\n";
+        let view: ViewDefinition = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(view.kind, ViewKind::List);
+    }
+
+    #[test]
+    fn view_kind_kanban_round_trips() {
+        let original = ViewDefinition {
+            name: "Sprint 1".to_string(),
+            icon: None,
+            color: None,
+            sort: None,
+            list_properties_display: Vec::new(),
+            filters: FilterGroup::All(vec![]),
+            kind: ViewKind::Kanban,
+        };
+        let yaml = serde_yaml::to_string(&original).unwrap();
+        assert!(yaml.contains("kind: kanban"), "expected kanban kind to serialize, got:\n{yaml}");
+        let parsed: ViewDefinition = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.kind, ViewKind::Kanban);
+    }
+
+    #[test]
+    fn view_kind_list_is_skipped_in_serialization() {
+        let view = ViewDefinition {
+            name: "Inbox".to_string(),
+            icon: None,
+            color: None,
+            sort: None,
+            list_properties_display: Vec::new(),
+            filters: FilterGroup::All(vec![]),
+            kind: ViewKind::List,
+        };
+        let yaml = serde_yaml::to_string(&view).unwrap();
+        assert!(!yaml.contains("kind:"), "default 'list' kind should not appear in YAML, got:\n{yaml}");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1244,6 +1244,22 @@ function App() {
     () => vault.modifiedFiles.some((file) => file.path === notes.activeTabPath),
     [notes.activeTabPath, vault.modifiedFiles],
   )
+  const activeKanbanView = useMemo(() => {
+    if (effectiveSelection.kind !== 'view') return null
+    const view = vault.views.find((candidate) => candidate.filename === effectiveSelection.filename)
+    return view?.definition.kind === 'kanban' ? view : null
+  }, [effectiveSelection, vault.views])
+  const kanbanBoardEntries = useMemo(
+    () => (activeKanbanView ? evaluateView(activeKanbanView.definition, vault.entries) : []),
+    [activeKanbanView, vault.entries],
+  )
+  const handleKanbanUpdateStatus = useCallback(
+    (notePath: string, newStatus: string) => {
+      vault.updateEntry(notePath, { status: newStatus })
+      return notes.handleUpdateFrontmatter(notePath, 'status', newStatus, { silent: true })
+    },
+    [notes, vault],
+  )
   const toggleDiffCommand = useCallback(() => diffToggleRef.current(), [])
   const toggleRawEditorCommand = useMemo(
     () => canToggleRichEditor ? () => rawToggleRef.current() : undefined,
@@ -1481,24 +1497,18 @@ function App() {
               <ResizeHandle onResize={layout.handleSidebarResize} />
             </>
           )}
-          {(() => {
-            if (effectiveSelection.kind !== 'view') return null
-            const activeView = vault.views.find((view) => view.filename === effectiveSelection.filename)
-            if (activeView?.definition.kind !== 'kanban') return null
-            const boardEntries = evaluateView(activeView.definition, vault.entries)
-            return (
-              <div className="flex flex-1 flex-col overflow-hidden">
-                <KanbanBoard
-                  entries={boardEntries}
-                  selectedNotePath={activeTab?.entry?.path ?? null}
-                  onSelectNote={(entry) => notes.handleSelectNote(entry)}
-                  onUpdateStatus={(notePath, newStatus) => notes.handleUpdateFrontmatter(notePath, 'status', newStatus, { silent: true })}
-                  emptyMessage={`No notes match the "${activeView.definition.name}" board.`}
-                />
-              </div>
-            )
-          })()}
-          {noteListVisible && !(effectiveSelection.kind === 'view' && vault.views.find((view) => view.filename === effectiveSelection.filename)?.definition.kind === 'kanban') && (
+          {activeKanbanView && (
+            <div className="flex flex-1 flex-col overflow-hidden">
+              <KanbanBoard
+                entries={kanbanBoardEntries}
+                selectedNotePath={activeTab?.entry?.path ?? null}
+                onSelectNote={(entry) => notes.handleSelectNote(entry)}
+                onUpdateStatus={handleKanbanUpdateStatus}
+                emptyMessage={`No notes match the "${activeKanbanView.definition.name}" board.`}
+              />
+            </div>
+          )}
+          {!activeKanbanView && noteListVisible && (
             <>
               <div className={`app__note-list${aiActivity.highlightElement === 'notelist' ? ' ai-highlight' : ''}`} style={{ width: layout.noteListWidth }}>
                 {effectiveSelection.kind === 'filter' && effectiveSelection.filter === 'pulse' ? (
@@ -1510,6 +1520,7 @@ function App() {
               <ResizeHandle onResize={layout.handleNoteListResize} />
             </>
           )}
+          {!activeKanbanView && (
           <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`}>
             <Editor
               tabs={notes.tabs}
@@ -1569,6 +1580,7 @@ function App() {
               flushPendingRawContentRef={flushPendingRawContentRef}
             />
           </div>
+          )}
         </div>
         <UpdateBanner status={updateStatus} actions={updateActions} />
         <RenameDetectedBanner renames={detectedRenames} onUpdate={handleUpdateWikilinks} onDismiss={handleDismissRenames} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
+import { CaretDoubleRight } from '@phosphor-icons/react'
 import { KanbanBoard } from './components/kanban/KanbanBoard'
 import { evaluateView } from './utils/viewFilters'
 import { isKanbanEligibleEntry } from './utils/kanbanEntries'
@@ -1284,10 +1285,19 @@ function App() {
     },
     [notes, vault, setToastMessage],
   )
+  const [kanbanSplitDismissed, setKanbanSplitDismissed] = useState(false)
   const isKanbanCardActive = useMemo(() => {
+    if (kanbanSplitDismissed) return false
     if (!activeKanbanView || !notes.activeTabPath) return false
     return kanbanBoardEntries.some((entry) => entry.path === notes.activeTabPath)
-  }, [activeKanbanView, notes.activeTabPath, kanbanBoardEntries])
+  }, [kanbanSplitDismissed, activeKanbanView, notes.activeTabPath, kanbanBoardEntries])
+  const handleKanbanSelectNote = useCallback((entry: VaultEntry) => {
+    setKanbanSplitDismissed(false)
+    notes.handleSelectNote(entry)
+  }, [notes])
+  const handleKanbanCloseSplit = useCallback(() => {
+    setKanbanSplitDismissed(true)
+  }, [])
   const toggleDiffCommand = useCallback(() => diffToggleRef.current(), [])
   const toggleRawEditorCommand = useMemo(
     () => canToggleRichEditor ? () => rawToggleRef.current() : undefined,
@@ -1533,7 +1543,7 @@ function App() {
               <KanbanBoard
                 entries={kanbanBoardEntries}
                 selectedNotePath={activeTab?.entry?.path ?? null}
-                onSelectNote={(entry) => notes.handleSelectNote(entry)}
+                onSelectNote={handleKanbanSelectNote}
                 onUpdateStatus={handleKanbanUpdateStatus}
                 emptyMessage={kanbanEmptyMessage}
               />
@@ -1552,7 +1562,20 @@ function App() {
             </>
           )}
           {(!activeKanbanView || isKanbanCardActive) && (
-          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360 } : undefined}>
+          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360, position: 'relative' } : undefined}>
+            {isKanbanCardActive && (
+              <button
+                type="button"
+                onClick={handleKanbanCloseSplit}
+                className="absolute z-50 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                style={{ top: 12, left: 8 }}
+                aria-label="Close note panel and return to full board"
+                title="Return to full board"
+                data-testid="kanban-close-split"
+              >
+                <CaretDoubleRight size={16} />
+              </button>
+            )}
             <Editor
               tabs={notes.tabs}
               activeTabPath={notes.activeTabPath}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1284,6 +1284,10 @@ function App() {
     },
     [notes, vault, setToastMessage],
   )
+  const isKanbanCardActive = useMemo(() => {
+    if (!activeKanbanView || !notes.activeTabPath) return false
+    return kanbanBoardEntries.some((entry) => entry.path === notes.activeTabPath)
+  }, [activeKanbanView, notes.activeTabPath, kanbanBoardEntries])
   const toggleDiffCommand = useCallback(() => diffToggleRef.current(), [])
   const toggleRawEditorCommand = useMemo(
     () => canToggleRichEditor ? () => rawToggleRef.current() : undefined,
@@ -1522,7 +1526,10 @@ function App() {
             </>
           )}
           {activeKanbanView && (
-            <div className="flex flex-1 flex-col overflow-hidden">
+            <div
+              className={isKanbanCardActive ? 'flex flex-[3] flex-col overflow-hidden border-r border-border' : 'flex flex-1 flex-col overflow-hidden'}
+              style={isKanbanCardActive ? { minWidth: 480 } : undefined}
+            >
               <KanbanBoard
                 entries={kanbanBoardEntries}
                 selectedNotePath={activeTab?.entry?.path ?? null}
@@ -1544,8 +1551,8 @@ function App() {
               <ResizeHandle onResize={layout.handleNoteListResize} />
             </>
           )}
-          {!activeKanbanView && (
-          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`}>
+          {(!activeKanbanView || isKanbanCardActive) && (
+          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360 } : undefined}>
             <Editor
               tabs={notes.tabs}
               activeTabPath={notes.activeTabPath}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1646,6 +1646,7 @@ function App() {
                   agent={aiAgentPreferences.defaultAiAgent}
                   agentReady={aiAgentPreferences.defaultAiAgentReady}
                   agentLabel={aiAgentPreferences.defaultAiAgentLabel}
+                  onUpdateStatus={handleKanbanUpdateStatus}
                 />
               </div>
             )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { KanbanBoard } from './components/kanban/KanbanBoard'
 import { evaluateView } from './utils/viewFilters'
+import { isKanbanEligibleEntry } from './utils/kanbanEntries'
 import type { DeletedNoteEntry } from './components/note-list/noteListUtils'
 import { Editor } from './components/Editor'
 import { ResizeHandle } from './components/ResizeHandle'
@@ -1250,15 +1251,23 @@ function App() {
     return view?.definition.kind === 'kanban' ? view : null
   }, [effectiveSelection, vault.views])
   const kanbanBoardEntries = useMemo(
-    () => (activeKanbanView ? evaluateView(activeKanbanView.definition, vault.entries) : []),
+    () => (activeKanbanView ? evaluateView(activeKanbanView.definition, vault.entries).filter(isKanbanEligibleEntry) : []),
     [activeKanbanView, vault.entries],
   )
   const handleKanbanUpdateStatus = useCallback(
-    (notePath: string, newStatus: string) => {
+    async (notePath: string, newStatus: string) => {
+      console.log('[kanban] drag drop -> update status', { notePath, newStatus })
       vault.updateEntry(notePath, { status: newStatus })
-      return notes.handleUpdateFrontmatter(notePath, 'status', newStatus, { silent: true })
+      try {
+        await notes.handleUpdateFrontmatter(notePath, 'status', newStatus, { silent: true })
+        console.log('[kanban] frontmatter persisted', { notePath, newStatus })
+      } catch (err) {
+        console.error('[kanban] frontmatter update failed', { notePath, newStatus, err })
+        setToastMessage(`Kanban: failed to update status (${err})`)
+        throw err
+      }
     },
-    [notes, vault],
+    [notes, vault, setToastMessage],
   )
   const toggleDiffCommand = useCallback(() => diffToggleRef.current(), [])
   const toggleRawEditorCommand = useMemo(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1250,10 +1250,25 @@ function App() {
     const view = vault.views.find((candidate) => candidate.filename === effectiveSelection.filename)
     return view?.definition.kind === 'kanban' ? view : null
   }, [effectiveSelection, vault.views])
-  const kanbanBoardEntries = useMemo(
-    () => (activeKanbanView ? evaluateView(activeKanbanView.definition, vault.entries).filter(isKanbanEligibleEntry) : []),
+  const kanbanRawMatches = useMemo(
+    () => (activeKanbanView ? evaluateView(activeKanbanView.definition, vault.entries) : []),
     [activeKanbanView, vault.entries],
   )
+  const kanbanBoardEntries = useMemo(
+    () => kanbanRawMatches.filter(isKanbanEligibleEntry),
+    [kanbanRawMatches],
+  )
+  const kanbanEmptyMessage = useMemo(() => {
+    if (!activeKanbanView) return undefined
+    const boardName = activeKanbanView.definition.name
+    if (kanbanRawMatches.length === 0) {
+      return `No notes match the "${boardName}" board. Try editing the filter (sidebar > right-click on the board).`
+    }
+    if (kanbanBoardEntries.length === 0) {
+      return `The "${boardName}" filter matches ${kanbanRawMatches.length} item(s), but they are all view configs or binaries (excluded from kanban). Edit the filter to target real notes (e.g. status is_not_empty).`
+    }
+    return undefined
+  }, [activeKanbanView, kanbanRawMatches, kanbanBoardEntries])
   const handleKanbanUpdateStatus = useCallback(
     async (notePath: string, newStatus: string) => {
       console.log('[kanban] drag drop -> update status', { notePath, newStatus })
@@ -1513,7 +1528,7 @@ function App() {
                 selectedNotePath={activeTab?.entry?.path ?? null}
                 onSelectNote={(entry) => notes.handleSelectNote(entry)}
                 onUpdateStatus={handleKanbanUpdateStatus}
-                emptyMessage={`No notes match the "${activeKanbanView.definition.name}" board.`}
+                emptyMessage={kanbanEmptyMessage}
               />
             </div>
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
+import { KanbanBoard } from './components/kanban/KanbanBoard'
+import { evaluateView } from './utils/viewFilters'
 import type { DeletedNoteEntry } from './components/note-list/noteListUtils'
 import { Editor } from './components/Editor'
 import { ResizeHandle } from './components/ResizeHandle'
@@ -1474,12 +1476,29 @@ function App() {
           {sidebarVisible && (
             <>
               <div className="app__sidebar" style={{ width: layout.sidebarWidth }}>
-                <Sidebar entries={vault.entries} folders={vault.folders} views={vault.views} selection={effectiveSelection} onSelect={handleSetSelection} onSelectNote={notes.handleSelectNote} onSelectFavorite={handleOpenFavorite} onReorderFavorites={entryActions.handleReorderFavorites} onCreateType={notes.handleCreateNoteImmediate} onCreateNewType={dialogs.openCreateType} onCustomizeType={entryActions.handleCustomizeType} onUpdateTypeTemplate={entryActions.handleUpdateTypeTemplate} onReorderSections={entryActions.handleReorderSections} onRenameSection={entryActions.handleRenameSection} onToggleTypeVisibility={entryActions.handleToggleTypeVisibility} onCreateFolder={handleCreateFolder} onRenameFolder={folderActions.renameFolder} onDeleteFolder={folderActions.requestDeleteFolder} renamingFolderPath={folderActions.renamingFolderPath} onStartRenameFolder={folderActions.startFolderRename} onCancelRenameFolder={folderActions.cancelFolderRename} onCreateView={dialogs.openCreateView} onEditView={handleEditView} onDeleteView={handleDeleteView} showInbox={explicitOrganizationEnabled} inboxCount={inboxCount} />
+                <Sidebar entries={vault.entries} folders={vault.folders} views={vault.views} selection={effectiveSelection} onSelect={handleSetSelection} onSelectNote={notes.handleSelectNote} onSelectFavorite={handleOpenFavorite} onReorderFavorites={entryActions.handleReorderFavorites} onCreateType={notes.handleCreateNoteImmediate} onCreateNewType={dialogs.openCreateType} onCustomizeType={entryActions.handleCustomizeType} onUpdateTypeTemplate={entryActions.handleUpdateTypeTemplate} onReorderSections={entryActions.handleReorderSections} onRenameSection={entryActions.handleRenameSection} onToggleTypeVisibility={entryActions.handleToggleTypeVisibility} onCreateFolder={handleCreateFolder} onRenameFolder={folderActions.renameFolder} onDeleteFolder={folderActions.requestDeleteFolder} renamingFolderPath={folderActions.renamingFolderPath} onStartRenameFolder={folderActions.startFolderRename} onCancelRenameFolder={folderActions.cancelFolderRename} onCreateView={dialogs.openCreateView} onCreateBoard={dialogs.openCreateBoard} onEditView={handleEditView} onDeleteView={handleDeleteView} showInbox={explicitOrganizationEnabled} inboxCount={inboxCount} />
               </div>
               <ResizeHandle onResize={layout.handleSidebarResize} />
             </>
           )}
-          {noteListVisible && (
+          {(() => {
+            if (effectiveSelection.kind !== 'view') return null
+            const activeView = vault.views.find((view) => view.filename === effectiveSelection.filename)
+            if (activeView?.definition.kind !== 'kanban') return null
+            const boardEntries = evaluateView(activeView.definition, vault.entries)
+            return (
+              <div className="flex flex-1 flex-col overflow-hidden">
+                <KanbanBoard
+                  entries={boardEntries}
+                  selectedNotePath={activeTab?.entry?.path ?? null}
+                  onSelectNote={(entry) => notes.handleSelectNote(entry)}
+                  onUpdateStatus={(notePath, newStatus) => notes.handleUpdateFrontmatter(notePath, 'status', newStatus, { silent: true })}
+                  emptyMessage={`No notes match the "${activeView.definition.name}" board.`}
+                />
+              </div>
+            )
+          })()}
+          {noteListVisible && !(effectiveSelection.kind === 'view' && vault.views.find((view) => view.filename === effectiveSelection.filename)?.definition.kind === 'kanban') && (
             <>
               <div className={`app__note-list${aiActivity.highlightElement === 'notelist' ? ' ai-highlight' : ''}`} style={{ width: layout.noteListWidth }}>
                 {effectiveSelection.kind === 'filter' && effectiveSelection.filter === 'pulse' ? (
@@ -1577,7 +1596,7 @@ function App() {
           onSelectType={noteRetargetingUi.selectType}
           onSelectFolder={noteRetargetingUi.selectFolder}
         />
-        <CreateViewDialog open={dialogs.showCreateViewDialog} onClose={dialogs.closeCreateView} onCreate={handleCreateOrUpdateView} availableFields={availableFields} editingView={dialogs.editingView?.definition ?? null} />
+        <CreateViewDialog open={dialogs.showCreateViewDialog} onClose={dialogs.closeCreateView} onCreate={handleCreateOrUpdateView} availableFields={availableFields} editingView={dialogs.editingView?.definition ?? null} defaultKind={dialogs.createViewDefaultKind} />
         <CommitDialog
           open={commitFlow.showCommitDialog}
           modifiedCount={vault.modifiedFiles.length}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { CaretDoubleRight } from '@phosphor-icons/react'
 import { KanbanBoard } from './components/kanban/KanbanBoard'
+import { KanbanAgentPanel } from './components/kanban/KanbanAgentPanel'
 import { evaluateView } from './utils/viewFilters'
 import { isKanbanEligibleEntry } from './utils/kanbanEntries'
 import type { DeletedNoteEntry } from './components/note-list/noteListUtils'
@@ -1575,7 +1576,8 @@ function App() {
             </>
           )}
           {(!activeKanbanView || isKanbanCardActive) && (
-          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360 } : undefined}>
+          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360, display: 'flex', flexDirection: 'column' } : undefined}>
+            <div style={isKanbanCardActive ? { flex: '7 1 0', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' } : undefined}>
             <Editor
               tabs={notes.tabs}
               activeTabPath={notes.activeTabPath}
@@ -1633,6 +1635,20 @@ function App() {
               onKeepTheirs={conflictFlow.handleKeepTheirs}
               flushPendingRawContentRef={flushPendingRawContentRef}
             />
+            </div>
+            {isKanbanCardActive && activeTab && (
+              <div style={{ flex: '3 1 0', minHeight: 200, maxHeight: 480, display: 'flex', flexDirection: 'column' }}>
+                <KanbanAgentPanel
+                  entry={activeTab.entry}
+                  noteContent={activeTab.content ?? null}
+                  allEntries={vault.entries}
+                  vaultPath={resolvedPath}
+                  agent={aiAgentPreferences.defaultAiAgent}
+                  agentReady={aiAgentPreferences.defaultAiAgentReady}
+                  agentLabel={aiAgentPreferences.defaultAiAgentLabel}
+                />
+              </div>
+            )}
           </div>
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1537,7 +1537,7 @@ function App() {
           )}
           {activeKanbanView && (
             <div
-              className={isKanbanCardActive ? 'flex flex-[3] flex-col overflow-hidden border-r border-border' : 'flex flex-1 flex-col overflow-hidden'}
+              className={isKanbanCardActive ? 'relative flex flex-[3] flex-col overflow-hidden border-r border-border' : 'flex flex-1 flex-col overflow-hidden'}
               style={isKanbanCardActive ? { minWidth: 480 } : undefined}
             >
               <KanbanBoard
@@ -1547,6 +1547,19 @@ function App() {
                 onUpdateStatus={handleKanbanUpdateStatus}
                 emptyMessage={kanbanEmptyMessage}
               />
+              {isKanbanCardActive && (
+                <button
+                  type="button"
+                  onClick={handleKanbanCloseSplit}
+                  className="absolute z-50 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-l-md border border-r-0 border-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+                  style={{ top: '50%', right: 0 }}
+                  aria-label="Close note panel and return to full board"
+                  title="Return to full board"
+                  data-testid="kanban-close-split"
+                >
+                  <CaretDoubleRight size={14} />
+                </button>
+              )}
             </div>
           )}
           {!activeKanbanView && noteListVisible && (
@@ -1562,20 +1575,7 @@ function App() {
             </>
           )}
           {(!activeKanbanView || isKanbanCardActive) && (
-          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360, position: 'relative' } : undefined}>
-            {isKanbanCardActive && (
-              <button
-                type="button"
-                onClick={handleKanbanCloseSplit}
-                className="absolute z-50 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                style={{ top: 12, left: 8 }}
-                aria-label="Close note panel and return to full board"
-                title="Return to full board"
-                data-testid="kanban-close-split"
-              >
-                <CaretDoubleRight size={16} />
-              </button>
-            )}
+          <div className={`app__editor${aiActivity.highlightElement === 'editor' || aiActivity.highlightElement === 'tab' ? ' ai-highlight' : ''}`} style={isKanbanCardActive ? { flex: '2 1 0', minWidth: 360 } : undefined}>
             <Editor
               tabs={notes.tabs}
               activeTabPath={notes.activeTabPath}

--- a/src/components/CreateViewDialog.tsx
+++ b/src/components/CreateViewDialog.tsx
@@ -119,10 +119,17 @@ function CreateViewDialogForm({
   )
 }
 
+function defaultFiltersForKind(kind: ViewKind, availableFields: string[]): FilterGroup {
+  if (kind === 'kanban') {
+    return { all: [{ field: 'status', op: 'is_not_empty' }] }
+  }
+  return { all: [{ field: availableFields[0] ?? 'type', op: 'equals', value: '' }] }
+}
+
 export function CreateViewDialog({ open, onClose, onCreate, availableFields, editingView, defaultKind = 'list' }: CreateViewDialogProps) {
   const isEditing = !!editingView
-  const initialFilters = editingView?.filters ?? { all: [{ field: availableFields[0] ?? 'type', op: 'equals', value: '' }] }
   const initialKind: ViewKind = editingView?.kind ?? defaultKind
+  const initialFilters = editingView?.filters ?? defaultFiltersForKind(initialKind, availableFields)
   const formKey = editingView ? `edit:${editingView.name}` : `create:${initialKind}:${availableFields[0] ?? 'type'}`
   const isBoard = initialKind === 'kanban'
   const titleLabel = isEditing ? (isBoard ? 'Edit Board' : 'Edit View') : (isBoard ? 'Create Board' : 'Create View')

--- a/src/components/CreateViewDialog.tsx
+++ b/src/components/CreateViewDialog.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { FilterBuilder } from './FilterBuilder'
 import { EmojiPicker } from './EmojiPicker'
-import type { FilterGroup, ViewDefinition } from '../types'
+import type { FilterGroup, ViewDefinition, ViewKind } from '../types'
 
 interface CreateViewDialogProps {
   open: boolean
@@ -13,6 +13,8 @@ interface CreateViewDialogProps {
   availableFields: string[]
   /** When provided, the dialog operates in edit mode with pre-populated fields. */
   editingView?: ViewDefinition | null
+  /** Defaults the view kind for new views (board section opens with 'kanban'). */
+  defaultKind?: ViewKind
 }
 
 interface CreateViewDialogFormProps {
@@ -20,6 +22,7 @@ interface CreateViewDialogFormProps {
   initialName: string
   initialIcon: string
   initialFilters: FilterGroup
+  initialKind: ViewKind
   isEditing: boolean
   onClose: () => void
   onCreate: (definition: ViewDefinition) => void
@@ -30,6 +33,7 @@ function CreateViewDialogForm({
   initialName,
   initialIcon,
   initialFilters,
+  initialKind,
   isEditing,
   onClose,
   onCreate,
@@ -55,6 +59,7 @@ function CreateViewDialogForm({
       color: null,
       sort: null,
       filters,
+      ...(initialKind !== 'list' ? { kind: initialKind } : {}),
     }
     onCreate(definition)
     onClose()
@@ -114,16 +119,19 @@ function CreateViewDialogForm({
   )
 }
 
-export function CreateViewDialog({ open, onClose, onCreate, availableFields, editingView }: CreateViewDialogProps) {
+export function CreateViewDialog({ open, onClose, onCreate, availableFields, editingView, defaultKind = 'list' }: CreateViewDialogProps) {
   const isEditing = !!editingView
   const initialFilters = editingView?.filters ?? { all: [{ field: availableFields[0] ?? 'type', op: 'equals', value: '' }] }
-  const formKey = editingView ? `edit:${editingView.name}` : `create:${availableFields[0] ?? 'type'}`
+  const initialKind: ViewKind = editingView?.kind ?? defaultKind
+  const formKey = editingView ? `edit:${editingView.name}` : `create:${initialKind}:${availableFields[0] ?? 'type'}`
+  const isBoard = initialKind === 'kanban'
+  const titleLabel = isEditing ? (isBoard ? 'Edit Board' : 'Edit View') : (isBoard ? 'Create Board' : 'Create View')
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
       <DialogContent showCloseButton={false} className="flex max-h-[80vh] flex-col sm:max-w-[600px]">
         <DialogHeader>
-          <DialogTitle>{isEditing ? 'Edit View' : 'Create View'}</DialogTitle>
+          <DialogTitle>{titleLabel}</DialogTitle>
           <DialogDescription className="sr-only">
             {isEditing ? 'Update the name, icon, and filters for this saved view.' : 'Create a saved view by choosing a name, icon, and filter rules.'}
           </DialogDescription>
@@ -135,6 +143,7 @@ export function CreateViewDialog({ open, onClose, onCreate, availableFields, edi
             initialName={editingView?.name ?? ''}
             initialIcon={editingView?.icon ?? ''}
             initialFilters={initialFilters}
+            initialKind={initialKind}
             isEditing={isEditing}
             onClose={onClose}
             onCreate={onCreate}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   useSidebarSections,
 } from './sidebar/sidebarHooks'
 import {
+  BoardsSection,
   ContextMenuOverlay,
   CustomizeOverlay,
   FavoritesSection,
@@ -39,6 +40,7 @@ interface SidebarProps {
   onReorderFavorites?: (orderedPaths: string[]) => void
   views?: ViewFile[]
   onCreateView?: () => void
+  onCreateBoard?: () => void
   onEditView?: (filename: string) => void
   onDeleteView?: (filename: string) => void
   folders?: FolderNode[]
@@ -66,6 +68,7 @@ export const Sidebar = memo(function Sidebar({
   onReorderFavorites,
   views = [],
   onCreateView,
+  onCreateBoard,
   onEditView,
   onDeleteView,
   folders = [],
@@ -118,7 +121,10 @@ export const Sidebar = memo(function Sidebar({
   }
 
   const hasFavorites = entries.some((entry) => entry.favorite && !entry.archived)
-  const hasViews = views.length > 0 || !!onCreateView
+  const listViews = views.filter((view) => (view.definition.kind ?? 'list') === 'list')
+  const boardViews = views.filter((view) => view.definition.kind === 'kanban')
+  const hasViews = listViews.length > 0 || !!onCreateView
+  const hasBoards = boardViews.length > 0 || !!onCreateBoard
 
   return (
     <aside className="flex h-full flex-col overflow-hidden border-r border-[var(--sidebar-border)] bg-sidebar text-sidebar-foreground">
@@ -153,6 +159,19 @@ export const Sidebar = memo(function Sidebar({
             collapsed={groupCollapsed.views}
             onToggle={() => toggleGroup('views')}
             onCreateView={onCreateView}
+            onEditView={onEditView}
+            onDeleteView={onDeleteView}
+            entries={entries}
+          />
+        )}
+        {hasBoards && (
+          <BoardsSection
+            views={views}
+            selection={selection}
+            onSelect={onSelect}
+            collapsed={groupCollapsed.boards}
+            onToggle={() => toggleGroup('boards')}
+            onCreateBoard={onCreateBoard}
             onEditView={onEditView}
             onDeleteView={onDeleteView}
             entries={entries}

--- a/src/components/kanban/KanbanAgentPanel.tsx
+++ b/src/components/kanban/KanbanAgentPanel.tsx
@@ -97,9 +97,15 @@ export function KanbanAgentPanel({
     }
   }, [agent, allEntries, entry, noteContent, sendMessage])
 
-  const handleStop = useCallback(() => {
-    console.log('[kanban-agent] clear conversation', { path: entry.path })
+  const handleStop = useCallback(async () => {
+    console.log('[kanban-agent] stop requested', { path: entry.path })
     clearConversation()
+    try {
+      const killed = await invoke<boolean>('kill_active_agent')
+      console.log('[kanban-agent] kill_active_agent', { killed })
+    } catch (err) {
+      console.warn('[kanban-agent] kill_active_agent failed', err)
+    }
   }, [clearConversation, entry.path])
 
   const isRunning = status === 'thinking' || status === 'tool-executing' || isBuildingContext

--- a/src/components/kanban/KanbanAgentPanel.tsx
+++ b/src/components/kanban/KanbanAgentPanel.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Play, Stop, Sparkle } from '@phosphor-icons/react'
+import { invoke } from '@tauri-apps/api/core'
+import type { VaultEntry } from '../../types'
+import type { AiAgentId } from '../../lib/aiAgents'
+import { useCliAiAgent, type AgentStatus, type AiAgentMessage } from '../../hooks/useCliAiAgent'
+import { buildKanbanAgentContext } from '../../utils/kanbanAgentContext'
+import { Button } from '@/components/ui/button'
+
+interface KanbanAgentPanelProps {
+  entry: VaultEntry
+  noteContent: string | null
+  allEntries: VaultEntry[]
+  vaultPath: string
+  agent: AiAgentId
+  agentReady: boolean
+  agentLabel: string
+}
+
+const STATUS_LABEL: Record<AgentStatus, string> = {
+  idle: 'Idle',
+  thinking: 'Thinking…',
+  'tool-executing': 'Working…',
+  done: 'Done',
+  error: 'Error',
+}
+
+const STATUS_COLOR: Record<AgentStatus, string> = {
+  idle: 'var(--muted-foreground)',
+  thinking: 'var(--accent-blue)',
+  'tool-executing': 'var(--accent-orange)',
+  done: 'var(--accent-green)',
+  error: 'var(--destructive)',
+}
+
+async function fetchNoteContent(path: string): Promise<string> {
+  return invoke<string>('get_note_content', { path })
+}
+
+function userPreview(message: AiAgentMessage): string {
+  return message.userMessage.length > 200
+    ? message.userMessage.slice(0, 200).trimEnd() + '…'
+    : message.userMessage
+}
+
+export function KanbanAgentPanel({
+  entry,
+  noteContent,
+  allEntries,
+  vaultPath,
+  agent,
+  agentReady,
+  agentLabel,
+}: KanbanAgentPanelProps) {
+  const [contextPrompt, setContextPrompt] = useState<string | undefined>(undefined)
+  const [contextError, setContextError] = useState<string | null>(null)
+  const [isBuildingContext, setIsBuildingContext] = useState(false)
+  const cardPathRef = useRef(entry.path)
+
+  useEffect(() => { cardPathRef.current = entry.path }, [entry.path])
+
+  const { messages, status, sendMessage, clearConversation } = useCliAiAgent(
+    vaultPath,
+    contextPrompt,
+    undefined,
+    { agent, agentReady },
+  )
+
+  const handleRun = useCallback(async () => {
+    if (!noteContent) return
+    setContextError(null)
+    setIsBuildingContext(true)
+    try {
+      const prompt = await buildKanbanAgentContext({
+        entry,
+        noteContent,
+        allEntries,
+        getContent: fetchNoteContent,
+      })
+      setContextPrompt(prompt)
+      console.log('[kanban-agent] running on card', { path: entry.path, agent, contextLength: prompt.length })
+      await sendMessage('Complete the task described above. Make the necessary changes to the vault and summarise.')
+    } catch (err) {
+      console.error('[kanban-agent] failed to start run', err)
+      setContextError(`Failed to start agent: ${err}`)
+    } finally {
+      setIsBuildingContext(false)
+    }
+  }, [agent, allEntries, entry, noteContent, sendMessage])
+
+  const handleStop = useCallback(() => {
+    console.log('[kanban-agent] clear conversation', { path: entry.path })
+    clearConversation()
+  }, [clearConversation, entry.path])
+
+  const isRunning = status === 'thinking' || status === 'tool-executing' || isBuildingContext
+  const canRun = !isRunning && agentReady && !!noteContent
+
+  const renderedMessages = messages
+
+  return (
+    <div className="flex h-full flex-col gap-2 border-t bg-muted/10 p-3" data-testid="kanban-agent-panel">
+      <header className="flex shrink-0 items-center gap-2">
+        <Sparkle size={14} className="text-muted-foreground" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Agent</span>
+        <span className="text-xs text-muted-foreground">·</span>
+        <span className="text-xs text-foreground">{agentLabel}</span>
+        <span
+          className="ml-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
+          style={{ color: STATUS_COLOR[status], background: 'var(--muted)' }}
+          data-testid="kanban-agent-status"
+        >
+          <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: 999, background: STATUS_COLOR[status] }} />
+          {isBuildingContext ? 'Preparing context…' : STATUS_LABEL[status]}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          {isRunning ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              onClick={handleStop}
+              className="h-7 gap-1 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+              data-testid="kanban-agent-stop"
+            >
+              <Stop size={12} weight="fill" />
+              Stop
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="xs"
+              onClick={handleRun}
+              disabled={!canRun}
+              className="h-7 gap-1 text-xs"
+              data-testid="kanban-agent-run"
+            >
+              <Play size={12} weight="fill" />
+              Run on this task
+            </Button>
+          )}
+        </div>
+      </header>
+      {contextError ? (
+        <p className="text-xs text-destructive" data-testid="kanban-agent-error">{contextError}</p>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-y-auto rounded-md border bg-background p-3 text-xs leading-relaxed">
+        {renderedMessages.length === 0 ? (
+          <p className="text-muted-foreground" data-testid="kanban-agent-empty">
+            {agentReady
+              ? 'Click "Run on this task" to start the agent. The note content and any wikilinked notes will be sent as context.'
+              : `${agentLabel} is not ready. Check its installation in Settings before running.`}
+          </p>
+        ) : (
+          <ol className="flex flex-col gap-3">
+            {renderedMessages.map((message, index) => (
+              <li key={message.id ?? `msg-${index}`} className="flex flex-col gap-1">
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">User</span>
+                <pre className="max-w-full whitespace-pre-wrap break-words rounded-md bg-muted/30 px-2 py-1 font-sans text-foreground">
+                  {userPreview(message)}
+                </pre>
+                {message.reasoning ? (
+                  <details className="ml-2">
+                    <summary className="cursor-pointer text-[10px] uppercase tracking-wide text-muted-foreground hover:text-foreground">
+                      Reasoning {message.reasoningDone ? '(done)' : '…'}
+                    </summary>
+                    <pre className="mt-1 max-w-full whitespace-pre-wrap break-words rounded-md bg-muted/20 px-2 py-1 font-sans italic text-muted-foreground">
+                      {message.reasoning}
+                    </pre>
+                  </details>
+                ) : null}
+                {message.response ? (
+                  <>
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      {agentLabel}
+                      {message.isStreaming ? ' (streaming…)' : ''}
+                    </span>
+                    <pre className="max-w-full whitespace-pre-wrap break-words rounded-md bg-background px-2 py-1 font-sans text-foreground">
+                      {message.response}
+                    </pre>
+                  </>
+                ) : message.isStreaming ? (
+                  <span className="text-[10px] italic text-muted-foreground">{agentLabel} is thinking…</span>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/kanban/KanbanAgentPanel.tsx
+++ b/src/components/kanban/KanbanAgentPanel.tsx
@@ -82,9 +82,13 @@ export function KanbanAgentPanel({
         allEntries,
         getContent: fetchNoteContent,
       })
+      // Keep the system prompt override for follow-up messages in the same conversation,
+      // but ALSO inline the context in the first user message so the agent sees it on the
+      // initial round (useState updates don't propagate before the awaited sendMessage call).
       setContextPrompt(prompt)
       console.log('[kanban-agent] running on card', { path: entry.path, agent, contextLength: prompt.length })
-      await sendMessage('Complete the task described above. Make the necessary changes to the vault and summarise.')
+      const inlineMessage = `${prompt}\n\n---\n\nComplete the task described above. Make the necessary changes to the vault and summarise what you did.`
+      await sendMessage(inlineMessage)
     } catch (err) {
       console.error('[kanban-agent] failed to start run', err)
       setContextError(`Failed to start agent: ${err}`)

--- a/src/components/kanban/KanbanAgentPanel.tsx
+++ b/src/components/kanban/KanbanAgentPanel.tsx
@@ -15,6 +15,8 @@ interface KanbanAgentPanelProps {
   agent: AiAgentId
   agentReady: boolean
   agentLabel: string
+  /** Optional callback to move the card to a new status. Used by the "Move to Review" CTA after a successful run. */
+  onUpdateStatus?: (notePath: string, newStatus: string) => Promise<unknown> | void
 }
 
 const STATUS_LABEL: Record<AgentStatus, string> = {
@@ -51,13 +53,16 @@ export function KanbanAgentPanel({
   agent,
   agentReady,
   agentLabel,
+  onUpdateStatus,
 }: KanbanAgentPanelProps) {
   const [contextPrompt, setContextPrompt] = useState<string | undefined>(undefined)
   const [contextError, setContextError] = useState<string | null>(null)
   const [isBuildingContext, setIsBuildingContext] = useState(false)
+  const [reviewSuggestionDismissed, setReviewSuggestionDismissed] = useState(false)
   const cardPathRef = useRef(entry.path)
 
   useEffect(() => { cardPathRef.current = entry.path }, [entry.path])
+  useEffect(() => { setReviewSuggestionDismissed(false) }, [entry.path])
 
   const { messages, status, sendMessage, clearConversation } = useCliAiAgent(
     vaultPath,
@@ -95,6 +100,24 @@ export function KanbanAgentPanel({
 
   const isRunning = status === 'thinking' || status === 'tool-executing' || isBuildingContext
   const canRun = !isRunning && agentReady && !!noteContent
+  const showReviewSuggestion =
+    status === 'done'
+    && !isRunning
+    && !!onUpdateStatus
+    && !reviewSuggestionDismissed
+    && (entry.status ?? 'backlog') !== 'review'
+    && (entry.status ?? 'backlog') !== 'done'
+
+  const handleMoveToReview = useCallback(async () => {
+    if (!onUpdateStatus) return
+    console.log('[kanban-agent] move to review after run', { path: entry.path })
+    setReviewSuggestionDismissed(true)
+    try {
+      await onUpdateStatus(entry.path, 'review')
+    } catch (err) {
+      console.error('[kanban-agent] move to review failed', err)
+    }
+  }, [entry.path, onUpdateStatus])
 
   const renderedMessages = messages
 
@@ -143,6 +166,35 @@ export function KanbanAgentPanel({
       </header>
       {contextError ? (
         <p className="text-xs text-destructive" data-testid="kanban-agent-error">{contextError}</p>
+      ) : null}
+      {showReviewSuggestion ? (
+        <div
+          className="flex items-center justify-between gap-2 rounded-md border border-[var(--accent-green)]/40 bg-[var(--accent-green)]/10 px-2 py-1.5 text-xs"
+          data-testid="kanban-agent-review-suggestion"
+        >
+          <span className="text-foreground">Run finished. Move card to Review?</span>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              onClick={() => setReviewSuggestionDismissed(true)}
+              className="h-6 text-[11px] text-muted-foreground hover:text-foreground"
+              data-testid="kanban-agent-review-dismiss"
+            >
+              Dismiss
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              onClick={handleMoveToReview}
+              className="h-6 text-[11px]"
+              data-testid="kanban-agent-review-confirm"
+            >
+              Move to Review
+            </Button>
+          </div>
+        </div>
       ) : null}
       <div className="min-h-0 flex-1 overflow-y-auto rounded-md border bg-background p-3 text-xs leading-relaxed">
         {renderedMessages.length === 0 ? (

--- a/src/components/kanban/KanbanBoard.test.tsx
+++ b/src/components/kanban/KanbanBoard.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { VaultEntry } from '../../types'
+import { KanbanBoard } from './KanbanBoard'
+
+vi.mock('../../hooks/frontmatterOps', () => ({
+  runFrontmatterAndApply: vi.fn().mockResolvedValue('content'),
+}))
+
+function makeEntry(overrides: Partial<VaultEntry> = {}): VaultEntry {
+  return {
+    path: 'notes/foo.md',
+    filename: 'foo.md',
+    title: 'Foo note',
+    isA: null,
+    aliases: [],
+    belongsTo: [],
+    relatedTo: [],
+    status: null,
+    archived: false,
+    modifiedAt: null,
+    createdAt: null,
+    fileSize: 0,
+    snippet: 'Some snippet',
+    wordCount: 0,
+    relationships: {},
+    icon: null,
+    color: null,
+    order: null,
+    sidebarLabel: null,
+    template: null,
+    sort: null,
+    view: null,
+    visible: null,
+    organized: false,
+    favorite: false,
+    favoriteIndex: null,
+    listPropertiesDisplay: [],
+    outgoingLinks: [],
+    properties: {},
+    hasH1: false,
+    ...overrides,
+  }
+}
+
+function renderBoard(entries: VaultEntry[], extra: Partial<Parameters<typeof KanbanBoard>[0]> = {}) {
+  return render(
+    <KanbanBoard
+      entries={entries}
+      selectedNotePath={null}
+      onSelectNote={vi.fn()}
+      updateTab={vi.fn()}
+      updateEntry={vi.fn()}
+      setToastMessage={vi.fn()}
+      getEntry={vi.fn()}
+      {...extra}
+    />,
+  )
+}
+
+describe('KanbanBoard', () => {
+  it('renders the empty state when there are no entries', () => {
+    renderBoard([])
+    expect(screen.getByTestId('kanban-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('kanban-board')).not.toBeInTheDocument()
+  })
+
+  it('renders the five canonical columns when entries exist', () => {
+    renderBoard([makeEntry({ path: 'a.md', status: 'doing' })])
+    for (const key of ['backlog', 'doing', 'review', 'done', 'blocked']) {
+      expect(screen.getByTestId(`kanban-column-${key}`)).toBeInTheDocument()
+    }
+  })
+
+  it('shows the count badge per column', () => {
+    renderBoard([
+      makeEntry({ path: 'a.md', status: 'doing' }),
+      makeEntry({ path: 'b.md', status: 'doing' }),
+      makeEntry({ path: 'c.md', status: 'done' }),
+    ])
+    expect(screen.getByTestId('kanban-column-count-doing')).toHaveTextContent('2')
+    expect(screen.getByTestId('kanban-column-count-done')).toHaveTextContent('1')
+    expect(screen.getByTestId('kanban-column-count-backlog')).toHaveTextContent('0')
+  })
+
+  it('appends a custom column for non-canonical statuses', () => {
+    renderBoard([makeEntry({ path: 'a.md', status: 'wip' })])
+    const wip = screen.getByTestId('kanban-column-wip')
+    expect(wip).toBeInTheDocument()
+    expect(wip).toHaveTextContent('custom')
+  })
+
+  it('invokes onSelectNote when a card is clicked', () => {
+    const onSelectNote = vi.fn()
+    renderBoard([makeEntry({ path: 'a.md', title: 'Foo', status: 'doing' })], { onSelectNote })
+    fireEvent.click(screen.getByTestId('kanban-card-a.md'))
+    expect(onSelectNote).toHaveBeenCalledTimes(1)
+    expect(onSelectNote.mock.calls[0]?.[0]?.path).toBe('a.md')
+  })
+
+  it('renders the note title and snippet on the card', () => {
+    renderBoard([makeEntry({ path: 'a.md', title: 'My note', snippet: 'A short summary', status: 'doing' })])
+    expect(screen.getByText('My note')).toBeInTheDocument()
+    expect(screen.getByText('A short summary')).toBeInTheDocument()
+  })
+})

--- a/src/components/kanban/KanbanBoard.test.tsx
+++ b/src/components/kanban/KanbanBoard.test.tsx
@@ -3,10 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import type { VaultEntry } from '../../types'
 import { KanbanBoard } from './KanbanBoard'
 
-vi.mock('../../hooks/frontmatterOps', () => ({
-  runFrontmatterAndApply: vi.fn().mockResolvedValue('content'),
-}))
-
 function makeEntry(overrides: Partial<VaultEntry> = {}): VaultEntry {
   return {
     path: 'notes/foo.md',
@@ -49,10 +45,7 @@ function renderBoard(entries: VaultEntry[], extra: Partial<Parameters<typeof Kan
       entries={entries}
       selectedNotePath={null}
       onSelectNote={vi.fn()}
-      updateTab={vi.fn()}
-      updateEntry={vi.fn()}
-      setToastMessage={vi.fn()}
-      getEntry={vi.fn()}
+      onUpdateStatus={vi.fn().mockResolvedValue(undefined)}
       {...extra}
     />,
   )

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -8,13 +8,14 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import type { VaultEntry } from '../../types'
-import { useKanbanModel, type UseKanbanModelDeps } from '../../hooks/useKanbanModel'
+import { useKanbanModel, type UpdateStatusFn } from '../../hooks/useKanbanModel'
 import { KanbanColumn } from './KanbanColumn'
 
-interface KanbanBoardProps extends UseKanbanModelDeps {
+interface KanbanBoardProps {
   entries: VaultEntry[]
   selectedNotePath: string | null
   onSelectNote: (entry: VaultEntry, event: ReactMouseEvent) => void
+  onUpdateStatus: UpdateStatusFn
   emptyMessage?: string
 }
 
@@ -22,10 +23,10 @@ export function KanbanBoard({
   entries,
   selectedNotePath,
   onSelectNote,
+  onUpdateStatus,
   emptyMessage,
-  ...modelDeps
 }: KanbanBoardProps) {
-  const { columns, handleDragEnd } = useKanbanModel(entries, modelDeps)
+  const { columns, handleDragEnd } = useKanbanModel(entries, onUpdateStatus)
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor),

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -1,0 +1,57 @@
+import { type MouseEvent as ReactMouseEvent } from 'react'
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { VaultEntry } from '../../types'
+import { useKanbanModel, type UseKanbanModelDeps } from '../../hooks/useKanbanModel'
+import { KanbanColumn } from './KanbanColumn'
+
+interface KanbanBoardProps extends UseKanbanModelDeps {
+  entries: VaultEntry[]
+  selectedNotePath: string | null
+  onSelectNote: (entry: VaultEntry, event: ReactMouseEvent) => void
+  emptyMessage?: string
+}
+
+export function KanbanBoard({
+  entries,
+  selectedNotePath,
+  onSelectNote,
+  emptyMessage,
+  ...modelDeps
+}: KanbanBoardProps) {
+  const { columns, handleDragEnd } = useKanbanModel(entries, modelDeps)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
+  )
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground" data-testid="kanban-empty">
+        {emptyMessage ?? 'No notes match this board.'}
+      </div>
+    )
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+      <div className="flex h-full gap-3 overflow-x-auto p-3" data-testid="kanban-board">
+        {columns.map((column) => (
+          <KanbanColumn
+            key={column.status.key}
+            status={column.status}
+            cards={column.cards}
+            selectedNotePath={selectedNotePath}
+            onClickNote={onSelectNote}
+          />
+        ))}
+      </div>
+    </DndContext>
+  )
+}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -1,15 +1,19 @@
-import { type MouseEvent as ReactMouseEvent } from 'react'
+import { useCallback, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   DndContext,
+  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   closestCorners,
   useSensor,
   useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
 } from '@dnd-kit/core'
 import type { VaultEntry } from '../../types'
 import { useKanbanModel, type UpdateStatusFn } from '../../hooks/useKanbanModel'
 import { KanbanColumn } from './KanbanColumn'
+import { KanbanCard } from './KanbanCard'
 
 interface KanbanBoardProps {
   entries: VaultEntry[]
@@ -31,6 +35,22 @@ export function KanbanBoard({
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor),
   )
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const activeEntry = activeId ? entries.find((entry) => entry.path === activeId) ?? null : null
+
+  const handleStart = useCallback((event: DragStartEvent) => {
+    setActiveId(String(event.active.id))
+  }, [])
+
+  const handleEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null)
+      void handleDragEnd(event)
+    },
+    [handleDragEnd],
+  )
+
+  const handleCancel = useCallback(() => setActiveId(null), [])
 
   if (entries.length === 0) {
     return (
@@ -41,7 +61,13 @@ export function KanbanBoard({
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleStart}
+      onDragEnd={handleEnd}
+      onDragCancel={handleCancel}
+    >
       <div className="flex h-full gap-3 overflow-x-auto p-3" data-testid="kanban-board">
         {columns.map((column) => (
           <KanbanColumn
@@ -49,10 +75,16 @@ export function KanbanBoard({
             status={column.status}
             cards={column.cards}
             selectedNotePath={selectedNotePath}
+            activeDragId={activeId}
             onClickNote={onSelectNote}
           />
         ))}
       </div>
+      <DragOverlay dropAnimation={null}>
+        {activeEntry ? (
+          <KanbanCard entry={activeEntry} onClickNote={() => undefined} dragOverlay />
+        ) : null}
+      </DragOverlay>
     </DndContext>
   )
 }

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,0 +1,47 @@
+import { type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react'
+import { useDraggable } from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import type { VaultEntry } from '../../types'
+import { NoteTitleIcon } from '../NoteTitleIcon'
+import { cn } from '@/lib/utils'
+
+interface KanbanCardProps {
+  entry: VaultEntry
+  isSelected?: boolean
+  onClickNote: (entry: VaultEntry, event: ReactMouseEvent) => void
+}
+
+const CARD_BASE_CLASS = 'flex select-none flex-col gap-1.5 rounded-md border bg-background p-3 text-sm shadow-sm transition-colors hover:border-foreground/30 hover:bg-muted/40'
+
+export function KanbanCard({ entry, isSelected = false, onClickNote }: KanbanCardProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: entry.path })
+
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.5 : 1,
+    cursor: isDragging ? 'grabbing' : 'grab',
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(CARD_BASE_CLASS, isSelected && 'border-foreground/40 bg-muted/40')}
+      {...listeners}
+      {...attributes}
+      onClick={(event) => {
+        if (isDragging) return
+        onClickNote(entry, event)
+      }}
+      data-testid={`kanban-card-${entry.path}`}
+    >
+      <div className="flex items-center gap-1.5 text-foreground">
+        <NoteTitleIcon icon={entry.icon} size={14} />
+        <span className="truncate font-medium">{entry.title || entry.filename}</span>
+      </div>
+      {entry.snippet ? (
+        <p className="line-clamp-2 text-xs text-muted-foreground">{entry.snippet}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,6 +1,5 @@
 import { type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react'
 import { useDraggable } from '@dnd-kit/core'
-import { CSS } from '@dnd-kit/utilities'
 import type { VaultEntry } from '../../types'
 import { NoteTitleIcon } from '../NoteTitleIcon'
 import { cn } from '@/lib/utils'
@@ -8,29 +7,41 @@ import { cn } from '@/lib/utils'
 interface KanbanCardProps {
   entry: VaultEntry
   isSelected?: boolean
+  isPlaceholder?: boolean
+  dragOverlay?: boolean
   onClickNote: (entry: VaultEntry, event: ReactMouseEvent) => void
 }
 
-const CARD_BASE_CLASS = 'flex select-none flex-col gap-1.5 rounded-md border bg-background p-3 text-sm shadow-sm transition-colors hover:border-foreground/30 hover:bg-muted/40'
+const CARD_BASE_CLASS = 'flex flex-col gap-1.5 rounded-md border bg-background p-3 text-sm shadow-sm transition-colors hover:border-foreground/30 hover:bg-muted/40'
 
-export function KanbanCard({ entry, isSelected = false, onClickNote }: KanbanCardProps) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: entry.path })
+export function KanbanCard({ entry, isSelected = false, isPlaceholder = false, dragOverlay = false, onClickNote }: KanbanCardProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: entry.path,
+    disabled: dragOverlay,
+  })
 
-  const style: CSSProperties = {
-    transform: CSS.Translate.toString(transform),
-    opacity: isDragging ? 0.5 : 1,
-    cursor: isDragging ? 'grabbing' : 'grab',
-  }
+  const placeholderStyle: CSSProperties = isPlaceholder || isDragging
+    ? { opacity: 0, pointerEvents: 'none' }
+    : {}
+
+  const overlayStyle: CSSProperties = dragOverlay
+    ? { cursor: 'grabbing', boxShadow: '0 12px 32px -8px rgba(0,0,0,0.35)', transform: 'rotate(1.5deg)' }
+    : {}
 
   return (
     <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(CARD_BASE_CLASS, isSelected && 'border-foreground/40 bg-muted/40')}
-      {...listeners}
-      {...attributes}
+      ref={dragOverlay ? undefined : setNodeRef}
+      style={{ ...placeholderStyle, ...overlayStyle }}
+      className={cn(
+        CARD_BASE_CLASS,
+        'select-none',
+        isSelected && 'border-foreground/40 bg-muted/40',
+        !dragOverlay && 'cursor-grab active:cursor-grabbing',
+      )}
+      {...(dragOverlay ? {} : listeners)}
+      {...(dragOverlay ? {} : attributes)}
       onClick={(event) => {
-        if (isDragging) return
+        if (dragOverlay) return
         onClickNote(entry, event)
       }}
       data-testid={`kanban-card-${entry.path}`}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -1,0 +1,61 @@
+import { type MouseEvent as ReactMouseEvent } from 'react'
+import { useDroppable } from '@dnd-kit/core'
+import type { VaultEntry } from '../../types'
+import type { KanbanStatusDef } from '../../utils/kanbanStatuses'
+import { KanbanCard } from './KanbanCard'
+import { cn } from '@/lib/utils'
+
+interface KanbanColumnProps {
+  status: KanbanStatusDef
+  cards: VaultEntry[]
+  selectedNotePath: string | null
+  onClickNote: (entry: VaultEntry, event: ReactMouseEvent) => void
+}
+
+export function KanbanColumn({ status, cards, selectedNotePath, onClickNote }: KanbanColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: status.key })
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={cn(
+        'flex h-full min-w-[260px] max-w-[320px] flex-1 flex-col overflow-hidden rounded-lg border bg-muted/20 transition-colors',
+        isOver && 'border-foreground/40 bg-muted/40',
+      )}
+      data-testid={`kanban-column-${status.key}`}
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b bg-background/50 px-3 py-2">
+        <span
+          aria-hidden="true"
+          style={{ width: 8, height: 8, borderRadius: 999, background: status.color }}
+        />
+        <span className="text-sm font-semibold uppercase tracking-wide text-foreground">
+          {status.label}
+        </span>
+        {!status.canonical ? (
+          <span className="text-[10px] uppercase text-muted-foreground" title="Custom status">custom</span>
+        ) : null}
+        <span
+          className="ml-auto rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+          data-testid={`kanban-column-count-${status.key}`}
+        >
+          {cards.length}
+        </span>
+      </header>
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-2">
+        {cards.length === 0 ? (
+          <p className="px-2 py-6 text-center text-xs text-muted-foreground">No tasks</p>
+        ) : (
+          cards.map((entry) => (
+            <KanbanCard
+              key={entry.path}
+              entry={entry}
+              isSelected={selectedNotePath === entry.path}
+              onClickNote={onClickNote}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -9,17 +9,18 @@ interface KanbanColumnProps {
   status: KanbanStatusDef
   cards: VaultEntry[]
   selectedNotePath: string | null
+  activeDragId?: string | null
   onClickNote: (entry: VaultEntry, event: ReactMouseEvent) => void
 }
 
-export function KanbanColumn({ status, cards, selectedNotePath, onClickNote }: KanbanColumnProps) {
+export function KanbanColumn({ status, cards, selectedNotePath, activeDragId = null, onClickNote }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status.key })
 
   return (
     <section
       ref={setNodeRef}
       className={cn(
-        'flex h-full min-w-[260px] max-w-[320px] flex-1 flex-col overflow-hidden rounded-lg border bg-muted/20 transition-colors',
+        'flex h-full min-w-[220px] max-w-[320px] flex-1 basis-[260px] flex-col overflow-hidden rounded-lg border bg-muted/20 transition-colors',
         isOver && 'border-foreground/40 bg-muted/40',
       )}
       data-testid={`kanban-column-${status.key}`}
@@ -51,6 +52,7 @@ export function KanbanColumn({ status, cards, selectedNotePath, onClickNote }: K
               key={entry.path}
               entry={entry}
               isSelected={selectedNotePath === entry.path}
+              isPlaceholder={activeDragId === entry.path}
               onClickNote={onClickNote}
             />
           ))

--- a/src/components/sidebar/SidebarSections.tsx
+++ b/src/components/sidebar/SidebarSections.tsx
@@ -39,6 +39,63 @@ export interface SidebarSectionProps {
   onRenameCancel: () => void
 }
 
+interface ViewListSectionProps {
+  label: string
+  views: ViewFile[]
+  selection: SidebarSelection
+  onSelect: (selection: SidebarSelection) => void
+  collapsed: boolean
+  onToggle: () => void
+  onCreate?: () => void
+  onEditView?: (filename: string) => void
+  onDeleteView?: (filename: string) => void
+  entries: VaultEntry[]
+  testId?: string
+}
+
+function ViewListSection({
+  label,
+  views,
+  selection,
+  onSelect,
+  collapsed,
+  onToggle,
+  onCreate,
+  onEditView,
+  onDeleteView,
+  entries,
+  testId,
+}: ViewListSectionProps) {
+  return (
+    <div className="border-b border-border" style={{ padding: '0 6px' }} data-testid={testId}>
+      <SidebarGroupHeader label={label} collapsed={collapsed} onToggle={onToggle}>
+        {onCreate && (
+          <Plus
+            size={12}
+            className="text-muted-foreground hover:text-foreground"
+            onClick={(event) => { event.stopPropagation(); onCreate() }}
+          />
+        )}
+      </SidebarGroupHeader>
+      {!collapsed && (
+        <div style={{ paddingBottom: 4 }}>
+          {views.map((view) => (
+            <SidebarViewItem
+              key={view.filename}
+              view={view}
+              isActive={isSelectionActive(selection, { kind: 'view', filename: view.filename })}
+              onSelect={() => onSelect({ kind: 'view', filename: view.filename })}
+              onEditView={onEditView}
+              onDeleteView={onDeleteView}
+              entries={entries}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function ViewsSection({
   views,
   selection,
@@ -60,33 +117,60 @@ export function ViewsSection({
   onDeleteView?: (filename: string) => void
   entries: VaultEntry[]
 }) {
+  const listViews = views.filter((view) => (view.definition.kind ?? 'list') === 'list')
   return (
-    <div className="border-b border-border" style={{ padding: '0 6px' }}>
-      <SidebarGroupHeader label="VIEWS" collapsed={collapsed} onToggle={onToggle}>
-        {onCreateView && (
-          <Plus
-            size={12}
-            className="text-muted-foreground hover:text-foreground"
-            onClick={(event) => { event.stopPropagation(); onCreateView() }}
-          />
-        )}
-      </SidebarGroupHeader>
-      {!collapsed && (
-        <div style={{ paddingBottom: 4 }}>
-          {views.map((view) => (
-            <SidebarViewItem
-              key={view.filename}
-              view={view}
-              isActive={isSelectionActive(selection, { kind: 'view', filename: view.filename })}
-              onSelect={() => onSelect({ kind: 'view', filename: view.filename })}
-              onEditView={onEditView}
-              onDeleteView={onDeleteView}
-              entries={entries}
-            />
-          ))}
-        </div>
-      )}
-    </div>
+    <ViewListSection
+      label="VIEWS"
+      views={listViews}
+      selection={selection}
+      onSelect={onSelect}
+      collapsed={collapsed}
+      onToggle={onToggle}
+      onCreate={onCreateView}
+      onEditView={onEditView}
+      onDeleteView={onDeleteView}
+      entries={entries}
+      testId="sidebar-views-section"
+    />
+  )
+}
+
+export function BoardsSection({
+  views,
+  selection,
+  onSelect,
+  collapsed,
+  onToggle,
+  onCreateBoard,
+  onEditView,
+  onDeleteView,
+  entries,
+}: {
+  views: ViewFile[]
+  selection: SidebarSelection
+  onSelect: (selection: SidebarSelection) => void
+  collapsed: boolean
+  onToggle: () => void
+  onCreateBoard?: () => void
+  onEditView?: (filename: string) => void
+  onDeleteView?: (filename: string) => void
+  entries: VaultEntry[]
+}) {
+  const boardViews = views.filter((view) => view.definition.kind === 'kanban')
+  return (
+    <ViewListSection
+      label="BOARDS"
+      views={boardViews}
+      selection={selection}
+      onSelect={onSelect}
+      collapsed={collapsed}
+      onToggle={onToggle}
+      onCreate={onCreateBoard}
+      onEditView={onEditView}
+      onDeleteView={onDeleteView}
+      entries={entries}
+      testId="sidebar-boards-section"
+    />
   )
 }
 

--- a/src/components/sidebar/sidebarHooks.ts
+++ b/src/components/sidebar/sidebarHooks.ts
@@ -5,7 +5,7 @@ import { buildTypeEntryMap } from '../../utils/typeColors'
 import { countAllNotesByFilter } from '../../utils/noteListHelpers'
 import { buildDynamicSections, sortSections } from '../../utils/sidebarSections'
 
-export type SidebarGroupKey = 'favorites' | 'views' | 'sections' | 'folders'
+export type SidebarGroupKey = 'favorites' | 'views' | 'boards' | 'sections' | 'folders'
 
 export function useOutsideClick(ref: RefObject<HTMLElement | null>, isOpen: boolean, onClose: () => void) {
   useEffect(() => {
@@ -32,14 +32,18 @@ export function useSidebarSections(entries: VaultEntry[]) {
   return { typeEntryMap, allSectionGroups, visibleSections, sectionIds }
 }
 
+const DEFAULT_COLLAPSED_STATE: Record<SidebarGroupKey, boolean> = {
+  favorites: false, views: false, boards: false, sections: false, folders: false,
+}
+
 function loadCollapsedState(): Record<SidebarGroupKey, boolean> {
   try {
     const raw = getAppStorageItem('sidebarCollapsed')
-    if (raw) return JSON.parse(raw)
+    if (raw) return { ...DEFAULT_COLLAPSED_STATE, ...JSON.parse(raw) }
   } catch {
     // Ignore localStorage failures and fall back to defaults.
   }
-  return { favorites: false, views: false, sections: false, folders: false }
+  return { ...DEFAULT_COLLAPSED_STATE }
 }
 
 export function useSidebarCollapsed() {

--- a/src/hooks/useDialogs.ts
+++ b/src/hooks/useDialogs.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import type { ViewDefinition } from '../types'
+import type { ViewDefinition, ViewKind } from '../types'
 
 export function useDialogs() {
   const [showCreateTypeDialog, setShowCreateTypeDialog] = useState(false)
@@ -12,6 +12,7 @@ export function useDialogs() {
   const [showConflictResolver, setShowConflictResolver] = useState(false)
   const [showCreateViewDialog, setShowCreateViewDialog] = useState(false)
   const [editingView, setEditingView] = useState<{ filename: string; definition: ViewDefinition } | null>(null)
+  const [createViewDefaultKind, setCreateViewDefaultKind] = useState<ViewKind>('list')
 
   const openCreateType = useCallback(() => setShowCreateTypeDialog(true), [])
   const closeCreateType = useCallback(() => setShowCreateTypeDialog(false), [])
@@ -28,8 +29,9 @@ export function useDialogs() {
   const closeSearch = useCallback(() => setShowSearch(false), [])
   const openConflictResolver = useCallback(() => setShowConflictResolver(true), [])
   const closeConflictResolver = useCallback(() => setShowConflictResolver(false), [])
-  const openCreateView = useCallback(() => { setEditingView(null); setShowCreateViewDialog(true) }, [])
-  const closeCreateView = useCallback(() => { setShowCreateViewDialog(false); setEditingView(null) }, [])
+  const openCreateView = useCallback(() => { setEditingView(null); setCreateViewDefaultKind('list'); setShowCreateViewDialog(true) }, [])
+  const openCreateBoard = useCallback(() => { setEditingView(null); setCreateViewDefaultKind('kanban'); setShowCreateViewDialog(true) }, [])
+  const closeCreateView = useCallback(() => { setShowCreateViewDialog(false); setEditingView(null); setCreateViewDefaultKind('list') }, [])
   const openEditView = useCallback((filename: string, definition: ViewDefinition) => {
     setEditingView({ filename, definition })
     setShowCreateViewDialog(true)
@@ -44,6 +46,6 @@ export function useDialogs() {
     showCloneVault, openCloneVault, closeCloneVault,
     showSearch, openSearch, closeSearch,
     showConflictResolver, openConflictResolver, closeConflictResolver,
-    showCreateViewDialog, openCreateView, closeCreateView, editingView, openEditView,
+    showCreateViewDialog, openCreateView, openCreateBoard, closeCreateView, editingView, openEditView, createViewDefaultKind,
   }
 }

--- a/src/hooks/useKanbanModel.test.tsx
+++ b/src/hooks/useKanbanModel.test.tsx
@@ -1,12 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { VaultEntry } from '../types'
 import { groupByStatus, useKanbanModel } from './useKanbanModel'
-
-const runFrontmatterAndApply = vi.hoisted(() => vi.fn().mockResolvedValue('content'))
-vi.mock('./frontmatterOps', () => ({
-  runFrontmatterAndApply: runFrontmatterAndApply,
-}))
 
 function makeEntry(overrides: Partial<VaultEntry> = {}): VaultEntry {
   return {
@@ -104,64 +99,49 @@ describe('groupByStatus', () => {
 })
 
 describe('useKanbanModel', () => {
-  beforeEach(() => {
-    runFrontmatterAndApply.mockClear()
-  })
-
   it('exposes a memoised columns list', () => {
     const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
-    const { result } = renderHook(() => useKanbanModel(entries, makeDeps()))
+    const { result } = renderHook(() => useKanbanModel(entries, vi.fn()))
     expect(result.current.columns.find((column) => column.status.key === 'doing')?.cards).toHaveLength(1)
   })
 
-  it('writes the new status when a card is dropped on a different column', async () => {
+  it('calls onUpdateStatus with the new column when a card is dropped on a different column', async () => {
     const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
-    const deps = makeDeps()
-    const { result } = renderHook(() => useKanbanModel(entries, deps))
+    const onUpdateStatus = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useKanbanModel(entries, onUpdateStatus))
     await act(async () => {
       await result.current.handleDragEnd({ active: { id: 'a.md' }, over: { id: 'done' } } as never)
     })
-    expect(runFrontmatterAndApply).toHaveBeenCalledTimes(1)
-    expect(runFrontmatterAndApply.mock.calls[0]?.slice(0, 4)).toEqual([
-      'update',
-      'a.md',
-      'status',
-      'done',
-    ])
+    expect(onUpdateStatus).toHaveBeenCalledTimes(1)
+    expect(onUpdateStatus).toHaveBeenCalledWith('a.md', 'done')
   })
 
-  it('skips the write when dropped on the same column', async () => {
+  it('skips the call when dropped on the same column', async () => {
     const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
-    const { result } = renderHook(() => useKanbanModel(entries, makeDeps()))
+    const onUpdateStatus = vi.fn()
+    const { result } = renderHook(() => useKanbanModel(entries, onUpdateStatus))
     await act(async () => {
       await result.current.handleDragEnd({ active: { id: 'a.md' }, over: { id: 'doing' } } as never)
     })
-    expect(runFrontmatterAndApply).not.toHaveBeenCalled()
+    expect(onUpdateStatus).not.toHaveBeenCalled()
   })
 
-  it('skips the write when dropped outside any column', async () => {
+  it('skips the call when dropped outside any column', async () => {
     const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
-    const { result } = renderHook(() => useKanbanModel(entries, makeDeps()))
+    const onUpdateStatus = vi.fn()
+    const { result } = renderHook(() => useKanbanModel(entries, onUpdateStatus))
     await act(async () => {
       await result.current.handleDragEnd({ active: { id: 'a.md' }, over: null } as never)
     })
-    expect(runFrontmatterAndApply).not.toHaveBeenCalled()
+    expect(onUpdateStatus).not.toHaveBeenCalled()
   })
 
-  it('skips the write when the dragged note is unknown', async () => {
-    const { result } = renderHook(() => useKanbanModel([], makeDeps()))
+  it('skips the call when the dragged note is unknown', async () => {
+    const onUpdateStatus = vi.fn()
+    const { result } = renderHook(() => useKanbanModel([], onUpdateStatus))
     await act(async () => {
       await result.current.handleDragEnd({ active: { id: 'ghost.md' }, over: { id: 'done' } } as never)
     })
-    expect(runFrontmatterAndApply).not.toHaveBeenCalled()
+    expect(onUpdateStatus).not.toHaveBeenCalled()
   })
 })
-
-function makeDeps() {
-  return {
-    updateTab: vi.fn(),
-    updateEntry: vi.fn(),
-    setToastMessage: vi.fn(),
-    getEntry: vi.fn(),
-  }
-}

--- a/src/hooks/useKanbanModel.test.tsx
+++ b/src/hooks/useKanbanModel.test.tsx
@@ -1,0 +1,167 @@
+import { renderHook, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VaultEntry } from '../types'
+import { groupByStatus, useKanbanModel } from './useKanbanModel'
+
+const runFrontmatterAndApply = vi.hoisted(() => vi.fn().mockResolvedValue('content'))
+vi.mock('./frontmatterOps', () => ({
+  runFrontmatterAndApply: runFrontmatterAndApply,
+}))
+
+function makeEntry(overrides: Partial<VaultEntry> = {}): VaultEntry {
+  return {
+    path: 'notes/foo.md',
+    filename: 'foo.md',
+    title: 'Foo',
+    isA: null,
+    aliases: [],
+    belongsTo: [],
+    relatedTo: [],
+    status: null,
+    archived: false,
+    modifiedAt: null,
+    createdAt: null,
+    fileSize: 0,
+    snippet: '',
+    wordCount: 0,
+    relationships: {},
+    icon: null,
+    color: null,
+    order: null,
+    sidebarLabel: null,
+    template: null,
+    sort: null,
+    view: null,
+    visible: null,
+    organized: false,
+    favorite: false,
+    favoriteIndex: null,
+    listPropertiesDisplay: [],
+    outgoingLinks: [],
+    properties: {},
+    hasH1: false,
+    ...overrides,
+  }
+}
+
+describe('groupByStatus', () => {
+  it('always emits the five canonical columns even when empty', () => {
+    const columns = groupByStatus([])
+    expect(columns.map((column) => column.status.key)).toEqual([
+      'backlog',
+      'doing',
+      'review',
+      'done',
+      'blocked',
+    ])
+    for (const column of columns) {
+      expect(column.cards).toEqual([])
+    }
+  })
+
+  it('places notes in their declared canonical bucket', () => {
+    const columns = groupByStatus([
+      makeEntry({ path: 'a.md', status: 'doing' }),
+      makeEntry({ path: 'b.md', status: 'done' }),
+      makeEntry({ path: 'c.md', status: 'doing' }),
+    ])
+    const doing = columns.find((column) => column.status.key === 'doing')
+    const done = columns.find((column) => column.status.key === 'done')
+    expect(doing?.cards.map((card) => card.path)).toEqual(['a.md', 'c.md'])
+    expect(done?.cards.map((card) => card.path)).toEqual(['b.md'])
+  })
+
+  it('routes notes with null or empty status to backlog', () => {
+    const columns = groupByStatus([
+      makeEntry({ path: 'a.md', status: null }),
+      makeEntry({ path: 'b.md', status: '' }),
+      makeEntry({ path: 'c.md', status: '   ' }),
+    ])
+    const backlog = columns.find((column) => column.status.key === 'backlog')
+    expect(backlog?.cards.map((card) => card.path)).toEqual(['a.md', 'b.md', 'c.md'])
+  })
+
+  it('creates extra columns for non-canonical statuses, alphabetically after canonical', () => {
+    const columns = groupByStatus([
+      makeEntry({ path: 'a.md', status: 'wip' }),
+      makeEntry({ path: 'b.md', status: 'archived' }),
+    ])
+    const keys = columns.map((column) => column.status.key)
+    expect(keys.slice(0, 5)).toEqual(['backlog', 'doing', 'review', 'done', 'blocked'])
+    expect(keys.slice(5)).toEqual(['archived', 'wip'])
+    const wip = columns.find((column) => column.status.key === 'wip')
+    expect(wip?.status.canonical).toBe(false)
+  })
+
+  it('sorts cards inside a column by modifiedAt descending', () => {
+    const columns = groupByStatus([
+      makeEntry({ path: 'older.md', status: 'doing', modifiedAt: 100 }),
+      makeEntry({ path: 'newer.md', status: 'doing', modifiedAt: 200 }),
+    ])
+    const doing = columns.find((column) => column.status.key === 'doing')
+    expect(doing?.cards.map((card) => card.path)).toEqual(['newer.md', 'older.md'])
+  })
+})
+
+describe('useKanbanModel', () => {
+  beforeEach(() => {
+    runFrontmatterAndApply.mockClear()
+  })
+
+  it('exposes a memoised columns list', () => {
+    const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
+    const { result } = renderHook(() => useKanbanModel(entries, makeDeps()))
+    expect(result.current.columns.find((column) => column.status.key === 'doing')?.cards).toHaveLength(1)
+  })
+
+  it('writes the new status when a card is dropped on a different column', async () => {
+    const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
+    const deps = makeDeps()
+    const { result } = renderHook(() => useKanbanModel(entries, deps))
+    await act(async () => {
+      await result.current.handleDragEnd({ active: { id: 'a.md' }, over: { id: 'done' } } as never)
+    })
+    expect(runFrontmatterAndApply).toHaveBeenCalledTimes(1)
+    expect(runFrontmatterAndApply.mock.calls[0]?.slice(0, 4)).toEqual([
+      'update',
+      'a.md',
+      'status',
+      'done',
+    ])
+  })
+
+  it('skips the write when dropped on the same column', async () => {
+    const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
+    const { result } = renderHook(() => useKanbanModel(entries, makeDeps()))
+    await act(async () => {
+      await result.current.handleDragEnd({ active: { id: 'a.md' }, over: { id: 'doing' } } as never)
+    })
+    expect(runFrontmatterAndApply).not.toHaveBeenCalled()
+  })
+
+  it('skips the write when dropped outside any column', async () => {
+    const entries = [makeEntry({ path: 'a.md', status: 'doing' })]
+    const { result } = renderHook(() => useKanbanModel(entries, makeDeps()))
+    await act(async () => {
+      await result.current.handleDragEnd({ active: { id: 'a.md' }, over: null } as never)
+    })
+    expect(runFrontmatterAndApply).not.toHaveBeenCalled()
+  })
+
+  it('skips the write when the dragged note is unknown', async () => {
+    const { result } = renderHook(() => useKanbanModel([], makeDeps()))
+    await act(async () => {
+      await result.current.handleDragEnd({ active: { id: 'ghost.md' }, over: { id: 'done' } } as never)
+    })
+    expect(runFrontmatterAndApply).not.toHaveBeenCalled()
+  })
+})
+
+function makeDeps() {
+  return {
+    updateTab: vi.fn(),
+    updateEntry: vi.fn(),
+    setToastMessage: vi.fn(),
+    getEntry: vi.fn(),
+  }
+}

--- a/src/hooks/useKanbanModel.ts
+++ b/src/hooks/useKanbanModel.ts
@@ -1,0 +1,81 @@
+import { useCallback, useMemo } from 'react'
+import type { DragEndEvent } from '@dnd-kit/core'
+import type { VaultEntry } from '../types'
+import {
+  CANONICAL_STATUSES,
+  customStatusDef,
+  getCanonicalStatus,
+  statusKeyOf,
+  type KanbanStatusDef,
+} from '../utils/kanbanStatuses'
+import { runFrontmatterAndApply } from './frontmatterOps'
+
+export interface KanbanColumn {
+  status: KanbanStatusDef
+  cards: VaultEntry[]
+}
+
+export interface UseKanbanModelDeps {
+  updateTab: (path: string, content: string) => void
+  updateEntry: (path: string, patch: Partial<VaultEntry>) => void
+  setToastMessage: (message: string | null) => void
+  getEntry?: (path: string) => VaultEntry | undefined
+}
+
+function compareEntriesByModifiedDesc(a: VaultEntry, b: VaultEntry): number {
+  return (b.modifiedAt ?? 0) - (a.modifiedAt ?? 0)
+}
+
+export function groupByStatus(entries: VaultEntry[]): KanbanColumn[] {
+  const buckets = new Map<string, VaultEntry[]>()
+  for (const status of CANONICAL_STATUSES) {
+    buckets.set(status.key, [])
+  }
+  for (const entry of entries) {
+    const key = statusKeyOf(entry.status)
+    if (!buckets.has(key)) buckets.set(key, [])
+    buckets.get(key)!.push(entry)
+  }
+
+  const canonicalKeys = new Set(CANONICAL_STATUSES.map((status) => status.key))
+  const customKeys = [...buckets.keys()].filter((key) => !canonicalKeys.has(key)).sort()
+  const orderedKeys = [...CANONICAL_STATUSES.map((status) => status.key), ...customKeys]
+
+  return orderedKeys.map((key) => ({
+    status: getCanonicalStatus(key) ?? customStatusDef(key),
+    cards: (buckets.get(key) ?? []).sort(compareEntriesByModifiedDesc),
+  }))
+}
+
+export function useKanbanModel(entries: VaultEntry[], deps: UseKanbanModelDeps) {
+  const columns = useMemo<KanbanColumn[]>(() => groupByStatus(entries), [entries])
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const notePath = String(event.active.id)
+      const targetStatus = event.over ? String(event.over.id) : null
+      if (!targetStatus) return
+      const entry = entries.find((candidate) => candidate.path === notePath)
+      if (!entry) return
+      const currentStatus = statusKeyOf(entry.status)
+      if (currentStatus === targetStatus) return
+
+      await runFrontmatterAndApply(
+        'update',
+        notePath,
+        'status',
+        targetStatus,
+        {
+          updateTab: deps.updateTab,
+          updateEntry: deps.updateEntry,
+          toast: deps.setToastMessage,
+          getEntry: deps.getEntry,
+        },
+        { silent: true },
+      )
+    },
+    [entries, deps],
+  )
+
+  return { columns, handleDragEnd }
+}

--- a/src/hooks/useKanbanModel.ts
+++ b/src/hooks/useKanbanModel.ts
@@ -48,11 +48,21 @@ export function useKanbanModel(entries: VaultEntry[], onUpdateStatus: UpdateStat
     async (event: DragEndEvent) => {
       const notePath = String(event.active.id)
       const targetStatus = event.over ? String(event.over.id) : null
-      if (!targetStatus) return
+      if (!targetStatus) {
+        console.log('[kanban] drag dropped outside any column', { notePath })
+        return
+      }
       const entry = entries.find((candidate) => candidate.path === notePath)
-      if (!entry) return
+      if (!entry) {
+        console.warn('[kanban] dragged entry not found in current entries', { notePath, targetStatus })
+        return
+      }
       const currentStatus = statusKeyOf(entry.status)
-      if (currentStatus === targetStatus) return
+      if (currentStatus === targetStatus) {
+        console.log('[kanban] drop on same column, no-op', { notePath, status: currentStatus })
+        return
+      }
+      console.log('[kanban] drag end -> status change', { notePath, from: currentStatus, to: targetStatus })
       await onUpdateStatus(notePath, targetStatus)
     },
     [entries, onUpdateStatus],

--- a/src/hooks/useKanbanModel.ts
+++ b/src/hooks/useKanbanModel.ts
@@ -8,19 +8,13 @@ import {
   statusKeyOf,
   type KanbanStatusDef,
 } from '../utils/kanbanStatuses'
-import { runFrontmatterAndApply } from './frontmatterOps'
 
 export interface KanbanColumn {
   status: KanbanStatusDef
   cards: VaultEntry[]
 }
 
-export interface UseKanbanModelDeps {
-  updateTab: (path: string, content: string) => void
-  updateEntry: (path: string, patch: Partial<VaultEntry>) => void
-  setToastMessage: (message: string | null) => void
-  getEntry?: (path: string) => VaultEntry | undefined
-}
+export type UpdateStatusFn = (notePath: string, newStatus: string) => Promise<unknown> | void
 
 function compareEntriesByModifiedDesc(a: VaultEntry, b: VaultEntry): number {
   return (b.modifiedAt ?? 0) - (a.modifiedAt ?? 0)
@@ -47,7 +41,7 @@ export function groupByStatus(entries: VaultEntry[]): KanbanColumn[] {
   }))
 }
 
-export function useKanbanModel(entries: VaultEntry[], deps: UseKanbanModelDeps) {
+export function useKanbanModel(entries: VaultEntry[], onUpdateStatus: UpdateStatusFn) {
   const columns = useMemo<KanbanColumn[]>(() => groupByStatus(entries), [entries])
 
   const handleDragEnd = useCallback(
@@ -59,22 +53,9 @@ export function useKanbanModel(entries: VaultEntry[], deps: UseKanbanModelDeps) 
       if (!entry) return
       const currentStatus = statusKeyOf(entry.status)
       if (currentStatus === targetStatus) return
-
-      await runFrontmatterAndApply(
-        'update',
-        notePath,
-        'status',
-        targetStatus,
-        {
-          updateTab: deps.updateTab,
-          updateEntry: deps.updateEntry,
-          toast: deps.setToastMessage,
-          getEntry: deps.getEntry,
-        },
-        { silent: true },
-      )
+      await onUpdateStatus(notePath, targetStatus)
     },
-    [entries, deps],
+    [entries, onUpdateStatus],
   )
 
   return { columns, handleDragEnd }

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,6 +210,8 @@ export interface FilterCondition {
 export type FilterGroup = { all: FilterNode[] } | { any: FilterNode[] }
 export type FilterNode = FilterCondition | FilterGroup
 
+export type ViewKind = 'list' | 'kanban'
+
 export interface ViewDefinition {
   name: string
   icon: string | null
@@ -217,6 +219,8 @@ export interface ViewDefinition {
   sort: string | null
   listPropertiesDisplay?: string[]
   filters: FilterGroup
+  /** UI rendering mode. Absent or 'list' = the classic note list. 'kanban' = a board grouped by status. */
+  kind?: ViewKind
 }
 
 export interface ViewFile {

--- a/src/utils/kanbanAgentContext.test.ts
+++ b/src/utils/kanbanAgentContext.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { VaultEntry } from '../types'
+import { buildKanbanAgentContext } from './kanbanAgentContext'
+
+function makeEntry(overrides: Partial<VaultEntry> = {}): VaultEntry {
+  return {
+    path: 'notes/foo.md',
+    filename: 'foo.md',
+    title: 'Foo',
+    isA: null,
+    aliases: [],
+    belongsTo: [],
+    relatedTo: [],
+    status: null,
+    archived: false,
+    modifiedAt: null,
+    createdAt: null,
+    fileSize: 0,
+    snippet: '',
+    wordCount: 0,
+    relationships: {},
+    icon: null,
+    color: null,
+    order: null,
+    sidebarLabel: null,
+    template: null,
+    sort: null,
+    view: null,
+    visible: null,
+    organized: false,
+    favorite: false,
+    favoriteIndex: null,
+    listPropertiesDisplay: [],
+    outgoingLinks: [],
+    properties: {},
+    hasH1: false,
+    ...overrides,
+  }
+}
+
+describe('buildKanbanAgentContext', () => {
+  it('includes the task title, path, type, status and body', async () => {
+    const entry = makeEntry({
+      path: 'projects/cerbonix.md',
+      filename: 'cerbonix.md',
+      title: 'Cerbonix',
+      isA: 'Project',
+      status: 'doing',
+    })
+    const noteContent = '---\nstatus: doing\n---\n# Cerbonix\n\nDeploy the new server.\n'
+
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent,
+      allEntries: [entry],
+      getContent: vi.fn(),
+    })
+
+    expect(prompt).toContain('# Task: Cerbonix')
+    expect(prompt).toContain('projects/cerbonix.md')
+    expect(prompt).toContain('Type: Project')
+    expect(prompt).toContain('Status: doing')
+    expect(prompt).toContain('Deploy the new server.')
+    expect(prompt).toContain('## Instructions')
+  })
+
+  it('falls back to filename when title is empty', async () => {
+    const entry = makeEntry({ path: 'projects/foo.md', filename: 'foo.md', title: '' })
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: 'body',
+      allEntries: [entry],
+      getContent: vi.fn(),
+    })
+    expect(prompt).toContain('# Task: foo.md')
+  })
+
+  it('falls back to "backlog" status when entry.status is null', async () => {
+    const entry = makeEntry({ status: null })
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: 'x',
+      allEntries: [entry],
+      getContent: vi.fn(),
+    })
+    expect(prompt).toContain('Status: backlog')
+  })
+
+  it('inlines the body of linked notes resolved via wikilinks', async () => {
+    const target = makeEntry({
+      path: 'projects/related.md',
+      filename: 'related.md',
+      title: 'Related Project',
+    })
+    const entry = makeEntry({
+      path: 'projects/source.md',
+      filename: 'source.md',
+      title: 'Source',
+      outgoingLinks: ['Related Project'],
+    })
+    const getContent = vi.fn(async (path: string) => {
+      if (path === 'projects/related.md') return '---\nstatus: doing\n---\n# Related Project\n\nDetails of related work.\n'
+      throw new Error('unexpected path: ' + path)
+    })
+
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: '# Source\n\nMain task.',
+      allEntries: [entry, target],
+      getContent,
+    })
+
+    expect(prompt).toContain('## Related notes (linked via wikilinks)')
+    expect(prompt).toContain('### Related Project (projects/related.md)')
+    expect(prompt).toContain('Details of related work.')
+    expect(getContent).toHaveBeenCalledWith('projects/related.md')
+  })
+
+  it('drops linked notes whose content cannot be read', async () => {
+    const target = makeEntry({ path: 'gone.md', filename: 'gone.md', title: 'Gone' })
+    const entry = makeEntry({ outgoingLinks: ['Gone'] })
+    const getContent = vi.fn(async () => { throw new Error('not found') })
+
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: 'body',
+      allEntries: [entry, target],
+      getContent,
+    })
+
+    expect(prompt).not.toContain('### Gone')
+    expect(prompt).not.toContain('## Related notes')
+  })
+
+  it('caps the number of linked notes at maxLinkedNotes', async () => {
+    const targets = Array.from({ length: 5 }, (_, i) =>
+      makeEntry({ path: `link-${i}.md`, filename: `link-${i}.md`, title: `Link ${i}` }),
+    )
+    const entry = makeEntry({ outgoingLinks: targets.map((t) => t.title) })
+    const getContent = vi.fn(async () => '# body\n\nstuff')
+
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: 'main',
+      allEntries: [entry, ...targets],
+      getContent,
+      maxLinkedNotes: 2,
+    })
+
+    expect(prompt).toContain('### Link 0')
+    expect(prompt).toContain('### Link 1')
+    expect(prompt).not.toContain('### Link 2')
+    expect(getContent).toHaveBeenCalledTimes(2)
+  })
+
+  it('truncates linked note bodies past maxLinkedBodyChars', async () => {
+    const target = makeEntry({ path: 'big.md', filename: 'big.md', title: 'Big' })
+    const entry = makeEntry({ outgoingLinks: ['Big'] })
+    const longBody = 'x'.repeat(5000)
+    const getContent = vi.fn(async () => `# Big\n\n${longBody}`)
+
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: 'main',
+      allEntries: [entry, target],
+      getContent,
+      maxLinkedBodyChars: 100,
+    })
+
+    expect(prompt).toContain('_[truncated]_')
+    const linkedSection = prompt.split('## Related notes')[1] ?? ''
+    expect(linkedSection.length).toBeLessThan(longBody.length)
+  })
+
+  it('renders empty body placeholder when the note body is blank', async () => {
+    const entry = makeEntry({ title: 'Empty' })
+    const prompt = await buildKanbanAgentContext({
+      entry,
+      noteContent: '---\nstatus: doing\n---\n',
+      allEntries: [entry],
+      getContent: vi.fn(),
+    })
+    expect(prompt).toContain('_(empty body)_')
+  })
+})

--- a/src/utils/kanbanAgentContext.ts
+++ b/src/utils/kanbanAgentContext.ts
@@ -1,0 +1,113 @@
+import type { VaultEntry } from '../types'
+import { collectLinkedEntries } from './ai-context'
+import { splitFrontmatter } from './wikilinks'
+
+const DEFAULT_MAX_LINKED_NOTES = 8
+const DEFAULT_MAX_LINKED_BODY_CHARS = 2000
+
+export interface KanbanAgentContextParams {
+  /** The kanban card we are running an agent on. */
+  entry: VaultEntry
+  /** Raw file content of the active note (with frontmatter). */
+  noteContent: string
+  /** All entries in the vault, used to resolve wikilink targets. */
+  allEntries: VaultEntry[]
+  /** Async getter that returns the raw file content of a note (with frontmatter). */
+  getContent: (path: string) => Promise<string>
+  /** Cap the number of linked notes injected. Default 8. */
+  maxLinkedNotes?: number
+  /** Cap the body length of each linked note (in chars). Default 2000. */
+  maxLinkedBodyChars?: number
+}
+
+interface ResolvedLinkedNote {
+  entry: VaultEntry
+  body: string
+  truncated: boolean
+}
+
+function extractBody(rawContent: string): string {
+  const [, body] = splitFrontmatter(rawContent)
+  return body.trim()
+}
+
+function truncateBody(body: string, max: number): { body: string; truncated: boolean } {
+  if (body.length <= max) return { body, truncated: false }
+  return { body: body.slice(0, max).trimEnd() + '…', truncated: true }
+}
+
+async function resolveLinkedContent(
+  entries: VaultEntry[],
+  getContent: (path: string) => Promise<string>,
+  maxLinkedBodyChars: number,
+): Promise<ResolvedLinkedNote[]> {
+  const results: ResolvedLinkedNote[] = []
+  for (const entry of entries) {
+    try {
+      const raw = await getContent(entry.path)
+      const { body, truncated } = truncateBody(extractBody(raw), maxLinkedBodyChars)
+      results.push({ entry, body, truncated })
+    } catch {
+      // Linked note unreadable (deleted, permission, binary). Skip silently.
+    }
+  }
+  return results
+}
+
+function formatLinkedSection(linked: ResolvedLinkedNote[]): string {
+  if (linked.length === 0) return ''
+  const blocks = linked.map((item) => {
+    const header = `### ${item.entry.title || item.entry.filename} (${item.entry.path})`
+    const truncatedNotice = item.truncated ? '\n\n_[truncated]_' : ''
+    return `${header}\n\n${item.body}${truncatedNotice}`
+  })
+  return ['', '## Related notes (linked via wikilinks)', '', blocks.join('\n\n')].join('\n')
+}
+
+/**
+ * Build a textual prompt for an agent (Claude / Codex / Gemini) running on a kanban card.
+ *
+ * The prompt contains:
+ * - The active note's body (the "task description")
+ * - The body of each note linked via wikilinks (1-level depth, capped)
+ * - Explicit instructions to act on the vault
+ *
+ * This is the differentiator vs other kanban-agent tools : the agent receives
+ * the knowledge graph around the task, not just a flat ticket description.
+ */
+export async function buildKanbanAgentContext(
+  params: KanbanAgentContextParams,
+): Promise<string> {
+  const {
+    entry,
+    noteContent,
+    allEntries,
+    getContent,
+    maxLinkedNotes = DEFAULT_MAX_LINKED_NOTES,
+    maxLinkedBodyChars = DEFAULT_MAX_LINKED_BODY_CHARS,
+  } = params
+
+  const cardBody = extractBody(noteContent)
+  const linkedRaw = collectLinkedEntries(entry, allEntries).slice(0, maxLinkedNotes)
+  const linked = await resolveLinkedContent(linkedRaw, getContent, maxLinkedBodyChars)
+
+  const sections = [
+    `# Task: ${entry.title || entry.filename}`,
+    '',
+    `Path: \`${entry.path}\` | Type: ${entry.isA ?? 'Note'} | Status: ${entry.status ?? 'backlog'}`,
+    '',
+    '## Task description',
+    '',
+    cardBody.length > 0 ? cardBody : '_(empty body)_',
+    formatLinkedSection(linked),
+    '',
+    '## Instructions',
+    '',
+    '- Read the task description and the related notes for context.',
+    '- Take whatever action is needed in the vault to complete this task (edit notes, create new ones, run commands, etc.).',
+    '- Be concise in your reasoning. Prefer doing over explaining.',
+    '- When done, summarise what you changed in 2-3 bullet points.',
+  ]
+
+  return sections.join('\n')
+}

--- a/src/utils/kanbanEntries.test.ts
+++ b/src/utils/kanbanEntries.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { VaultEntry } from '../types'
+import { isKanbanEligibleEntry } from './kanbanEntries'
+
+function makeEntry(overrides: Partial<VaultEntry> = {}): VaultEntry {
+  return {
+    path: 'notes/foo.md',
+    filename: 'foo.md',
+    title: 'Foo',
+    isA: null,
+    aliases: [],
+    belongsTo: [],
+    relatedTo: [],
+    status: null,
+    archived: false,
+    modifiedAt: null,
+    createdAt: null,
+    fileSize: 0,
+    snippet: '',
+    wordCount: 0,
+    relationships: {},
+    icon: null,
+    color: null,
+    order: null,
+    sidebarLabel: null,
+    template: null,
+    sort: null,
+    view: null,
+    visible: null,
+    organized: false,
+    favorite: false,
+    favoriteIndex: null,
+    listPropertiesDisplay: [],
+    outgoingLinks: [],
+    properties: {},
+    hasH1: false,
+    ...overrides,
+  }
+}
+
+describe('isKanbanEligibleEntry', () => {
+  it('keeps a regular markdown note', () => {
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'notes/foo.md' }))).toBe(true)
+  })
+
+  it('rejects binary files', () => {
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'attachments/image.png', fileKind: 'binary' }))).toBe(false)
+  })
+
+  it('rejects view definition YAMLs at the root views/ folder', () => {
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'views/inbox.yml' }))).toBe(false)
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'views/board.yaml' }))).toBe(false)
+  })
+
+  it('rejects view definition YAMLs in a nested vault', () => {
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'subvault/views/board.yml' }))).toBe(false)
+  })
+
+  it('keeps notes that just happen to contain "views" in the name', () => {
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'notes/my-views-note.md' }))).toBe(true)
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'projects/views-rework.md' }))).toBe(true)
+  })
+
+  it('keeps non-binary text files that are not view configs', () => {
+    expect(isKanbanEligibleEntry(makeEntry({ path: 'snippets/code.txt', fileKind: 'text' }))).toBe(true)
+  })
+})

--- a/src/utils/kanbanEntries.ts
+++ b/src/utils/kanbanEntries.ts
@@ -1,0 +1,21 @@
+import type { VaultEntry } from '../types'
+
+/**
+ * Decides whether a vault entry can appear as a kanban card.
+ *
+ * Excluded:
+ * - Binary files (images, attachments) — not editable as a "task" note.
+ * - View definition YAMLs (`views/*.yml`) — these are the kanban configs themselves,
+ *   not notes. Including them allowed a self-referential drag where the YAML got
+ *   `update_frontmatter`-ed and corrupted (lost `kind: kanban`, board disappeared).
+ */
+export function isKanbanEligibleEntry(entry: VaultEntry): boolean {
+  if (entry.fileKind === 'binary') return false
+  if (isViewDefinitionPath(entry.path)) return false
+  return true
+}
+
+function isViewDefinitionPath(path: string): boolean {
+  if (!path.endsWith('.yml') && !path.endsWith('.yaml')) return false
+  return path.startsWith('views/') || path.includes('/views/')
+}

--- a/src/utils/kanbanStatuses.test.ts
+++ b/src/utils/kanbanStatuses.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CANONICAL_STATUSES,
+  DEFAULT_STATUS_KEY,
+  customStatusDef,
+  getCanonicalStatus,
+  isCanonicalStatus,
+  resolveStatusDef,
+  statusKeyOf,
+} from './kanbanStatuses'
+
+describe('kanbanStatuses', () => {
+  it('exposes the five canonical statuses in stable order', () => {
+    expect(CANONICAL_STATUSES.map((status) => status.key)).toEqual([
+      'backlog',
+      'doing',
+      'review',
+      'done',
+      'blocked',
+    ])
+  })
+
+  it('marks every canonical status as canonical', () => {
+    for (const status of CANONICAL_STATUSES) {
+      expect(status.canonical).toBe(true)
+    }
+  })
+
+  it('detects canonical keys and rejects unknown ones', () => {
+    expect(isCanonicalStatus('doing')).toBe(true)
+    expect(isCanonicalStatus('done')).toBe(true)
+    expect(isCanonicalStatus('wip')).toBe(false)
+    expect(isCanonicalStatus(null)).toBe(false)
+    expect(isCanonicalStatus(undefined)).toBe(false)
+    expect(isCanonicalStatus('')).toBe(false)
+  })
+
+  it('returns the canonical definition by key', () => {
+    expect(getCanonicalStatus('done')?.label).toBe('Done')
+    expect(getCanonicalStatus('unknown')).toBeUndefined()
+  })
+
+  it('falls back to the default status key for null, undefined and empty values', () => {
+    expect(statusKeyOf(null)).toBe(DEFAULT_STATUS_KEY)
+    expect(statusKeyOf(undefined)).toBe(DEFAULT_STATUS_KEY)
+    expect(statusKeyOf('')).toBe(DEFAULT_STATUS_KEY)
+    expect(statusKeyOf('   ')).toBe(DEFAULT_STATUS_KEY)
+    expect(statusKeyOf('doing')).toBe('doing')
+  })
+
+  it('builds a custom status def for non-canonical keys', () => {
+    const def = customStatusDef('wip')
+    expect(def.key).toBe('wip')
+    expect(def.label).toBe('wip')
+    expect(def.canonical).toBe(false)
+  })
+
+  it('resolves to canonical when known and falls back to custom otherwise', () => {
+    expect(resolveStatusDef('done').canonical).toBe(true)
+    expect(resolveStatusDef('done').label).toBe('Done')
+    expect(resolveStatusDef('wip').canonical).toBe(false)
+    expect(resolveStatusDef('wip').label).toBe('wip')
+  })
+})

--- a/src/utils/kanbanStatuses.ts
+++ b/src/utils/kanbanStatuses.ts
@@ -1,0 +1,53 @@
+export interface KanbanStatusDef {
+  key: string
+  label: string
+  color: string
+  order: number
+  canonical: boolean
+}
+
+const CANONICAL_LIST: ReadonlyArray<Omit<KanbanStatusDef, 'canonical'>> = [
+  { key: 'backlog', label: 'Backlog', color: 'var(--muted-foreground)', order: 0 },
+  { key: 'doing', label: 'In Progress', color: 'var(--accent-blue)', order: 1 },
+  { key: 'review', label: 'Review', color: 'var(--accent-orange)', order: 2 },
+  { key: 'done', label: 'Done', color: 'var(--accent-green)', order: 3 },
+  { key: 'blocked', label: 'Blocked', color: 'var(--destructive)', order: 4 },
+] as const
+
+export const CANONICAL_STATUSES: ReadonlyArray<KanbanStatusDef> = CANONICAL_LIST.map((status) => ({
+  ...status,
+  canonical: true,
+}))
+
+const CANONICAL_BY_KEY = new Map<string, KanbanStatusDef>(
+  CANONICAL_STATUSES.map((status) => [status.key, status]),
+)
+
+export const DEFAULT_STATUS_KEY = 'backlog'
+
+export function isCanonicalStatus(value: string | null | undefined): boolean {
+  return value !== null && value !== undefined && CANONICAL_BY_KEY.has(value)
+}
+
+export function getCanonicalStatus(key: string): KanbanStatusDef | undefined {
+  return CANONICAL_BY_KEY.get(key)
+}
+
+export function statusKeyOf(value: string | null | undefined): string {
+  if (value === null || value === undefined || value.trim().length === 0) return DEFAULT_STATUS_KEY
+  return value
+}
+
+export function customStatusDef(key: string): KanbanStatusDef {
+  return {
+    key,
+    label: key,
+    color: 'var(--muted-foreground)',
+    order: CANONICAL_STATUSES.length + 1,
+    canonical: false,
+  }
+}
+
+export function resolveStatusDef(key: string): KanbanStatusDef {
+  return getCanonicalStatus(key) ?? customStatusDef(key)
+}


### PR DESCRIPTION
## Summary

Phase 3 of the kanban feature: from a card on the board, run a CLI agent (Claude / Codex / Gemini, whichever is set as default) **with the note + its wikilinked notes as context**, stream the output inline below the editor, and offer to move the card to **Review** when the agent finishes.

3 commits on top of the existing kanban MVP:

1. \`feat: kanban agent context builder with linked notes\` — \`src/utils/kanbanAgentContext.ts\` builds a prompt from the card's body + each wikilinked note's body (1-level depth, capped to 8 notes / 2000 chars each). Reuses existing \`collectLinkedEntries\` from \`ai-context.ts\`. 8 vitest tests cover empty body, missing target, dedupe, truncation, link cap.
2. \`feat: kanban agent panel below editor in split view\` — \`src/components/kanban/KanbanAgentPanel.tsx\`. When the kanban split is open (a card is active), the editor is subdivided vertically: note on top, agent panel on bottom. Reuses \`useCliAiAgent\` for streaming.
3. \`feat: auto-suggest move to review after agent run\` — when the run finishes (status \`done\`), a green CTA appears in the panel: \"Run finished. Move card to Review?\" with Confirm / Dismiss. Per-card dismissal so it doesn't reappear on every re-render.

## Why

The kanban view in phase 1 was a Trello clone. The differentiator that justifies a notes-first kanban: **the agent receives the knowledge graph around the task** (note + linked notes), not just a flat ticket description. This PR delivers that.

## UX flow

1. Open a board, click a card → split view with editor on the right.
2. Below the editor, the agent panel shows: agent name, status pill (idle/thinking/working/done), \`Run on this task\` button.
3. Click Run → context is built (note body + linked notes body), prompt is sent to the configured agent, output streams in below in real time.
4. Agent finishes → if the card is not already in \`review\`/\`done\`, a CTA suggests moving it to \`review\`.
5. \`Stop\` clears the conversation if the user wants to start over.

The agent operates on the live vault (no worktree isolation) — that's phase 4.

## Test plan

- [x] \`pnpm vitest run src/utils/kanbanAgentContext.test.ts\` — 8 tests pass
- [x] \`pnpm vitest run src/App.test.tsx\` — 28 tests still pass (no regression)
- [x] Full \`pnpm build\` and \`pnpm lint\` green
- [x] Native test on Linux Fedora 43 RPM build (in progress at PR time, will confirm in comment)

## Notes

- No new runtime dependencies. Uses existing \`useCliAiAgent\` / \`stream_claude_chat\` infra.
- Aware of \`AGENTS.md\` \"no branches, no PRs, ever\". Fifth PR after #319, #324, #325, #327. Happy to close if not wanted.
- Phase 4 (worktree isolation + multi-instances parallel) and phase 5 (auto-PR after run) are out of scope.