### PR TITLE
Fix tooltip positioning when app zoom is above 100% on Windows

### DIFF
--- a/src/components/BreadcrumbBar.test.tsx
+++ b/src/components/BreadcrumbBar.test.tsx
@@ -307,6 +307,23 @@ describe('BreadcrumbBar — action buttons always right-aligned', () => {
     expect(widthActionGroup).toHaveClass('gap-2')
   })
 
+  it('end-aligns toolbar action tooltips so zoomed windows keep them inside the right edge', async () => {
+    render(
+      <BreadcrumbBar
+        entry={baseEntry}
+        {...defaultProps}
+        onToggleFavorite={vi.fn()}
+      />,
+    )
+
+    act(() => {
+      fireEvent.focus(screen.getByRole('button', { name: 'Add to favorites' }))
+    })
+    const tooltip = await screen.findByRole('tooltip')
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toHaveAttribute('data-align', 'end')
+    expect(tooltip).toHaveTextContent('Add to favorites')
+  })
+
   it('lets the title use the free space before the fixed drag gap', () => {
     const { container } = render(<BreadcrumbBar entry={baseEntry} {...defaultProps} />)
 

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -120,7 +120,7 @@ function IconActionButton({
   style,
   children,
   testId,
-  tooltipAlign,
+  tooltipAlign = 'end',
 }: {
   copy: ActionTooltipCopy
   onClick?: () => void

--- a/src/components/ui/overlayPresence.test.tsx
+++ b/src/components/ui/overlayPresence.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, renderHook, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import {
   Tooltip,
@@ -11,6 +11,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from './popover'
+import { useZoom } from '@/hooks/useZoom'
 
 const PRESENCE_ANIMATION_CLASS_PARTS = [
   'animate-',
@@ -43,6 +44,33 @@ describe('overlay presence stability', () => {
     )
 
     expectNoPresenceAnimationClasses(screen.getByTestId('tooltip-content'))
+  })
+
+  it('compensates tooltip portal coordinates for app-level CSS zoom', () => {
+    document.documentElement.style.setProperty('--tolaria-overlay-zoom-compensation', '0.7142857142857143')
+
+    render(
+      <TooltipProvider>
+        <Tooltip open>
+          <TooltipTrigger asChild>
+            <button type="button">Tooltip trigger</button>
+          </TooltipTrigger>
+          <TooltipContent data-testid="tooltip-content">Tooltip copy</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    )
+
+    expect(document.querySelector('[data-slot="tooltip-zoom-compensation"]')).toBeInTheDocument()
+  })
+
+  it('publishes inverse zoom for overlay portals', () => {
+    const { result } = renderHook(() => useZoom())
+
+    act(() => {
+      result.current.zoomIn()
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--tolaria-overlay-zoom-compensation')).toBe(String(100 / 110))
   })
 
   it('keeps popover content free of Radix presence animation classes', () => {

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -33,16 +33,19 @@ function TooltipTrigger({
 function TooltipContent({
   className,
   sideOffset = 0,
+  collisionPadding = 8,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
     <TooltipPrimitive.Portal>
+      <div data-slot="tooltip-zoom-compensation" style={{ zoom: 'var(--tolaria-overlay-zoom-compensation, 1)' }}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
-          "bg-foreground text-background z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-foreground text-background z-50 w-fit max-w-[min(var(--radix-tooltip-content-available-width,22rem),22rem)] origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}
@@ -50,6 +53,7 @@ function TooltipContent({
         {children}
         <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
+      </div>
     </TooltipPrimitive.Portal>
   )
 }

--- a/src/hooks/useZoom.ts
+++ b/src/hooks/useZoom.ts
@@ -28,6 +28,7 @@ function loadPersistedZoom(): number {
 
 function applyZoomToDocument(level: number): void {
   document.documentElement.style.setProperty('zoom', `${level}%`)
+  document.documentElement.style.setProperty('--tolaria-overlay-zoom-compensation', String(DEFAULT_ZOOM / level))
   window.dispatchEvent(new Event('laputa-zoom-change'))
 }
 
@@ -41,6 +42,7 @@ export function useZoom() {
     // Apply zoom synchronously during init so child components (e.g. CodeMirror)
     // measure the correct scale factor in their own effects.
     document.documentElement.style.setProperty('zoom', `${level}%`)
+    document.documentElement.style.setProperty('--tolaria-overlay-zoom-compensation', String(DEFAULT_ZOOM / level))
     return level
   })
 


### PR DESCRIPTION
## Summary
Fixes toolbar tooltip positioning when Tolaria is zoomed above 100% in the Tauri/WebView app.

Root cause: Tolaria applies app zoom with CSS `zoom` on `document.documentElement`. Radix tooltip content is rendered through a portal, so its computed viewport coordinates were being scaled again by the app-level zoom and could shift past the window edge at zoom levels such as 120% or 140%.

This keeps the change small by compensating tooltip portal content with the inverse app zoom, tightening tooltip collision/max-width behavior, and end-aligning breadcrumb toolbar action tooltips.

## Testing
- `pnpm.cmd exec vitest run src/components/ui/overlayPresence.test.tsx src/components/BreadcrumbBar.test.tsx src/hooks/useZoom.test.ts`
- `pnpm.cmd exec eslint src/components/ui/tooltip.tsx src/components/ui/overlayPresence.test.tsx src/hooks/useZoom.ts src/components/BreadcrumbBar.tsx src/components/BreadcrumbBar.test.tsx`
- `pnpm.cmd build`
- Pre-commit hook: `pnpm lint --quiet` and full Vitest suite passed

## Screenshots
### Before
To note that sometimes I cannot even get the tooltip to show at all. Haven't l
<img width="2562" height="1401" alt="image" src="https://github.com/user-attachments/assets/e60ec0c1-afad-4849-8269-f1f9f11cced6" />
### After
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/4b513a4a-cba6-4cf2-a9be-ec690ac545bd" />

