### PR TITLE
fix: prevent IME stray text node accumulation in AI composer

### DIFF
--- a/src/components/WikilinkChatInput.consecutive-ime.test.tsx
+++ b/src/components/WikilinkChatInput.consecutive-ime.test.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { WikilinkChatInput } from './WikilinkChatInput'
+import type { VaultEntry } from '../types'
+
+const entries: VaultEntry[] = []
+
+function Controlled({
+  onDraftChange,
+}: {
+  onDraftChange?: (value: string) => void
+}) {
+  const [value, setValue] = useState('')
+  return (
+    <WikilinkChatInput
+      entries={entries}
+      value={value}
+      onChange={(next) => {
+        onDraftChange?.(next)
+        setValue(next)
+      }}
+      onSend={vi.fn()}
+    />
+  )
+}
+
+describe('WikilinkChatInput — consecutive IME compositions', () => {
+  it('does not duplicate syllables across two consecutive compositions', async () => {
+    const onDraftChange = vi.fn()
+    render(<Controlled onDraftChange={onDraftChange} />)
+
+    const editor1 = screen.getByTestId('agent-input') as HTMLDivElement
+    editor1.focus()
+
+    // Syllable 1: 안 (IME injects plain text node directly into editor)
+    fireEvent.compositionStart(editor1)
+    editor1.appendChild(document.createTextNode('안'))
+    fireEvent.input(editor1)
+    fireEvent.compositionEnd(editor1)
+
+    await waitFor(() => {
+      expect(onDraftChange).toHaveBeenLastCalledWith('안')
+    })
+
+    // Re-query: forceRender may have remounted the editor
+    const editor2 = screen.getByTestId('agent-input') as HTMLDivElement
+
+    // Syllable 2: 녕 — IME again injects a sibling plain text node
+    fireEvent.compositionStart(editor2)
+    editor2.appendChild(document.createTextNode('녕'))
+    fireEvent.input(editor2)
+    fireEvent.compositionEnd(editor2)
+
+    await waitFor(() => {
+      expect(onDraftChange).toHaveBeenLastCalledWith('안녕')
+    })
+
+    const editor3 = screen.getByTestId('agent-input') as HTMLDivElement
+    // Bug symptom: would be "안안녕녕" if stray text nodes accumulate
+    expect(editor3.textContent).toBe('안녕')
+  })
+
+  it('does not duplicate across three consecutive compositions', async () => {
+    const onDraftChange = vi.fn()
+    render(<Controlled onDraftChange={onDraftChange} />)
+
+    const seq = ['안', '녕', '하']
+
+    for (const syllable of seq) {
+      const editor = screen.getByTestId('agent-input') as HTMLDivElement
+      editor.focus()
+      fireEvent.compositionStart(editor)
+      editor.appendChild(document.createTextNode(syllable))
+      fireEvent.input(editor)
+      fireEvent.compositionEnd(editor)
+    }
+
+    await waitFor(() => {
+      expect(onDraftChange).toHaveBeenLastCalledWith('안녕하')
+    })
+
+    const finalEditor = screen.getByTestId('agent-input') as HTMLDivElement
+    expect(finalEditor.textContent).toBe('안녕하')
+  })
+})

