### PR TITLE
fix: show immediate feedback when triggering update check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1177,6 +1177,7 @@ function App() {
       await restartApp()
       return
     }
+    setToastMessage('Checking for updates…')
     const result = await updateActions.checkForUpdates()
     if (result.kind === 'up-to-date') {
       const checkedChannel = normalizeReleaseChannel(settings.release_channel)


### PR DESCRIPTION
Add a toast before the async checkForUpdates call so the user sees a response on click rather than waiting in silence for the network round-trip.