### PR TITLE
feat : add right-click menu

### DIFF
--- a/src-tauri/src/commands/vault/file_cmds.rs
+++ b/src-tauri/src/commands/vault/file_cmds.rs
@@ -1,7 +1,7 @@
 use crate::commands::expand_tilde;
 use crate::vault::filename_rules::validate_folder_name;
 use crate::vault::{self, FolderNode, VaultEntry};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use super::boundary::{
     with_boundary, with_existing_paths, with_requested_root, with_validated_path, ValidatedPathMode,
@@ -150,12 +150,31 @@ pub fn create_vault_folder(vault_path: PathBuf, folder_name: PathBuf) -> Result<
     with_boundary(Some(raw_vault_path.as_ref()), |boundary| {
         let folder_name = folder_name.to_string_lossy();
         let folder_path = boundary.child_path(folder_name.as_ref())?;
-        validate_folder_name(folder_name.as_ref())?;
+        validate_folder_relative_path(folder_name.as_ref())?;
         ensure_missing_folder(&folder_path, folder_name.as_ref())?;
         std::fs::create_dir_all(&folder_path)
             .map_err(|e| format!("Failed to create folder: {}", e))?;
         Ok(folder_name.into_owned())
     })
+}
+
+fn validate_folder_relative_path(folder_name: &str) -> Result<(), String> {
+    let mut has_segment = false;
+    for component in Path::new(folder_name).components() {
+        match component {
+            Component::Normal(segment) => {
+                has_segment = true;
+                validate_folder_name(&segment.to_string_lossy())?;
+            }
+            _ => return Err("Invalid folder path".to_string()),
+        }
+    }
+
+    if has_segment {
+        Ok(())
+    } else {
+        Err("Invalid folder path".to_string())
+    }
 }
 
 fn ensure_missing_folder(folder_path: &Path, folder_name: &str) -> Result<(), String> {
@@ -324,6 +343,18 @@ mod tests {
 
         let folders = list_vault_folders(root).unwrap();
         assert!(folders.iter().any(|folder| folder.name == "Projects"));
+    }
+
+    #[test]
+    fn create_vault_folder_accepts_nested_relative_paths() {
+        let dir = TempDir::new().unwrap();
+
+        assert_eq!(
+            create_vault_folder(dir.path().to_path_buf(), PathBuf::from("Projects/backend"))
+                .unwrap(),
+            "Projects/backend"
+        );
+        assert!(dir.path().join("Projects/backend").is_dir());
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -806,12 +806,15 @@ function App() {
     })
   }, [updateConfig, vaultConfig.inbox])
 