--- a/src/components/WikilinkChatInput.test.tsx
+++ b/src/components/WikilinkChatInput.test.tsx
@@ -291,7 +291,7 @@ describe('WikilinkChatInput', () => {
     await waitFor(() => {
       expect(onDraftChange).toHaveBeenCalledWith('你')
     })
-    expect(editor.textContent).toContain('你')
+    expect(screen.getByTestId('agent-input').textContent).toContain('你')
   })
 
   it('does not select wikilink suggestions while IME composition is active', () => {

--- a/src/components/useInlineWikilinkSelection.ts
+++ b/src/components/useInlineWikilinkSelection.ts
@@ -27,15 +27,28 @@ function getSelectionSyncEditor(
   return editor
 }
 
-function getActiveSelectionEditor(
-  editor: HTMLDivElement | null,
-  isComposingRef?: React.RefObject<boolean>,
-) {
-  if (!editor) return null
-  if (document.activeElement !== editor) return null
-  if (isComposingRef?.current === true) return null
+function removeImeLeftoverTextNodes(editor: HTMLDivElement) {
+  // IME composition (Korean/Japanese/Chinese) inserts plain text nodes
+  // directly inside the contentEditable div, outside of React's reconciliation
+  // tree. After we commit the composed value, those orphan nodes survive the
+  // React re-render and accumulate as siblings on the next composition,
+  // producing per-syllable duplication (e.g. typing 안녕 → "안안녕녕").
+  //
+  // We only strip text nodes that sit alongside React-rendered element
+  // children (spans/chips). When the editor holds only text — for example,
+  // right after a manual `editor.textContent = ...` write before React has
+  // had a chance to mount its span — we leave it alone so we don't blank
+  // the field.
+  const hasElementChildren = Array.from(editor.childNodes).some(
+    (child) => child.nodeType === Node.ELEMENT_NODE,
+  )
+  if (!hasElementChildren) return
 
-  return editor
+  for (const child of Array.from(editor.childNodes)) {
+    if (child.nodeType !== Node.TEXT_NODE) continue
+    if (child.textContent === '​') continue
+    editor.removeChild(child)
+  }
 }
 
 export function useInlineWikilinkSelection({
@@ -84,8 +97,11 @@ export function useInlineWikilinkSelection({
   }, [onChange])
 
   useLayoutEffect(() => {
-    const editor = getActiveSelectionEditor(editorRef.current, isComposingRef)
+    const editor = editorRef.current
     if (!editor) return
+    if (isComposingRef?.current === true) return
+    removeImeLeftoverTextNodes(editor)
+    if (document.activeElement !== editor) return
     applySelectionRange(editor, selectionRange)
   }, [isComposingRef, selectionRange, value])
 


### PR DESCRIPTION
## Summary

Korean / Japanese / Chinese typing in the AI Agent panel currently accumulates each composition's intermediate state instead of replacing it. Typing `안녕` repeatedly produces output like:

```
안녕ㅇ안녕ㅇ안녕ㅇ안녀ㅇ안ㄴㅇ안ㅇ안ㅇ아ㅇㅇㅇㅇ아앙아ㅇ
```

## Root cause

`InlineWikilinkInput` already routes IME composition through `isComposingRef` and forces a remount of the editor (`key={renderVersion}`) when a composition commits. That mostly works, but the IME inserts plain text nodes directly into the contentEditable div, **outside React's reconciliation tree**. The trailing-jamo siblings survive React's normal child diff and pile up alongside the React-rendered `<span>` segments — every subsequent composition serializes the previous strays back into the value.

Existing IME tests cover only a single composition cycle, where the `key`-based remount cleans the DOM. Across consecutive compositions in WKWebView (Tauri), the strays leak.

## Fix

`useInlineWikilinkSelection` already re-runs its layout effect on every value/selection change (and skips while `isComposingRef.current === true`). The fix removes any stray text node siblings of React-rendered children at that point, while preserving the trailing ZWSP that React itself emits as a caret anchor.

A safety guard skips cleanup when the editor holds **only** text (no spans/chips). This avoids blanking the field in test or programmatic flows that set `editor.textContent` directly before React has had a chance to mount its span.

## Test coverage

- New `WikilinkChatInput.consecutive-ime.test.tsx`:
  - `does not duplicate syllables across two consecutive compositions`
  - `does not duplicate across three consecutive compositions`
- Hardened `does not hijack Enter while IME composition is active` to query the live editor element rather than a stale, detached reference.

All 3269 frontend unit tests pass.

## Manual verification

- Built locally and replaced `/Applications/Tolaria.app`. Typing 안녕 repeatedly in the AI Agent panel now commits the correct text without per-syllable duplication.

## Test plan

- [ ] CI green
- [ ] Type Korean / Japanese / Chinese into the AI composer, including:
  - [ ] Single syllable then commit (existing behaviour)
  - [ ] Several consecutive syllables back-to-back
  - [ ] Mid-composition cursor moves / clicking elsewhere
- [ ] Plain ASCII typing still commits correctly
- [ ] Wikilink suggestion menu still triggers on `[[`