### PR TITLE
feat: Add command palette theme mode actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { useAiAgentPreferences } from './hooks/useAiAgentPreferences'
 import { useSettings } from './hooks/useSettings'
 import { useDocumentThemeMode } from './hooks/useDocumentThemeMode'
 import { useThemeMode } from './hooks/useThemeMode'
+import type { ThemeMode } from './lib/themeMode'
 import { useNoteActions } from './hooks/useNoteActions'
 import { planNewTypeCreation } from './hooks/useNoteCreation'
 import { useCommitFlow } from './hooks/useCommitFlow'
@@ -434,6 +435,9 @@ function App() {
     const theme_mode = documentThemeMode === 'dark' ? 'light' : 'dark'
     void saveSettings({ ...settings, theme_mode })
   }, [documentThemeMode, saveSettings, settings])
+  const handleSetThemeMode = useCallback((theme_mode: ThemeMode) => {
+    void saveSettings({ ...settings, theme_mode })
+  }, [saveSettings, settings])
   const handleSetUiLanguage = useCallback((uiLanguage: UiLanguagePreference) => {
     void saveSettings({ ...settings, ui_language: serializeUiLanguagePreference(uiLanguage) })
   }, [saveSettings, settings])
@@ -1428,6 +1432,7 @@ function App() {
     systemLocale,
     selectedUiLanguage,
     onSetUiLanguage: handleSetUiLanguage,
+    onSetThemeMode: settingsLoaded ? handleSetThemeMode : undefined,
     mcpStatus,
     onInstallMcp: openMcpSetupDialog,
     onOpenAiAgents: dialogs.openSettings,

--- a/src/hooks/commands/settingsCommands.test.ts
+++ b/src/hooks/commands/settingsCommands.test.ts
@@ -67,6 +67,37 @@ describe('buildSettingsCommands', () => {
     expect(onSetUiLanguage).toHaveBeenCalledWith('zh-CN')
   })
 
+  it('adds quick theme mode commands when a setter is available', () => {
+    const onSetThemeMode = vi.fn()
+
+    const commands = buildSettingsCommands({
+      onOpenSettings: vi.fn(),
+      onSetThemeMode,
+    })
+
+    const lightMode = commands.find((item) => item.id === 'use-light-mode')
+    const darkMode = commands.find((item) => item.id === 'use-dark-mode')
+
+    expect(lightMode).toMatchObject({
+      label: 'Use Light Mode',
+      enabled: true,
+      group: 'Settings',
+    })
+    expect(lightMode?.keywords).toContain('light mode')
+    expect(darkMode).toMatchObject({
+      label: 'Use Dark Mode',
+      enabled: true,
+      group: 'Settings',
+    })
+    expect(darkMode?.keywords).toContain('dark mode')
+
+    lightMode?.execute()
+    darkMode?.execute()
+
+    expect(onSetThemeMode).toHaveBeenNthCalledWith(1, 'light')
+    expect(onSetThemeMode).toHaveBeenNthCalledWith(2, 'dark')
+  })
+
   it('localizes language commands', () => {
     const commands = buildSettingsCommands({
       onOpenSettings: vi.fn(),

--- a/src/hooks/commands/settingsCommands.ts
+++ b/src/hooks/commands/settingsCommands.ts
@@ -10,6 +10,7 @@ import {
   type AppLocale,
   type UiLanguagePreference,
 } from '../../lib/i18n'
+import type { ThemeMode } from '../../lib/themeMode'
 
 interface SettingsCommandsConfig {
   mcpStatus?: string
@@ -29,6 +30,7 @@ interface SettingsCommandsConfig {
   systemLocale?: AppLocale
   selectedUiLanguage?: UiLanguagePreference
   onSetUiLanguage?: (language: UiLanguagePreference) => void
+  onSetThemeMode?: (mode: ThemeMode) => void
 }
 
 function commandKeywords(raw: string): string[] {
@@ -119,6 +121,33 @@ function buildLanguageCommands({
   ]
 }
 
+function buildThemeCommands({
+  locale = 'en',
+  onSetThemeMode,
+}: Pick<SettingsCommandsConfig, 'locale' | 'onSetThemeMode'>): CommandAction[] {
+  const t = createTranslator(locale)
+  const canSetThemeMode = !!onSetThemeMode
+
+  return [
+    {
+      id: 'use-light-mode',
+      label: t('command.useLightMode'),
+      group: 'Settings',
+      keywords: ['theme', 'appearance', 'light', 'light mode', 'day'],
+      enabled: canSetThemeMode,
+      execute: () => onSetThemeMode?.('light'),
+    },
+    {
+      id: 'use-dark-mode',
+      label: t('command.useDarkMode'),
+      group: 'Settings',
+      keywords: ['theme', 'appearance', 'dark', 'dark mode', 'night'],
+      enabled: canSetThemeMode,
+      execute: () => onSetThemeMode?.('dark'),
+    },
+  ]
+}
+
 function buildVaultSettingsCommands({
   vaultCount,
   isGettingStartedHidden,
@@ -160,11 +189,12 @@ export function buildSettingsCommands(config: SettingsCommandsConfig): CommandAc
     mcpStatus, vaultCount, isGettingStartedHidden,
     onOpenSettings, onOpenFeedback, onOpenVault, onCreateEmptyVault, onRemoveActiveVault, onRestoreGettingStarted,
     onCheckForUpdates, onInstallMcp, onReloadVault, onRepairVault,
-    locale = 'en', systemLocale = locale, selectedUiLanguage = SYSTEM_UI_LANGUAGE, onSetUiLanguage,
+    locale = 'en', systemLocale = locale, selectedUiLanguage = SYSTEM_UI_LANGUAGE, onSetUiLanguage, onSetThemeMode,
   } = config
 
   return [
     ...buildPrimarySettingsCommands({ locale, onOpenSettings, onOpenFeedback, onCheckForUpdates }),
+    ...buildThemeCommands({ locale, onSetThemeMode }),
     ...buildLanguageCommands({
       locale,
       systemLocale,

--- a/src/hooks/useAppCommands.ts
+++ b/src/hooks/useAppCommands.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 import type { AiAgentId, AiAgentsStatus } from '../lib/aiAgents'
 import type { AppLocale, UiLanguagePreference } from '../lib/i18n'
+import type { ThemeMode } from '../lib/themeMode'
 import type { VaultAiGuidanceStatus } from '../lib/vaultAiGuidance'
 import { useAppKeyboard } from './useAppKeyboard'
 import { useCommandRegistry } from './useCommandRegistry'
@@ -75,6 +76,7 @@ interface AppCommandsConfig {
   systemLocale?: AppLocale
   selectedUiLanguage?: UiLanguagePreference
   onSetUiLanguage?: (language: UiLanguagePreference) => void
+  onSetThemeMode?: (mode: ThemeMode) => void
   mcpStatus?: string
   onInstallMcp?: () => void
   aiAgentsStatus?: AiAgentsStatus
@@ -173,6 +175,7 @@ type CommandRegistryVaultActions = Pick<
   | 'systemLocale'
   | 'selectedUiLanguage'
   | 'onSetUiLanguage'
+  | 'onSetThemeMode'
   | 'onRemoveActiveVault'
   | 'onRestoreGettingStarted'
   | 'isGettingStartedHidden'
@@ -441,6 +444,7 @@ function createCommandRegistryVaultConfig(
     systemLocale: config.systemLocale,
     selectedUiLanguage: config.selectedUiLanguage,
     onSetUiLanguage: config.onSetUiLanguage,
+    onSetThemeMode: config.onSetThemeMode,
     onRemoveActiveVault: config.onRemoveActiveVault,
     onRestoreGettingStarted: config.onRestoreGettingStarted,
     isGettingStartedHidden: config.isGettingStartedHidden,

--- a/src/hooks/useCommandRegistry.test.ts
+++ b/src/hooks/useCommandRegistry.test.ts
@@ -366,6 +366,31 @@ describe('useCommandRegistry', () => {
     expect(findCommand(result.current, 'toggle-note-layout')?.label).toBe('Use Centered Note Layout')
   })
 
+  it('exposes command palette actions for light and dark mode', () => {
+    const onSetThemeMode = vi.fn()
+    const config = makeConfig({ onSetThemeMode })
+    const { result } = renderHook(() => useCommandRegistry(config))
+    const lightMode = findCommand(result.current, 'use-light-mode')
+    const darkMode = findCommand(result.current, 'use-dark-mode')
+
+    expect(lightMode).toMatchObject({
+      label: 'Use Light Mode',
+      enabled: true,
+      group: 'Settings',
+    })
+    expect(darkMode).toMatchObject({
+      label: 'Use Dark Mode',
+      enabled: true,
+      group: 'Settings',
+    })
+
+    lightMode?.execute()
+    darkMode?.execute()
+
+    expect(onSetThemeMode).toHaveBeenNthCalledWith(1, 'light')
+    expect(onSetThemeMode).toHaveBeenNthCalledWith(2, 'dark')
+  })
+
   it('includes a New AI chat command that opens and resets the panel session', () => {
     const config = makeConfig()
     const dispatchSpy = vi.spyOn(window, 'dispatchEvent')

--- a/src/hooks/useCommandRegistry.ts
+++ b/src/hooks/useCommandRegistry.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { AiAgentId, AiAgentsStatus } from '../lib/aiAgents'
 import type { AppLocale, UiLanguagePreference } from '../lib/i18n'
+import type { ThemeMode } from '../lib/themeMode'
 import type { VaultAiGuidanceStatus } from '../lib/vaultAiGuidance'
 import type { NoteLayout, SidebarSelection, VaultEntry } from '../types'
 import type { NoteListFilter } from '../utils/noteListHelpers'
@@ -46,6 +47,7 @@ interface CommandRegistryConfig {
   systemLocale?: AppLocale
   selectedUiLanguage?: UiLanguagePreference
   onSetUiLanguage?: (language: UiLanguagePreference) => void
+  onSetThemeMode?: (mode: ThemeMode) => void
   onChangeNoteType?: () => void
   onMoveNoteToFolder?: () => void
   canMoveNoteToFolder?: boolean
@@ -129,7 +131,7 @@ export function useCommandRegistry(config: CommandRegistryConfig): import('./com
     mcpStatus, onInstallMcp, aiAgentsStatus, vaultAiGuidanceStatus,
     onOpenAiAgents, onRestoreVaultAiGuidance, onSetDefaultAiAgent, selectedAiAgent, onCycleDefaultAiAgent, selectedAiAgentLabel,
     onReloadVault, onRepairVault,
-    locale, systemLocale, selectedUiLanguage, onSetUiLanguage,
+    locale, systemLocale, selectedUiLanguage, onSetUiLanguage, onSetThemeMode,
     onSetNoteIcon, onRemoveNoteIcon, activeNoteHasIcon, onChangeNoteType, onMoveNoteToFolder, canMoveNoteToFolder,
     onOpenInNewWindow, onRevealActiveFile, onCopyActiveFilePath, onOpenActiveFileExternal, onToggleFavorite, onToggleOrganized,
     onCustomizeNoteListColumns, canCustomizeNoteListColumns,
@@ -225,12 +227,12 @@ export function useCommandRegistry(config: CommandRegistryConfig): import('./com
     mcpStatus, vaultCount, isGettingStartedHidden,
     onOpenSettings, onOpenFeedback, onOpenVault, onCreateEmptyVault, onRemoveActiveVault, onRestoreGettingStarted,
     onCheckForUpdates, onInstallMcp, onReloadVault, onRepairVault,
-    locale, systemLocale, selectedUiLanguage, onSetUiLanguage,
+    locale, systemLocale, selectedUiLanguage, onSetUiLanguage, onSetThemeMode,
   }), [
     mcpStatus, vaultCount, isGettingStartedHidden, onOpenSettings, onOpenFeedback,
     onOpenVault, onCreateEmptyVault, onRemoveActiveVault, onRestoreGettingStarted,
     onCheckForUpdates, onInstallMcp, onReloadVault, onRepairVault,
-    locale, systemLocale, selectedUiLanguage, onSetUiLanguage,
+    locale, systemLocale, selectedUiLanguage, onSetUiLanguage, onSetThemeMode,
   ])
 
   const aiCommands = useMemo(() => buildAiAgentCommands({

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -12,6 +12,8 @@
   "command.openLanguageSettings.keywords": "language locale i18n internationalization localization english italian french german russian spanish portuguese chinese japanese korean 中文",
   "command.useSystemLanguage": "Use System Language",
   "command.openH1Setting": "Open H1 Auto-Rename Setting",
+  "command.useLightMode": "Use Light Mode",
+  "command.useDarkMode": "Use Dark Mode",
   "command.contribute": "Contribute",
   "command.checkUpdates": "Check for Updates",
   "command.group.navigation": "Navigation",

--- a/src/lib/locales/zh-CN.json
+++ b/src/lib/locales/zh-CN.json
@@ -12,6 +12,8 @@
   "command.openLanguageSettings.keywords": "语言 区域 i18n 国际化 本地化 中文 english italian french german russian spanish portuguese japanese korean",
   "command.useSystemLanguage": "使用系统语言",
   "command.openH1Setting": "打开 H1 自动重命名设置",
+  "command.useLightMode": "使用浅色模式",
+  "command.useDarkMode": "使用深色模式",
   "command.contribute": "参与贡献",
   "command.checkUpdates": "检查更新",
   "command.group.navigation": "导航",


### PR DESCRIPTION
## Summary
Adds quick command palette actions for switching Tolaria between light and dark mode.

I often switch between light and dark mode, and I'm used to other apps like Figma letting me quickly select light or dark mode from the command menu. This makes the same workflow available in Tolaria via Cmd+K: type "light mode" or "dark mode" and select the mode directly.

## Screenshot

<img width="872" height="959" alt="image" src="https://github.com/user-attachments/assets/e264e95e-797b-4c15-8233-01f9b9360fc3" />

## Testing
- pnpm test src/hooks/commands/settingsCommands.test.ts src/hooks/useCommandRegistry.test.ts src/lib/i18n.test.ts
- npx tsc --noEmit
- pnpm lint

## Notes
- Uses the same persisted `settings.theme_mode` path as the Settings panel; no separate command-palette-only theme toggle.