-  const handleCreateFolder = useCallback(async (name: string) => {
+  const handleCreateFolder = useCallback(async (name: string, parentPath?: string | null) => {
+    const folderName = parentPath
+      ? `${parentPath.replace(/^\/+|\/+$/g, '')}/${name}`
+      : name
     try {
       if (isTauri()) {
-        await invoke('create_vault_folder', { vaultPath: resolvedPath, folderName: name })
+        await invoke('create_vault_folder', { vaultPath: resolvedPath, folderName })
       } else {
-        await mockInvoke('create_vault_folder', { vaultPath: resolvedPath, folderName: name })
+        await mockInvoke('create_vault_folder', { vaultPath: resolvedPath, folderName })
       }
       await vault.reloadFolders()
       setToastMessage(`Created folder "${name}"`)

--- a/src/components/FolderTree.test.tsx
+++ b/src/components/FolderTree.test.tsx
@@ -224,6 +224,29 @@ describe('FolderTree', () => {
     expect(onDeleteFolder).toHaveBeenCalledWith('projects')
   })
 
+  it('creates a subfolder from the folder context menu', async () => {
+    const onCreateFolder = vi.fn().mockResolvedValue(true)
+    render(
+      <FolderTree
+        folders={mockFolders}
+        selection={defaultSelection}
+        onSelect={vi.fn()}
+        onCreateFolder={onCreateFolder}
+      />,
+    )
+
+    fireEvent.contextMenu(screen.getByText('projects'))
+    fireEvent.click(screen.getByTestId('create-subfolder-menu-item'))
+
+    const input = await screen.findByTestId('new-child-folder-input:projects')
+    fireEvent.change(input, { target: { value: 'backend' } })
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(onCreateFolder).toHaveBeenCalledWith('backend', 'projects')
+  })
+
   it('opens folder file actions from the context menu', () => {
     const onRevealFolder = vi.fn()
     const onCopyFolderPath = vi.fn()

--- a/src/components/FolderTree.tsx
+++ b/src/components/FolderTree.tsx
@@ -1,6 +1,9 @@
 import {
   memo,
   useCallback,
+  useEffect,
+  useRef,
+  useState,
 } from 'react'
 import {
   Plus,
@@ -16,11 +19,13 @@ import { SidebarGroupHeader } from './sidebar/SidebarGroupHeader'
 import { translate, type AppLocale } from '../lib/i18n'
 import type { FolderFileActions } from '../hooks/useFileActions'
 
+type CreateFolderHandler = (name: string, parentPath?: string | null) => Promise<boolean> | boolean
+
 interface FolderTreeProps {
   folders: FolderNode[]
   selection: SidebarSelection
   onSelect: (selection: SidebarSelection) => void
-  onCreateFolder?: (name: string) => Promise<boolean> | boolean
+  onCreateFolder?: CreateFolderHandler
   onRenameFolder?: (folderPath: string, nextName: string) => Promise<boolean> | boolean
   onDeleteFolder?: (folderPath: string) => void
   folderFileActions?: FolderFileActions
@@ -28,6 +33,7 @@ interface FolderTreeProps {
   onStartRenameFolder?: (folderPath: string) => void
   onCancelRenameFolder?: () => void
   collapsed?: boolean
+  createRequestKey?: number
   locale?: AppLocale
   onToggle?: () => void
 }
@@ -44,6 +50,7 @@ export const FolderTree = memo(function FolderTree({
   onStartRenameFolder,
   onCancelRenameFolder,
   collapsed: externalCollapsed,
+  createRequestKey = 0,
   locale = 'en',
   onToggle,
 }: FolderTreeProps) {
@@ -61,6 +68,7 @@ export const FolderTree = memo(function FolderTree({
     renamingFolderPath,
     selection,
   })
+  const [creatingChildParentPath, setCreatingChildParentPath] = useState<string | null>(null)
   const {
     closeContextMenu,
     contextMenu,
@@ -88,10 +96,37 @@ export const FolderTree = memo(function FolderTree({
     return created
   }, [closeCreateForm, onCreateFolder])
 
+  const handleCreateChildFolderSubmit = useCallback(async (parentPath: string, value: string) => {
+    const nextName = value.trim()
+    if (!nextName || !onCreateFolder) {
+      setCreatingChildParentPath(null)
+      return true
+    }
+
+    const created = await onCreateFolder(nextName, parentPath)
+    if (created) setCreatingChildParentPath(null)
+    return created
+  }, [onCreateFolder])
+
+  const handleCreateChildFolderFromMenu = useCallback((folderPath: string) => {
+    closeContextMenu()
+    setCreatingChildParentPath(folderPath)
+    if (!expanded[folderPath]) toggleFolder(folderPath)
+  }, [closeContextMenu, expanded, toggleFolder])
+
   const handleCreateFolderClick = useCallback(() => {
     closeContextMenu()
+    setCreatingChildParentPath(null)
     openCreateForm()
   }, [closeContextMenu, openCreateForm])
+  const lastCreateRequestKey = useRef(createRequestKey)
+
+  useEffect(() => {
+    if (createRequestKey === lastCreateRequestKey.current) return
+    lastCreateRequestKey.current = createRequestKey
+    const timeoutId = window.setTimeout(handleCreateFolderClick, 0)
+    return () => window.clearTimeout(timeoutId)
+  }, [createRequestKey, handleCreateFolderClick])
 
   if (folders.length === 0 && !isCreating) return null
 
@@ -117,6 +152,9 @@ export const FolderTree = memo(function FolderTree({
               onStartRenameFolder={onStartRenameFolder}
               onToggle={toggleFolder}
               onCancelRenameFolder={onCancelRenameFolder}
+              creatingChildParentPath={creatingChildParentPath}
+              onCancelCreateChildFolder={() => setCreatingChildParentPath(null)}
+              onCreateChildFolder={handleCreateChildFolderSubmit}
               locale={locale}
               renamingFolderPath={renamingFolderPath}
               selection={selection}
@@ -143,6 +181,7 @@ export const FolderTree = memo(function FolderTree({
         onDelete={handleDeleteFromMenu}
         onReveal={handleRevealFromMenu}
         onCopyPath={handleCopyPathFromMenu}
+        onCreateSubfolder={onCreateFolder ? handleCreateChildFolderFromMenu : undefined}
         onRename={handleRenameFromMenu}
         locale={locale}
       />

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1360,6 +1360,73 @@ describe('Sidebar', () => {
     })
   })
 
+  describe('blank sidebar context menu', () => {
+    function openBlankSidebarMenu() {
+      const navigation = screen.getByTestId('sidebar-navigation')
+      fireEvent.contextMenu(navigation, { clientX: 48, clientY: 120 })
+    }
+
+    it('opens localized creation actions from empty sidebar space', () => {
+      render(
+        <Sidebar
+          entries={mockEntries}
+          selection={defaultSelection}
+          onSelect={() => {}}
+          onCreateFolder={() => true}
+          onCreateView={() => {}}
+          onCreateNewType={() => {}}
+          locale="zh-CN"
+        />
+      )
+
+      openBlankSidebarMenu()
+
+      expect(screen.getByTestId('sidebar-background-context-menu')).toHaveStyle({ left: '48px', top: '120px' })
+      expect(screen.getByText('创建文件夹')).toBeInTheDocument()
+      expect(screen.getByText('创建视图')).toBeInTheDocument()
+      expect(screen.getByText('新建类型')).toBeInTheDocument()
+    })
+
+    it('runs view and type creation callbacks from the blank-space menu', () => {
+      const onCreateView = vi.fn()
+      const onCreateNewType = vi.fn()
+      render(
+        <Sidebar
+          entries={mockEntries}
+          selection={defaultSelection}
+          onSelect={() => {}}
+          onCreateView={onCreateView}
+          onCreateNewType={onCreateNewType}
+        />
+      )
+
+      openBlankSidebarMenu()
+      fireEvent.click(screen.getByText('Create view'))
+      expect(onCreateView).toHaveBeenCalledOnce()
+
+      openBlankSidebarMenu()
+      fireEvent.click(screen.getByText('Create new type'))
+      expect(onCreateNewType).toHaveBeenCalledOnce()
+    })
+
+    it('opens the folder creation input from the blank-space menu', async () => {
+      render(
+        <Sidebar
+          entries={mockEntries}
+          selection={defaultSelection}
+          onSelect={() => {}}
+          folders={[]}
+          onCreateFolder={() => true}
+        />
+      )
+
+      openBlankSidebarMenu()
+      fireEvent.click(screen.getByText('Create folder'))
+
+      expect(await screen.findByTestId('new-folder-input')).toBeInTheDocument()
+    })
+  })
+
   describe('view note count chips', () => {
     const mockViews = [
       {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, memo } from 'react'
+import { useCallback, memo, useRef, useState } from 'react'
 import type { VaultEntry, FolderNode, SidebarSelection, ViewFile } from '../types'
 import {
   KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent,
@@ -8,10 +8,12 @@ import { FolderTree } from './FolderTree'
 import {
   computeReorder,
   useEntryCounts,
+  useOutsideClick,
   useSidebarCollapsed,
   useSidebarSections,
 } from './sidebar/sidebarHooks'
 import {
+  BackgroundContextMenuOverlay,
   ContextMenuOverlay,
   CustomizeOverlay,
   FavoritesSection,
@@ -44,7 +46,7 @@ interface SidebarProps {
   onEditView?: (filename: string) => void
   onDeleteView?: (filename: string) => void
   folders?: FolderNode[]
-  onCreateFolder?: (name: string) => Promise<boolean> | boolean
+  onCreateFolder?: (name: string, parentPath?: string | null) => Promise<boolean> | boolean
   onRenameFolder?: (folderPath: string, nextName: string) => Promise<boolean> | boolean
   onDeleteFolder?: (folderPath: string) => void
   folderFileActions?: FolderFileActions
@@ -94,6 +96,9 @@ interface SidebarNavigationProps extends Pick<
   typeInteractions: ReturnType<typeof useSidebarTypeInteractions>
   isSectionVisible: (type: string) => boolean
   toggleVisibility: (type: string) => void
+  folderCreateRequestKey: number
+  onSidebarBlankContextMenu: (event: React.MouseEvent) => void
+  onSidebarContextMenuCapture: (event: React.MouseEvent) => void
 }
 
 function SidebarNavigation({
@@ -131,12 +136,20 @@ function SidebarNavigation({
   typeInteractions,
   isSectionVisible,
   toggleVisibility,
+  folderCreateRequestKey,
+  onSidebarBlankContextMenu,
+  onSidebarContextMenuCapture,
 }: SidebarNavigationProps) {
   const hasFavorites = entries.some((entry) => entry.favorite && !entry.archived)
   const hasViews = views.length > 0 || !!onCreateView
 
   return (
-    <nav className="flex-1 overflow-y-auto">
+    <nav
+      className="flex-1 overflow-y-auto"
+      data-testid="sidebar-navigation"
+      onContextMenu={onSidebarBlankContextMenu}
+      onContextMenuCapture={onSidebarContextMenuCapture}
+    >
       <SidebarTopNav
         selection={selection}
         onSelect={onSelect}
@@ -202,6 +215,7 @@ function SidebarNavigation({
         renamingFolderPath={renamingFolderPath}
         onStartRenameFolder={onStartRenameFolder}
         onCancelRenameFolder={onCancelRenameFolder}
+        createRequestKey={folderCreateRequestKey}
         collapsed={groupCollapsed.folders}
         locale={locale}
         onToggle={() => toggleGroup('folders')}
@@ -249,6 +263,9 @@ export const Sidebar = memo(function Sidebar({
   const { typeEntryMap, allSectionGroups, visibleSections, sectionIds } = useSidebarSections(entries)
   const { activeCount, archivedCount } = useEntryCounts(entries)
   const { collapsed: groupCollapsed, toggle: toggleGroup } = useSidebarCollapsed()
+  const [backgroundMenuPos, setBackgroundMenuPos] = useState<{ x: number; y: number } | null>(null)
+  const [folderCreateRequestKey, setFolderCreateRequestKey] = useState(0)
+  const backgroundMenuRef = useRef<HTMLDivElement>(null)
   const typeInteractions = useSidebarTypeInteractions({
     allSectionGroups,
     typeEntryMap,
@@ -261,6 +278,34 @@ export const Sidebar = memo(function Sidebar({
   const toggleVisibility = useCallback((type: string) => onToggleTypeVisibility?.(type), [onToggleTypeVisibility])
 
   const sensors = useSidebarDndSensors()
+  const closeBackgroundMenu = useCallback(() => setBackgroundMenuPos(null), [])
+  useOutsideClick(backgroundMenuRef, !!backgroundMenuPos, closeBackgroundMenu)
+
+  const handleSidebarBlankContextMenu = useCallback((event: React.MouseEvent) => {
+    if (event.target !== event.currentTarget) return
+    if (!onCreateFolder && !onCreateView && !onCreateNewType) return
+    event.preventDefault()
+    setBackgroundMenuPos({ x: event.clientX, y: event.clientY })
+  }, [onCreateFolder, onCreateNewType, onCreateView])
+
+  const handleSidebarContextMenuCapture = useCallback((event: React.MouseEvent) => {
+    if (event.target !== event.currentTarget) closeBackgroundMenu()
+  }, [closeBackgroundMenu])
+
+  const handleCreateFolderFromMenu = useCallback(() => {
+    closeBackgroundMenu()
+    setFolderCreateRequestKey((value) => value + 1)
+  }, [closeBackgroundMenu])
+
+  const handleCreateViewFromMenu = useCallback(() => {
+    closeBackgroundMenu()
+    onCreateView?.()
+  }, [closeBackgroundMenu, onCreateView])
+
+  const handleCreateTypeFromMenu = useCallback(() => {
+    closeBackgroundMenu()
+    onCreateNewType?.()
+  }, [closeBackgroundMenu, onCreateNewType])
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event
@@ -319,6 +364,20 @@ export const Sidebar = memo(function Sidebar({
         typeInteractions={typeInteractions}
         isSectionVisible={isSectionVisible}
         toggleVisibility={toggleVisibility}
+        folderCreateRequestKey={folderCreateRequestKey}
+        onSidebarBlankContextMenu={handleSidebarBlankContextMenu}
+        onSidebarContextMenuCapture={handleSidebarContextMenuCapture}
+      />
+      <BackgroundContextMenuOverlay
+        pos={backgroundMenuPos}
+        innerRef={backgroundMenuRef}
+        canCreateFolder={!!onCreateFolder}
+        canCreateView={!!onCreateView}
+        canCreateType={!!onCreateNewType}
+        onCreateFolder={handleCreateFolderFromMenu}
+        onCreateView={handleCreateViewFromMenu}
+        onCreateType={handleCreateTypeFromMenu}
+        locale={locale}
       />
       <ContextMenuOverlay
         pos={typeInteractions.contextMenuPos}

--- a/src/components/folder-tree/FolderContextMenu.tsx
+++ b/src/components/folder-tree/FolderContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react'
-import { ClipboardText, FolderOpen, PencilSimple, Trash } from '@phosphor-icons/react'
+import { ClipboardText, FolderOpen, FolderPlus, PencilSimple, Trash } from '@phosphor-icons/react'
 import { Button } from '@/components/ui/button'
 import { translate, type AppLocale } from '../../lib/i18n'
 
@@ -15,6 +15,7 @@ interface FolderContextMenuProps {
   onDelete?: (folderPath: string) => void
   onReveal?: (folderPath: string) => void
   onCopyPath?: (folderPath: string) => void
+  onCreateSubfolder?: (folderPath: string) => void
   onRename: (folderPath: string) => void
   locale?: AppLocale
 }
@@ -25,6 +26,7 @@ export function FolderContextMenu({
   onDelete,
   onReveal,
   onCopyPath,
+  onCreateSubfolder,
   onRename,
   locale = 'en',
 }: FolderContextMenuProps) {
@@ -59,6 +61,18 @@ export function FolderContextMenu({
         >
           <ClipboardText size={14} />
           {translate(locale, 'sidebar.action.copyFolderPathMenu')}
+        </Button>
+      )}
+      {onCreateSubfolder && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-sm"
+          onClick={() => onCreateSubfolder(menu.path)}
+          data-testid="create-subfolder-menu-item"
+        >
+          <FolderPlus size={14} />
+          {translate(locale, 'sidebar.action.createSubfolderMenu')}
         </Button>
       )}
       <Button

--- a/src/components/folder-tree/FolderTreeRow.tsx
+++ b/src/components/folder-tree/FolderTreeRow.tsx
@@ -9,6 +9,9 @@ interface FolderTreeRowProps {
   expanded: Record<string, boolean>
   node: FolderNode
   onDeleteFolder?: (folderPath: string) => void
+  creatingChildParentPath?: string | null
+  onCancelCreateChildFolder?: () => void
+  onCreateChildFolder?: (parentPath: string, value: string) => Promise<boolean> | boolean
   onOpenMenu: (node: FolderNode, event: ReactMouseEvent<HTMLDivElement>) => void
   onRenameFolder?: (folderPath: string, nextName: string) => Promise<boolean> | boolean
   onSelect: (selection: SidebarSelection) => void
@@ -56,6 +59,9 @@ function FolderChildren({
   expanded,
   node,
   onDeleteFolder,
+  creatingChildParentPath,
+  onCancelCreateChildFolder,
+  onCreateChildFolder,
   onOpenMenu,
   onRenameFolder,
   onSelect,
@@ -83,6 +89,9 @@ function FolderChildren({
           expanded={expanded}
           node={child}
           onDeleteFolder={onDeleteFolder}
+          creatingChildParentPath={creatingChildParentPath}
+          onCancelCreateChildFolder={onCancelCreateChildFolder}
+          onCreateChildFolder={onCreateChildFolder}
           onOpenMenu={onOpenMenu}
           onRenameFolder={onRenameFolder}
           onSelect={onSelect}
@@ -103,6 +112,9 @@ export const FolderTreeRow = memo(function FolderTreeRow({
   expanded,
   node,
   onDeleteFolder,
+  creatingChildParentPath,
+  onCancelCreateChildFolder,
+  onCreateChildFolder,
   onOpenMenu,
   onRenameFolder,
   onSelect,
@@ -118,6 +130,7 @@ export const FolderTreeRow = memo(function FolderTreeRow({
   const isSelected = selection.kind === 'folder' && selection.path === node.path
   const depthIndent = depth * 16
   const contentInset = 16
+  const isCreatingChild = creatingChildParentPath === node.path
   const selectFolder = useCallback(() => {
     onSelect({ kind: 'folder', path: node.path })
   }, [node.path, onSelect])
@@ -149,11 +162,27 @@ export const FolderTreeRow = memo(function FolderTreeRow({
           onRenameFolder={onRenameFolder}
         />
       ) : row}
+      {isCreatingChild && onCreateChildFolder && onCancelCreateChildFolder && (
+        <div style={{ paddingLeft: (depth + 1) * 16 + 15 }}>
+          <FolderNameInput
+            ariaLabel={translate(locale, 'sidebar.folder.newName')}
+            initialValue=""
+            placeholder={translate(locale, 'sidebar.folder.name')}
+            submitOnBlur={true}
+            testId={`new-child-folder-input:${node.path}`}
+            onCancel={onCancelCreateChildFolder}
+            onSubmit={(value) => onCreateChildFolder(node.path, value)}
+          />
+        </div>
+      )}
       <FolderChildren
         depth={depth}
         expanded={expanded}
         node={node}
         onDeleteFolder={onDeleteFolder}
+        creatingChildParentPath={creatingChildParentPath}
+        onCancelCreateChildFolder={onCancelCreateChildFolder}
+        onCreateChildFolder={onCreateChildFolder}
         onOpenMenu={onOpenMenu}
         onRenameFolder={onRenameFolder}
         onSelect={onSelect}

--- a/src/components/sidebar/SidebarSections.tsx
+++ b/src/components/sidebar/SidebarSections.tsx
@@ -9,7 +9,7 @@ import {
   SortableContext, useSortable, verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { SlidersHorizontal } from 'lucide-react'
+import { FolderPlus, ListPlus, SlidersHorizontal, Tags } from 'lucide-react'
 import {
   CaretLeft, Plus,
 } from '@phosphor-icons/react'
@@ -283,6 +283,60 @@ export function ContextMenuOverlay({
       <button className={buttonClass} onClick={() => onOpenCustomize(type)}>
         {translate(locale, 'sidebar.action.customizeIconColor')}
       </button>
+    </div>
+  )
+}
+
+export function BackgroundContextMenuOverlay({
+  pos,
+  innerRef,
+  canCreateFolder,
+  canCreateView,
+  canCreateType,
+  onCreateFolder,
+  onCreateView,
+  onCreateType,
+  locale = 'en',
+}: {
+  pos: { x: number; y: number } | null
+  innerRef: Ref<HTMLDivElement>
+  canCreateFolder: boolean
+  canCreateView: boolean
+  canCreateType: boolean
+  onCreateFolder: () => void
+  onCreateView: () => void
+  onCreateType: () => void
+  locale?: AppLocale
+}) {
+  if (!pos) return null
+
+  const buttonClass = 'h-auto w-full justify-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm font-normal'
+
+  return (
+    <div
+      ref={innerRef}
+      className="fixed z-50 rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+      style={{ left: pos.x, top: pos.y, minWidth: 180 }}
+      data-testid="sidebar-background-context-menu"
+    >
+      {canCreateFolder && (
+        <Button type="button" variant="ghost" className={buttonClass} onClick={onCreateFolder}>
+          <FolderPlus size={15} />
+          {translate(locale, 'sidebar.action.createFolder')}
+        </Button>
+      )}
+      {canCreateView && (
+        <Button type="button" variant="ghost" className={buttonClass} onClick={onCreateView}>
+          <ListPlus size={15} />
+          {translate(locale, 'sidebar.action.createView')}
+        </Button>
+      )}
+      {canCreateType && (
+        <Button type="button" variant="ghost" className={buttonClass} onClick={onCreateType}>
+          <Tags size={15} />
+          {translate(locale, 'sidebar.action.createType')}
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/lib/locales/de-DE.json
+++ b/src/lib/locales/de-DE.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Ordner löschen",
   "sidebar.action.revealFolderMenu": "Im Finder anzeigen",
   "sidebar.action.copyFolderPathMenu": "Ordnerpfad kopieren",
+  "sidebar.action.createSubfolderMenu": "Unterordner erstellen",
   "sidebar.action.renameFolderMenu": "Ordner umbenennen …",
   "sidebar.action.deleteFolderMenu": "Ordner löschen …",
   "sidebar.folder.name": "Ordnername",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -164,6 +164,7 @@
   "sidebar.action.deleteFolder": "Delete folder",
   "sidebar.action.revealFolderMenu": "Reveal in Finder",
   "sidebar.action.copyFolderPathMenu": "Copy folder path",
+  "sidebar.action.createSubfolderMenu": "Create subfolder",
   "sidebar.action.renameFolderMenu": "Rename folder...",
   "sidebar.action.deleteFolderMenu": "Delete folder...",
   "sidebar.folder.name": "Folder name",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Eliminar carpeta",
   "sidebar.action.revealFolderMenu": "Mostrar en el Finder",
   "sidebar.action.copyFolderPathMenu": "Copiar ruta de la carpeta",
+  "sidebar.action.createSubfolderMenu": "Crear subcarpeta",
   "sidebar.action.renameFolderMenu": "Cambiar el nombre de la carpeta...",
   "sidebar.action.deleteFolderMenu": "Eliminar carpeta...",
   "sidebar.folder.name": "Nombre de la carpeta",

--- a/src/lib/locales/es-ES.json
+++ b/src/lib/locales/es-ES.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Eliminar carpeta",
   "sidebar.action.revealFolderMenu": "Mostrar en el Finder",
   "sidebar.action.copyFolderPathMenu": "Copiar ruta de la carpeta",
+  "sidebar.action.createSubfolderMenu": "Crear subcarpeta",
   "sidebar.action.renameFolderMenu": "Cambiar el nombre de la carpeta...",
   "sidebar.action.deleteFolderMenu": "Eliminar carpeta...",
   "sidebar.folder.name": "Nombre de la carpeta",

--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Supprimer le dossier",
   "sidebar.action.revealFolderMenu": "Afficher dans le Finder",
   "sidebar.action.copyFolderPathMenu": "Copier le chemin du dossier",
+  "sidebar.action.createSubfolderMenu": "Créer un sous-dossier",
   "sidebar.action.renameFolderMenu": "Renommer le dossier…",
   "sidebar.action.deleteFolderMenu": "Supprimer le dossier…",
   "sidebar.folder.name": "Nom du dossier",

--- a/src/lib/locales/it-IT.json
+++ b/src/lib/locales/it-IT.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Elimina cartella",
   "sidebar.action.revealFolderMenu": "Mostra in Finder",
   "sidebar.action.copyFolderPathMenu": "Copia percorso della cartella",
+  "sidebar.action.createSubfolderMenu": "Crea sottocartella",
   "sidebar.action.renameFolderMenu": "Rinomina cartella...",
   "sidebar.action.deleteFolderMenu": "Elimina cartella...",
   "sidebar.folder.name": "Nome della cartella",

--- a/src/lib/locales/ja-JP.json
+++ b/src/lib/locales/ja-JP.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "フォルダーを削除",
   "sidebar.action.revealFolderMenu": "Finder で表示",
   "sidebar.action.copyFolderPathMenu": "フォルダパスをコピー",
+  "sidebar.action.createSubfolderMenu": "サブフォルダーを作成",
   "sidebar.action.renameFolderMenu": "フォルダー名を変更...",
   "sidebar.action.deleteFolderMenu": "フォルダーを削除...",
   "sidebar.folder.name": "フォルダー名",

--- a/src/lib/locales/ko-KR.json
+++ b/src/lib/locales/ko-KR.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "폴더 삭제",
   "sidebar.action.revealFolderMenu": "Finder에서 표시",
   "sidebar.action.copyFolderPathMenu": "폴더 경로 복사",
+  "sidebar.action.createSubfolderMenu": "하위 폴더 만들기",
   "sidebar.action.renameFolderMenu": "폴더 이름 변경...",
   "sidebar.action.deleteFolderMenu": "폴더 삭제...",
   "sidebar.folder.name": "폴더 이름",

--- a/src/lib/locales/pt-BR.json
+++ b/src/lib/locales/pt-BR.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Excluir pasta",
   "sidebar.action.revealFolderMenu": "Exibir no Finder",
   "sidebar.action.copyFolderPathMenu": "Copiar caminho da pasta",
+  "sidebar.action.createSubfolderMenu": "Criar subpasta",
   "sidebar.action.renameFolderMenu": "Renomear pasta...",
   "sidebar.action.deleteFolderMenu": "Excluir pasta...",
   "sidebar.folder.name": "Nome da pasta",

--- a/src/lib/locales/pt-PT.json
+++ b/src/lib/locales/pt-PT.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Eliminar pasta",
   "sidebar.action.revealFolderMenu": "Mostrar no Finder",
   "sidebar.action.copyFolderPathMenu": "Copiar caminho da pasta",
+  "sidebar.action.createSubfolderMenu": "Criar subpasta",
   "sidebar.action.renameFolderMenu": "Mudar o nome da pasta...",
   "sidebar.action.deleteFolderMenu": "Eliminar pasta...",
   "sidebar.folder.name": "Nome da pasta",

--- a/src/lib/locales/ru-RU.json
+++ b/src/lib/locales/ru-RU.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "Удалить папку",
   "sidebar.action.revealFolderMenu": "Показать в Finder",
   "sidebar.action.copyFolderPathMenu": "Копировать путь к папке",
+  "sidebar.action.createSubfolderMenu": "Создать подпапку",
   "sidebar.action.renameFolderMenu": "Переименовать папку...",
   "sidebar.action.deleteFolderMenu": "Удалить папку...",
   "sidebar.folder.name": "Имя папки",

--- a/src/lib/locales/zh-CN.json
+++ b/src/lib/locales/zh-CN.json
@@ -158,6 +158,7 @@
   "sidebar.action.deleteFolder": "删除文件夹",
   "sidebar.action.revealFolderMenu": "在访达中显示",
   "sidebar.action.copyFolderPathMenu": "复制文件夹路径",
+  "sidebar.action.createSubfolderMenu": "创建子文件夹",
   "sidebar.action.renameFolderMenu": "重命名文件夹...",
   "sidebar.action.deleteFolderMenu": "删除文件夹...",
   "sidebar.folder.name": "文件夹名称",

--- a/src/mock-tauri/mock-handlers.ts
+++ b/src/mock-tauri/mock-handlers.ts
@@ -315,6 +315,7 @@ export const mockHandlers: Record<string, (args: any) => any> = {
   list_views: () => [],
   save_view_cmd: () => {},
   delete_view_cmd: () => {},
+  create_vault_folder: (args: { folderName?: string; folder_name?: string }) => args.folderName ?? args.folder_name ?? '',
   reload_vault: () => MOCK_ENTRIES,
   reload_vault_entry: (args: { path: string }) => MOCK_ENTRIES.find(e => e.path === args.path) ?? { path: args.path, title: 'Unknown', filename: 'unknown.md', aliases: [], belongsTo: [], relatedTo: [], archived: false, snippet: '', wordCount: 0, fileSize: 0, relationships: {}, outgoingLinks: [], properties: {} },
   sync_note_title: () => false,

--- a/ui-design.pen
+++ b/ui-design.pen
@@ -14098,6 +14098,152 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "sidebar_empty_context_menu",
+      "x": 560,
+      "y": 4800,
+      "name": "Sidebar Empty Context Menu",
+      "theme": {
+        "Mode": "Light"
+      },
+      "width": 320,
+      "height": 260,
+      "fill": "$--sidebar",
+      "padding": 24,
+      "layout": "vertical",
+      "gap": 12,
+      "children": [
+        {
+          "type": "text",
+          "id": "sidebar_empty_context_menu_title",
+          "fill": "$--foreground",
+          "content": "Right-click empty sidebar space",
+          "fontFamily": "Inter",
+          "fontSize": 16,
+          "fontWeight": "600",
+          "letterSpacing": 0
+        },
+        {
+          "type": "frame",
+          "id": "sidebar_empty_context_menu_popover",
+          "name": "Floating menu",
+          "width": 180,
+          "fill": "$--popover",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$--border"
+          },
+          "cornerRadius": 6,
+          "padding": 4,
+          "layout": "vertical",
+          "gap": 2,
+          "children": [
+            {
+              "type": "text",
+              "id": "sidebar_empty_context_menu_folder",
+              "fill": "$--popover-foreground",
+              "content": "New folder",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "letterSpacing": 0
+            },
+            {
+              "type": "text",
+              "id": "sidebar_empty_context_menu_view",
+              "fill": "$--popover-foreground",
+              "content": "New view",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "letterSpacing": 0
+            },
+            {
+              "type": "text",
+              "id": "sidebar_empty_context_menu_type",
+              "fill": "$--popover-foreground",
+              "content": "New type",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "letterSpacing": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "folder_context_menu_create_child",
+      "x": 920,
+      "y": 4800,
+      "name": "Folder Context Menu — Create Subfolder",
+      "theme": {
+        "Mode": "Light"
+      },
+      "width": 320,
+      "height": 260,
+      "fill": "$--sidebar",
+      "padding": 24,
+      "layout": "vertical",
+      "gap": 12,
+      "children": [
+        {
+          "type": "text",
+          "id": "folder_context_menu_create_child_title",
+          "fill": "$--foreground",
+          "content": "Right-click a folder",
+          "fontFamily": "Inter",
+          "fontSize": 16,
+          "fontWeight": "600",
+          "letterSpacing": 0
+        },
+        {
+          "type": "frame",
+          "id": "folder_context_menu_create_child_popover",
+          "name": "Floating menu",
+          "width": 190,
+          "fill": "$--popover",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$--border"
+          },
+          "cornerRadius": 6,
+          "padding": 4,
+          "layout": "vertical",
+          "gap": 2,
+          "children": [
+            {
+              "type": "text",
+              "id": "folder_context_menu_create_child_copy",
+              "fill": "$--popover-foreground",
+              "content": "Copy folder path",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "letterSpacing": 0
+            },
+            {
+              "type": "text",
+              "id": "folder_context_menu_create_child_action",
+              "fill": "$--popover-foreground",
+              "content": "Create subfolder",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "letterSpacing": 0
+            },
+            {
+              "type": "text",
+              "id": "folder_context_menu_create_child_rename",
+              "fill": "$--popover-foreground",
+              "content": "Rename folder",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "letterSpacing": 0
+            }
+          ]
+        }
+      ]
     }
   ],
   "themes": {


### PR DESCRIPTION
Since my knowledge base heavily relies on folders for hierarchical management, I just develop:
1. When the user right-clicks on an empty space, a menu will pop up to create folders, types, and tags
2 Users can right-click an exists folder to create a subfolder

If this feature is approved, I would like to proceed to the next step and implement more detailed functions to create and move files within folders

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/893173b6-0fa6-4460-81ef-eec37fd411a8" />

<img width="700" height="200" alt="image" src="https://github.com/user-attachments/assets/3d6eaff8-091a-4d18-8f0b-d3b9dcfc0b39" />
