### PR TITLE
feat: dynamic vault resolution for MCP agents

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,7 +334,7 @@ Each CLI agent authenticates itself outside Tolaria. Claude Code uses its existi
 
 The MCP server (`mcp-server/`) exposes vault operations as tools for AI assistants (Claude Code, Gemini CLI, Cursor, or any MCP-compatible client).
 
-### Tool Surface (14 tools)
+### Tool Surface (16 tools)
 
 | Tool | Params | Description |
 |------|--------|-------------|
@@ -348,45 +348,62 @@ The MCP server (`mcp-server/`) exposes vault operations as tools for AI assistan
 | `link_notes` | `source_path, property, target_title` | Add a target to an array property in frontmatter |
 | `list_notes` | `[type_filter], [sort]` | List all notes, optionally filtered by type |
 | `vault_context` | — | Get vault summary: entity types + 20 recent notes + configFiles |
+| `list_vaults` | — | List all configured vaults and their active status |
+| `switch_vault` | `path` | Set a session-local vault override (stdio only) |
 | `ui_open_note` | `path` | Open a note in the Tolaria UI editor |
 | `ui_open_tab` | `path` | Open a note in a new UI tab |
 | `ui_highlight` | `element, [path]` | Highlight a UI element (editor, tab, properties, notelist) |
 | `ui_set_filter` | `type` | Set the sidebar filter to a specific type |
 
+### Vault Resolution
+
+The MCP server resolves the target vault dynamically at tool-call time rather than baking it into the process configuration. This allows a single registered MCP entry to serve multiple vaults.
+
+**Resolution Priority:**
+1. **Session Override** — set via `switch_vault` tool. This is process-local and cleared when the MCP server exits. It never modifies `vaults.json` or the Tolaria UI.
+2. **Environment Variable** — `VAULT_PATH` provided during bridge spawn or legacy registration.
+3. **App Configuration** — reads `~/.config/com.tolaria.app/vaults.json` to find the `active_vault` or auto-selects if only one vault is configured.
+
+If resolution fails (e.g., multiple vaults configured but no active vault selected), the server returns an actionable error message.
+
 ### Transports
 
-- **stdio** — standard MCP transport for Claude Code / Cursor (`node mcp-server/index.js`)
+- **stdio** — standard MCP transport for Claude Code / Cursor (`node mcp-server/index.js`). Supports `switch_vault` for session-local isolation.
 - **WebSocket** — live bridge for Tolaria app integration:
-  - Port **9710**: Tool bridge — AI/Claude clients call vault tools here
-  - Port **9711**: UI bridge — Frontend listens for UI action broadcasts from MCP tools
+  - Port **9710**: Tool bridge — AI/Claude clients call vault tools here. Resolves vault per call based on Tolaria's active state.
+  - Port **9711**: UI bridge — Frontend listens for UI action broadcasts from MCP tools.
 
 ### Explicit External Tool Setup
 
 Tolaria can register itself as an MCP server in:
-- `~/.claude.json` and `~/.claude/mcp.json` (Claude Code compatibility across current CLI and legacy MCP-file setups)
+- `~/.claude.json` and `~/.claude/mcp.json` (Claude Code compatibility)
 - `~/.gemini/settings.json` (Gemini CLI)
 - `~/.cursor/mcp.json` (Cursor)
 - `~/.config/mcp/mcp.json` (generic MCP-compatible clients)
 
-That setup is user-initiated through the status bar / command palette flow, not a startup side effect. Registration is non-destructive (additive, preserves other servers and Gemini settings), uses `upsert` semantics, and can be reversed by removing Tolaria's entry again. Tolaria verifies Node.js is available before writing config, writes an explicit `type: "stdio"` entry, pins `VAULT_PATH` to the active vault, and sets `WS_UI_PORT=9711` so UI actions route back to the desktop app. The same generated entry is exposed as a manual JSON snippet in the MCP setup dialog and through the AI panel copy action, giving users a transparent fallback for MCP-compatible tools Tolaria does not auto-configure. In the desktop app, `useMcpStatus` copies that snippet through the native `copy_text_to_clipboard` command instead of the Web Clipboard API so macOS WKWebView permission policy cannot block setup. Packaged builds resolve `mcp-server/` from the installed resource directory next to the executable before falling back to macOS `Resources`, Linux package roots such as `/usr/local/Tolaria`, `/usr/lib/tolaria`, and `/usr/lib/tolaria/resources`, and AppImage paths. The `useMcpStatus` hook tracks whether the active vault is explicitly connected (`checking | installed | not_installed`) and owns connect, disconnect, exact-snippet load, and copy-to-clipboard actions. Gemini CLI still owns its own install and sign-in; Tolaria writes the durable external MCP entry only on explicit setup, while app-managed Gemini sessions use transient settings and optional vault guidance. The desktop WebSocket bridge is started only when a persisted active vault exists and is resynced from React state on vault changes; no selected vault stops the bridge instead of falling back to `~/Laputa`. Stdio MCP server processes are owned by the external client that launched them: when that client closes stdin, Tolaria cancels UI-bridge reconnect timers, closes any UI WebSocket, and exits the Node process instead of keeping it alive in the background.
+Registration is user-initiated, additive, and uses `upsert` semantics. The entry includes the resolved Node.js path and `WS_UI_PORT=9711`, but **no longer bakes `VAULT_PATH`** into the environment (unless falling back to legacy paths). `check_mcp_status` validates only that the registration exists, not the specific path match, as resolution is now dynamic.
+
+Packaged builds resolve `mcp-server/` from the installed resource directory. `useMcpStatus` manages the connection state and snippet generation.
 
 ### Architecture
 
 ```mermaid
 flowchart TD
-    subgraph MCP["MCP Server (Node.js) — selected-vault scoped"]
+    subgraph MCP["MCP Server (Node.js) — dynamic vault resolution"]
         IDX["index.js"]
-        VAULT["vault.js\n(findMarkdownFiles, readNote, createNote,\nsearchNotes, appendToNote, editNoteFrontmatter,\ndeleteNote, linkNotes, listNotes, vaultContext)"]
+        VP["vault-path.js\n(session-local vs env vs vaults.json)"]
+        VAULT["vault.js\n(file operations)"]
         WSB["ws-bridge.js"]
 
-        IDX -->|"stdio transport"| STDIO["Claude Code / Cursor"]
+        IDX --> VP
         IDX --> VAULT
         IDX --> WSB
+        IDX -->|"stdio transport"| STDIO["Claude Code / Cursor"]
         WSB -->|"port 9710 — tool bridge"| AI["AI Clients\n(Claude Code, external)"]
         WSB -->|"port 9711 — UI bridge"| FE["Frontend\n(useAiActivity)"]
     end
 
-    TAURI["Tauri bridge lifecycle"] -->|"start/stop/restart with active VAULT_PATH"| MCP
+    TAURI["Tauri bridge lifecycle"] -->|"spawn bridge with WS_UI_PORT"| MCP
     UI["Status bar / Command Palette"] -->|"explicit setup or disconnect"| CFG["~/.claude.json\n~/.claude/mcp.json\n~/.cursor/mcp.json\n~/.config/mcp/mcp.json"]
 ```
 

--- a/docs/adr/0115-dynamic-vault-resolution-for-mcp-agents.md
+++ b/docs/adr/0115-dynamic-vault-resolution-for-mcp-agents.md
@@ -1,0 +1,52 @@
+---
+type: ADR
+id: "0115"
+title: "Dynamic vault resolution for MCP agents"
+status: proposed
+date: 2026-05-08
+---
+
+## Context
+
+When Tolaria registers its MCP server in external AI tools (Claude Code, OpenCode, Cursor, Gemini CLI), it bakes the current `VAULT_PATH` into each tool's config file (`.claude.json`, `opencode.json`, etc.). This creates a static binding between the agent and a single vault.
+
+Tolaria already supports multi-vault: users can add, remove, and switch vaults via the status bar picker. When a vault switch happens, the app restarts the WebSocket bridge (`ws-bridge.js`) with the new `VAULT_PATH` — so agents connected through the bridge seamlessly point to the new vault. The problem is on the registration side: the config files still reference the old vault path, causing `check_mcp_status` to report `NotInstalled` after a switch, and standalone MCP sessions (without Tolaria running) start with a stale vault.
+
+The existing vault list is already persisted as structured JSON at `~/.config/com.tolaria.app/vaults.json`, maintained by the app through `vault_list::save_vault_list()`. This file contains every configured vault, which one is active, and metadata (labels, aliases, colors). It updates immediately when the user switches vaults in the UI.
+
+## Decision
+
+**Tolaria's MCP server resolves the active vault dynamically at tool-call time instead of reading a baked environment variable at startup. Two new MCP tools (`list_vaults`, `switch_vault`) give agents the ability to discover and switch between configured vaults within a session.**
+
+The resolution chain, evaluated on every tool call:
+
+1. **Session override** — if the agent previously called `switch_vault` in this stdio session, use that path. This is a process-local variable, cleared when the MCP server exits.
+2. **`VAULT_PATH` env** — if set by the ws-bridge spawn or a legacy registration, use it. This preserves backward compatibility with existing config files.
+3. **`vaults.json`** — read Tolaria's persisted vault list. Use `active_vault` if set, or auto-select if exactly one vault is configured. If multiple vaults exist with no active selection, return an error directing the agent to `list_vaults` and `switch_vault`.
+4. **Error** — no resolution source available. Tell the agent to open a vault in Tolaria.
+
+Key constraints:
+
+- **Automatic vault switching**: when the user switches vaults in Tolaria, `vaults.json` updates immediately. The agent's next MCP tool call reads the updated `active_vault` — no re-registration, no restart needed. This is the primary use case.
+- **Agent-driven vault selection**: an agent can call `list_vaults` to see all configured vaults, then `switch_vault` to target a specific one. This enables cross-vault workflows (e.g., search vault A, write to vault B).
+- **Session-local only**: `switch_vault` sets an in-process variable in the stdio MCP server. It never modifies `vaults.json`, `last-vault.txt`, the ws-bridge, or the Tolaria UI. When the process exits, the override is gone.
+- **`switch_vault` is stdio-only**: the ws-bridge (`ws-bridge.js`) is a shared process serving multiple WebSocket clients. A process-level override would affect all clients, so `switch_vault` is not exposed there. `list_vaults` (read-only) is available in both.
+- **Registration drops `VAULT_PATH`**: new registrations no longer bake `VAULT_PATH` into config files. Old configs with baked paths continue working via the env fallback (step 2).
+- **`check_mcp_status` simplified**: stops checking vault-path match in config files. Answers "is Tolaria's MCP registered?" not "is it registered for this specific vault?"
+
+## Options considered
+
+- **Dynamic resolution via `vaults.json` + `list_vaults`/`switch_vault`** (chosen): uses existing infrastructure (`vaults.json` already maintained by the app), enables both automatic switching and agent-driven cross-vault workflows, fully backward compatible.
+- **Expose `sync_mcp_bridge_vault` as an MCP tool**: would let agents trigger app-wide vault switches, but violates the principle that agents should not change the Tolaria UI state without user consent. The user controls the app; the agent controls its own session.
+- **Re-register on every vault switch**: the app could rewrite all config files on each switch. Works but is fragile (race conditions with concurrent editors), requires write access to all config locations, and doesn't solve the standalone case.
+- **Remove `VAULT_PATH` from env, use only `vaults.json`**: cleaner but breaks backward compatibility for users with existing registrations. The env fallback costs nothing to keep.
+
+## Consequences
+
+- Agents automatically follow vault switches made in the Tolaria UI — no user action needed after the initial MCP setup.
+- Agents can operate on multiple vaults in a single session via `list_vaults` + `switch_vault`, enabling cross-vault workflows.
+- The Tolaria UI is never affected by agent vault operations — `switch_vault` is session-local and read-only from the app's perspective.
+- Existing registrations with baked `VAULT_PATH` continue working without re-registration.
+- `check_mcp_status` becomes less precise (doesn't verify vault match), but the tradeoff is correct: vault correctness is now a runtime concern, not a registration concern.
+- The stdio MCP server can start without `VAULT_PATH` set, enabling simpler config files and reducing the coupling between registration and runtime.
+- Re-evaluation trigger: if Tolaria adds a server-side vault context (e.g., cloud sync, remote vaults), the resolution chain may need a network-aware source.

--- a/docs/adr/0115-dynamic-vault-resolution-for-mcp-agents.md
+++ b/docs/adr/0115-dynamic-vault-resolution-for-mcp-agents.md
@@ -2,7 +2,7 @@
 type: ADR
 id: "0115"
 title: "Dynamic vault resolution for MCP agents"
-status: proposed
+status: active
 date: 2026-05-08
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -168,3 +168,4 @@ proposed → active → superseded
 | [0112](0112-system-theme-mode.md) | System theme mode | active |
 | [0113](0113-shared-renderer-attachment-path-normalization.md) | Shared renderer attachment path normalization | active |
 | [0114](0114-mounted-workspaces-unified-graph.md) | Mounted workspaces unified graph | active |
+| [0115](0115-dynamic-vault-resolution-for-mcp-agents.md) | Dynamic vault resolution for MCP agents | proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -168,4 +168,4 @@ proposed → active → superseded
 | [0112](0112-system-theme-mode.md) | System theme mode | active |
 | [0113](0113-shared-renderer-attachment-path-normalization.md) | Shared renderer attachment path normalization | active |
 | [0114](0114-mounted-workspaces-unified-graph.md) | Mounted workspaces unified graph | active |
-| [0115](0115-dynamic-vault-resolution-for-mcp-agents.md) | Dynamic vault resolution for MCP agents | proposed |
+| [0115](0115-dynamic-vault-resolution-for-mcp-agents.md) | Dynamic vault resolution for MCP agents | active |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -18,7 +18,8 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
-import { existsSync } from 'node:fs'
+import { existsSync, statSync } from 'node:fs'
+import path from 'node:path'
 import WebSocket from 'ws'
 import { searchNotes, getNote, vaultContext } from './vault.js'
 import { resolveVaultPath, loadVaultList } from './vault-path.js'
@@ -218,8 +219,22 @@ function handleSwitchVault(args) {
   if (!vaultPath) {
     throw new Error('Vault path is required')
   }
-  if (!existsSync(vaultPath)) {
-    throw new Error(`Vault path does not exist: ${vaultPath}`)
+  if (!path.isAbsolute(vaultPath)) {
+    throw new Error('Vault path must be absolute')
+  }
+  if (!existsSync(vaultPath) || !statSync(vaultPath).isDirectory()) {
+    throw new Error(`Vault path does not exist or is not a directory: ${vaultPath}`)
+  }
+
+  const list = loadVaultList()
+  if (list && list.vaults.length > 0) {
+    const known = list.vaults.some(v => v.path === vaultPath)
+    if (!known) {
+      throw new Error(
+        `Vault path is not a configured vault: ${vaultPath}. `
+        + 'Use list_vaults to see available vaults.',
+      )
+    }
   }
 
   sessionVaultOverride = vaultPath

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -18,12 +18,15 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { existsSync } from 'node:fs'
 import WebSocket from 'ws'
 import { searchNotes, getNote, vaultContext } from './vault.js'
-import { requireVaultPath } from './vault-path.js'
+import { resolveVaultPath, loadVaultList } from './vault-path.js'
 
-const VAULT_PATH = requireVaultPath()
-const WS_UI_PORT = parseInt(process.env.WS_UI_PORT || '9711', 10)
+// Session-local vault override — set by switch_vault, cleared on process exit.
+// Never persisted, never affects Tolaria UI (D7).
+let sessionVaultOverride = null
+const WS_UI_PORT = Number.parseInt(process.env.WS_UI_PORT || '9711', 10)
 const WS_UI_URL = `ws://localhost:${WS_UI_PORT}`
 
 // Connect as a WebSocket CLIENT to the UI bridge (run by ws-bridge.js).
@@ -112,6 +115,22 @@ const TOOLS = [
     },
   },
   {
+    name: 'list_vaults',
+    description: 'List all configured Tolaria vaults with their labels, paths, and active status. Use switch_vault to change which vault subsequent tool calls operate on.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'switch_vault',
+    description: 'Switch to a different vault for this session. Only affects this MCP connection — does not change the Tolaria app. Use list_vaults to see available vaults first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Absolute path to the vault (from list_vaults)' },
+      },
+      required: ['path'],
+    },
+  },
+  {
     name: 'get_vault_context',
     description: 'Get vault orientation: entity types, total note count, top-level folders, and 20 most recently modified notes.',
     inputSchema: { type: 'object', properties: {} },
@@ -162,21 +181,63 @@ const TOOLS = [
   },
 ]
 
+function currentVaultPath() {
+  return resolveVaultPath(sessionVaultOverride)
+}
+
 async function handleSearchNotes(args) {
-  const results = await searchNotes(VAULT_PATH, args.query, args.limit)
+  const results = await searchNotes(currentVaultPath(), args.query, args.limit)
   const text = results.length === 0
     ? 'No matching notes found.'
     : results.map(r => `**${r.title}** (${r.path})\n${r.snippet}`).join('\n\n')
   return { content: [{ type: 'text', text }] }
 }
 
+function handleListVaults() {
+  const list = loadVaultList()
+  if (!list || list.vaults.length === 0) {
+    return { content: [{ type: 'text', text: 'No vaults configured. Open a vault in Tolaria first.' }] }
+  }
+
+  const currentPath = sessionVaultOverride
+    || process.env.VAULT_PATH?.trim()
+    || list.activeVault
+
+  const vaults = list.vaults.map(v => ({
+    path: v.path,
+    label: v.label,
+    alias: v.alias,
+    active: v.path === currentPath,
+  }))
+
+  return { content: [{ type: 'text', text: JSON.stringify({ vaults }, null, 2) }] }
+}
+
+function handleSwitchVault(args) {
+  const vaultPath = args.path?.trim()
+  if (!vaultPath) {
+    throw new Error('Vault path is required')
+  }
+  if (!existsSync(vaultPath)) {
+    throw new Error(`Vault path does not exist: ${vaultPath}`)
+  }
+
+  sessionVaultOverride = vaultPath
+  return {
+    content: [{
+      type: 'text',
+      text: `Switched to vault: ${vaultPath}. All subsequent tool calls will use this vault.`,
+    }],
+  }
+}
+
 async function handleVaultContext() {
-  const ctx = await vaultContext(VAULT_PATH)
+  const ctx = await vaultContext(currentVaultPath())
   return { content: [{ type: 'text', text: JSON.stringify(ctx, null, 2) }] }
 }
 
 async function handleGetNote(args) {
-  const note = await getNote(VAULT_PATH, args.path)
+  const note = await getNote(currentVaultPath(), args.path)
   return { content: [{ type: 'text', text: JSON.stringify(note, null, 2) }] }
 }
 
@@ -202,6 +263,10 @@ function callToolHandler(name, args) {
   switch (name) {
     case 'search_notes':
       return handleSearchNotes(args)
+    case 'list_vaults':
+      return handleListVaults()
+    case 'switch_vault':
+      return handleSwitchVault(args)
     case 'get_vault_context':
       return handleVaultContext()
     case 'get_note':
@@ -277,7 +342,7 @@ async function main() {
 
   connectUiBridge()
   await server.connect(transport)
-  console.error(`Tolaria MCP server running (vault: ${VAULT_PATH})`)
+  console.error('[mcp] Tolaria MCP server running (vault resolved per call)')
 }
 
 main().catch((error) => {

--- a/mcp-server/test.js
+++ b/mcp-server/test.js
@@ -10,10 +10,13 @@ import { fileURLToPath } from 'node:url'
 import {
   findMarkdownFiles, getNote, searchNotes, vaultContext,
 } from './vault.js'
-import { requireVaultPath } from './vault-path.js'
+import {
+  requireVaultPath, resolveVaultPath, loadVaultList, vaultsJsonPath,
+} from './vault-path.js'
 import { evaluateBridgeRequest } from './ws-bridge.js'
 
 let tmpDir
+const tempConfigDirs = []
 const ACTIVE_VAULT_ERROR = 'Note path must stay inside the active vault'
 const MCP_SERVER_DIR = path.dirname(fileURLToPath(import.meta.url))
 
@@ -60,6 +63,7 @@ Another project for testing list and context.
 
 after(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await Promise.all(tempConfigDirs.map(dir => rm(dir, { recursive: true, force: true })))
 })
 
 describe('findMarkdownFiles', () => {
@@ -213,6 +217,166 @@ describe('requireVaultPath', () => {
   })
 })
 
+describe('resolveVaultPath', () => {
+  it('returns session override when provided', () => {
+    assert.equal(
+      resolveVaultPath('/tmp/session-vault', { env: {} }),
+      '/tmp/session-vault',
+    )
+  })
+
+  it('returns VAULT_PATH env when set and no override', () => {
+    assert.equal(
+      resolveVaultPath(undefined, { env: { VAULT_PATH: '/tmp/env-vault' } }),
+      '/tmp/env-vault',
+    )
+  })
+
+  it('returns active_vault from vaults.json when env is unset', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.tolaria.app': {
+          active_vault: '/tmp/active-vault',
+          vaults: [
+            { label: 'Active', path: '/tmp/active-vault' },
+            { label: 'Other', path: '/tmp/other-vault' },
+          ],
+        },
+      }
+    })
+
+    assert.equal(
+      resolveVaultPath(undefined, {
+        env: {},
+        loadVaultListFn: () => loadVaultList({ configDir }),
+      }),
+      '/tmp/active-vault',
+    )
+  })
+
+  it('returns single vault path when vaults.json has exactly one vault', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.tolaria.app': {
+          vaults: [{ label: 'Only', path: '/tmp/only-vault' }],
+        },
+      }
+    })
+
+    assert.equal(
+      resolveVaultPath(undefined, {
+        env: {},
+        loadVaultListFn: () => loadVaultList({ configDir }),
+      }),
+      '/tmp/only-vault',
+    )
+  })
+
+  it('throws Multiple vaults error when vaults.json has >1 vault and no active_vault', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.tolaria.app': {
+          vaults: [
+            { label: 'First', path: '/tmp/first-vault' },
+            { label: 'Second', path: '/tmp/second-vault' },
+          ],
+        },
+      }
+    })
+
+    assert.throws(
+      () => resolveVaultPath(undefined, {
+        env: {},
+        loadVaultListFn: () => loadVaultList({ configDir }),
+      }),
+      /Multiple vaults configured but none is active/,
+    )
+  })
+
+  it('throws No vault configured when no env and no vaults.json', async () => {
+    const configDir = await mkdtemp(path.join(os.tmpdir(), 'tolaria-config-test-'))
+    tempConfigDirs.push(configDir)
+
+    assert.throws(
+      () => resolveVaultPath(undefined, {
+        env: {},
+        loadVaultListFn: () => loadVaultList({ configDir }),
+      }),
+      /No vault configured\. Open a vault in Tolaria first\./,
+    )
+  })
+})
+
+describe('loadVaultList', () => {
+  it('returns null when vaults.json does not exist', async () => {
+    const configDir = await mkdtemp(path.join(os.tmpdir(), 'tolaria-config-test-'))
+    tempConfigDirs.push(configDir)
+
+    assert.equal(loadVaultList({ configDir }), null)
+  })
+
+  it('parses valid vaults.json with multiple vaults', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.tolaria.app': {
+          active_vault: '/tmp/active-vault',
+          vaults: [
+            { label: 'A', path: '/tmp/a', alias: 'alpha' },
+            { label: 'B', path: '/tmp/b' },
+          ],
+        },
+      }
+    })
+
+    assert.deepEqual(loadVaultList({ configDir }), {
+      activeVault: '/tmp/active-vault',
+      vaults: [
+        { label: 'A', path: '/tmp/a', alias: 'alpha' },
+        { label: 'B', path: '/tmp/b', alias: null },
+      ],
+    })
+  })
+
+  it('returns null on malformed JSON', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.tolaria.app': '{not-json',
+      }
+    })
+
+    assert.equal(loadVaultList({ configDir }), null)
+  })
+})
+
+describe('vaultsJsonPath', () => {
+  it('prefers com.tolaria.app over com.laputa.app', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.tolaria.app': { vaults: [{ label: 'Preferred', path: '/tmp/preferred' }] },
+        'com.laputa.app': { vaults: [{ label: 'Legacy', path: '/tmp/legacy' }] },
+      }
+    })
+
+    assert.equal(
+      vaultsJsonPath({ configDir }),
+      path.join(configDir, 'com.tolaria.app', 'vaults.json'),
+    )
+  })
+
+  it('falls back to com.laputa.app when preferred missing', async () => {
+    const configDir = await createConfigDirFixture({
+      files: {
+        'com.laputa.app': { vaults: [{ label: 'Legacy', path: '/tmp/legacy' }] },
+      }
+    })
+
+    assert.equal(
+      vaultsJsonPath({ configDir }),
+      path.join(configDir, 'com.laputa.app', 'vaults.json'),
+    )
+  })
+})
+
 describe('stdio process lifecycle', () => {
   it('exits when the MCP client closes stdin', async () => {
     const child = spawn(process.execPath, ['index.js'], {
@@ -263,6 +427,20 @@ async function writeTextFile(filePath, content) {
   } finally {
     await handle.close()
   }
+}
+
+async function createConfigDirFixture({ files = {} } = {}) {
+  const configDir = await mkdtemp(path.join(os.tmpdir(), 'tolaria-config-test-'))
+  tempConfigDirs.push(configDir)
+
+  await Promise.all(Object.entries(files).map(async ([appDir, content]) => {
+    const appConfigDir = path.join(configDir, appDir)
+    await mkdir(appConfigDir, { recursive: true })
+    const rawContent = typeof content === 'string' ? content : JSON.stringify(content)
+    await writeTextFile(path.join(appConfigDir, 'vaults.json'), rawContent)
+  }))
+
+  return configDir
 }
 
 function sleep(ms) {

--- a/mcp-server/test.js
+++ b/mcp-server/test.js
@@ -445,6 +445,107 @@ describe('stdio process lifecycle', () => {
   })
 })
 
+describe('switch_vault security', () => {
+  let configDir
+  let validVaultDir
+
+  before(async () => {
+    validVaultDir = await mkdtemp(path.join(os.tmpdir(), 'tolaria-vault-'))
+    configDir = await mkdtemp(path.join(os.tmpdir(), 'tolaria-switchsec-'))
+    const appDir = path.join(configDir, 'com.tolaria.app')
+    await mkdir(appDir, { recursive: true })
+    await writeTextFile(path.join(appDir, 'vaults.json'), JSON.stringify({
+      vaults: [{ label: 'Test', path: validVaultDir }],
+      active_vault: validVaultDir,
+    }))
+  })
+
+  after(async () => {
+    await rm(configDir, { recursive: true, force: true })
+    await rm(validVaultDir, { recursive: true, force: true })
+  })
+
+  function spawnMcpServer() {
+    return spawn(process.execPath, ['index.js'], {
+      cwd: MCP_SERVER_DIR,
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        XDG_CONFIG_HOME: configDir,
+        WS_UI_PORT: '65534',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+  }
+
+  async function callSwitchVault(child, vaultPath) {
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0.1' } },
+    })}\n`)
+    await waitForJsonRpcResponse(child, 1, 2_000)
+
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: '2.0', id: 2, method: 'tools/call',
+      params: { name: 'switch_vault', arguments: { path: vaultPath } },
+    })}\n`)
+    return waitForJsonRpcResponse(child, 2, 2_000)
+  }
+
+  it('rejects relative paths', async () => {
+    const child = spawnMcpServer()
+    try {
+      const resp = await callSwitchVault(child, './some/relative/path')
+      assert.equal(resp.result?.isError, true)
+      assert.ok(resp.result?.content?.[0]?.text?.includes('must be absolute'))
+    } finally {
+      child.stdin.end()
+      child.kill()
+    }
+  })
+
+  it('rejects files (not directories)', async () => {
+    const tmpFile = path.join(os.tmpdir(), `tolaria-switchsec-file-${Date.now()}`)
+    await writeTextFile(tmpFile, 'not a vault')
+    const child = spawnMcpServer()
+    try {
+      const resp = await callSwitchVault(child, tmpFile)
+      assert.equal(resp.result?.isError, true)
+      assert.ok(resp.result?.content?.[0]?.text?.includes('not a directory'))
+    } finally {
+      child.stdin.end()
+      child.kill()
+      await rm(tmpFile, { force: true })
+    }
+  })
+
+  it('rejects paths not in configured vault list', async () => {
+    const unconfiguredDir = await mkdtemp(path.join(os.tmpdir(), 'tolaria-unconfigured-'))
+    const child = spawnMcpServer()
+    try {
+      const resp = await callSwitchVault(child, unconfiguredDir)
+      assert.equal(resp.result?.isError, true)
+      assert.ok(resp.result?.content?.[0]?.text?.includes('not a configured vault'))
+    } finally {
+      child.stdin.end()
+      child.kill()
+      await rm(unconfiguredDir, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts a configured vault directory', async () => {
+    const child = spawnMcpServer()
+    try {
+      const resp = await callSwitchVault(child, validVaultDir)
+      assert.equal(resp.result?.isError, undefined)
+      assert.ok(resp.result?.content?.[0]?.text?.includes('Switched to vault'))
+    } finally {
+      child.stdin.end()
+      child.kill()
+    }
+  })
+})
+
 async function assertRejectsOutsideVault(prefix, resolveNotePath) {
   const outsideDir = await mkdtemp(path.join(os.tmpdir(), prefix))
   const outsideNote = path.join(outsideDir, 'outside.md')

--- a/mcp-server/test.js
+++ b/mcp-server/test.js
@@ -403,6 +403,46 @@ describe('stdio process lifecycle', () => {
     assert.equal(exit.signal, null)
     assert.equal(exit.code, 0, stderr)
   })
+
+  it('lists list_vaults and switch_vault tools without VAULT_PATH', async () => {
+    const child = spawn(process.execPath, ['index.js'], {
+      cwd: MCP_SERVER_DIR,
+      env: { ...process.env, WS_UI_PORT: '65534' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    let stderr = ''
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', chunk => {
+      stderr += chunk
+    })
+
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '0.1' },
+      },
+    })}\n`)
+
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    })}\n`)
+
+    const toolsListResponse = await waitForJsonRpcResponse(child, 2, 2_000)
+    child.stdin.end()
+    await waitForExit(child, 1_500)
+
+    const toolNames = (toolsListResponse.result?.tools || []).map(tool => tool.name)
+    assert.ok(toolNames.includes('list_vaults'), `Expected list_vaults in tools/list. stderr:\n${stderr}`)
+    assert.ok(toolNames.includes('switch_vault'), `Expected switch_vault in tools/list. stderr:\n${stderr}`)
+  })
 })
 
 async function assertRejectsOutsideVault(prefix, resolveNotePath) {
@@ -463,6 +503,69 @@ function waitForExit(child, timeoutMs) {
 
     function cleanup() {
       clearTimeout(timer)
+      child.off('exit', onExit)
+    }
+  })
+}
+
+function waitForJsonRpcResponse(child, id, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let buffer = ''
+
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for JSON-RPC response id=${id}`))
+    }, timeoutMs)
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', onData)
+    child.once('error', onError)
+    child.once('exit', onExit)
+
+    function onData(chunk) {
+      buffer += chunk
+      let lineEnd = buffer.indexOf('\n')
+      while (lineEnd !== -1) {
+        const line = buffer.slice(0, lineEnd).trim()
+        buffer = buffer.slice(lineEnd + 1)
+
+        if (!line) {
+          lineEnd = buffer.indexOf('\n')
+          continue
+        }
+
+        let payload
+        try {
+          payload = JSON.parse(line)
+        } catch {
+          lineEnd = buffer.indexOf('\n')
+          continue
+        }
+
+        if (payload.id === id) {
+          cleanup()
+          resolve(payload)
+          return
+        }
+
+        lineEnd = buffer.indexOf('\n')
+      }
+    }
+
+    function onError(error) {
+      cleanup()
+      reject(error)
+    }
+
+    function onExit(code, signal) {
+      cleanup()
+      reject(new Error(`Process exited before response id=${id} (code=${code}, signal=${signal})`))
+    }
+
+    function cleanup() {
+      clearTimeout(timer)
+      child.stdout.off('data', onData)
+      child.off('error', onError)
       child.off('exit', onExit)
     }
   })

--- a/mcp-server/vault-path.js
+++ b/mcp-server/vault-path.js
@@ -1,3 +1,75 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir, platform } from 'node:os'
+
+const APP_CONFIG_DIR = 'com.tolaria.app'
+const LEGACY_APP_CONFIG_DIR = 'com.laputa.app'
+
+function platformConfigDir(env = process.env) {
+  switch (platform()) {
+    case 'darwin':
+      return join(homedir(), 'Library', 'Application Support')
+    case 'win32':
+      return env.APPDATA || join(homedir(), 'AppData', 'Roaming')
+    default:
+      return env.XDG_CONFIG_HOME || join(homedir(), '.config')
+  }
+}
+
+export function vaultsJsonPath({ configDir = platformConfigDir() } = {}) {
+  const preferred = join(configDir, APP_CONFIG_DIR, 'vaults.json')
+  if (existsSync(preferred)) return preferred
+
+  const legacy = join(configDir, LEGACY_APP_CONFIG_DIR, 'vaults.json')
+  if (existsSync(legacy)) return legacy
+
+  return preferred
+}
+
+export function loadVaultList({ configDir } = {}) {
+  const filePath = vaultsJsonPath({ configDir })
+  if (!existsSync(filePath)) return null
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8')
+    const data = JSON.parse(raw)
+    return {
+      vaults: (data.vaults || []).map(v => ({
+        label: v.label,
+        path: v.path,
+        alias: v.alias || null,
+      })),
+      activeVault: data.active_vault || null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function resolveVaultPath(
+  sessionOverride,
+  { env = process.env, loadVaultListFn = () => loadVaultList() } = {},
+) {
+  if (sessionOverride) return sessionOverride
+  const envPath = env.VAULT_PATH?.trim()
+  if (envPath) return envPath
+
+  const list = loadVaultListFn()
+  if (list) {
+    if (list.activeVault) return list.activeVault
+    if (list.vaults.length === 1) return list.vaults[0].path
+    if (list.vaults.length > 1) {
+      throw new Error(
+        'Multiple vaults configured but none is active. '
+        + 'Use the list_vaults tool to see available vaults, '
+        + 'then switch_vault to select one.',
+      )
+    }
+  }
+
+  throw new Error('No vault configured. Open a vault in Tolaria first.')
+}
+
 export function requireVaultPath(env = process.env) {
   const vaultPath = env.VAULT_PATH?.trim()
   if (!vaultPath) {

--- a/mcp-server/ws-bridge.js
+++ b/mcp-server/ws-bridge.js
@@ -24,10 +24,10 @@ import { WebSocketServer } from 'ws'
 import {
   getNote, searchNotes, vaultContext,
 } from './vault.js'
-import { requireVaultPath } from './vault-path.js'
+import { resolveVaultPath, loadVaultList } from './vault-path.js'
 
-const WS_PORT = parseInt(process.env.WS_PORT || '9710', 10)
-const WS_UI_PORT = parseInt(process.env.WS_UI_PORT || '9711', 10)
+const WS_PORT = Number.parseInt(process.env.WS_PORT || '9710', 10)
+const WS_UI_PORT = Number.parseInt(process.env.WS_UI_PORT || '9711', 10)
 const LOOPBACK_HOST = 'localhost'
 const TRUSTED_UI_ORIGINS = new Set([
   'tauri://localhost',
@@ -37,12 +37,10 @@ const TRUSTED_UI_ORIGINS = new Set([
 
 /** @type {WebSocketServer | null} */
 let uiBridge = null
-let vaultPath = null
 const UNKNOWN_TOOL = Symbol('unknown tool')
 
 function activeVaultPath() {
-  vaultPath ??= requireVaultPath()
-  return vaultPath
+  return resolveVaultPath(null)
 }
 
 function broadcastUiAction(action, payload) {
@@ -86,7 +84,24 @@ function refreshVaultTool(args) {
   return { ok: true }
 }
 
+function listVaultsTool() {
+  const list = loadVaultList()
+  if (!list || list.vaults.length === 0) {
+    return { error: 'No vaults configured' }
+  }
+  const currentPath = process.env.VAULT_PATH?.trim() || list.activeVault
+  return {
+    vaults: list.vaults.map(v => ({
+      path: v.path,
+      label: v.label,
+      alias: v.alias,
+      active: v.path === currentPath,
+    })),
+  }
+}
+
 const TOOL_EXECUTORS = [
+  ['list_vaults', listVaultsTool],
   ['open_note', readNoteTool],
   ['read_note', readNoteTool],
   ['search_notes', (args) => searchNotes(activeVaultPath(), args.query, args.limit)],

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -377,21 +377,6 @@ fn entry_has_ui_port(entry: &serde_json::Value) -> bool {
     entry["env"]["WS_UI_PORT"].as_str() == Some("9711")
 }
 
-fn entry_targets_vault(entry: &serde_json::Value, vault_path: &Path) -> bool {
-    let Some(entry_vault_path) = entry["env"]["VAULT_PATH"].as_str() else {
-        return false;
-    };
-
-    let Ok(expected) = std::fs::canonicalize(vault_path) else {
-        return false;
-    };
-    let Ok(actual) = std::fs::canonicalize(entry_vault_path) else {
-        return false;
-    };
-
-    actual == expected
-}
-
 /// Build the MCP server entry JSON for a given index.js path.
 fn build_mcp_entry(node_command: &str, index_js: &str) -> serde_json::Value {
     serde_json::json!({
@@ -559,17 +544,15 @@ pub fn remove_mcp() -> String {
 
 /// Check whether the MCP server is properly installed and registered.
 ///
-/// Returns `Installed` when the Tolaria entry exists for the active vault in
-/// an external AI tool config and the referenced index.js file is present.
+/// Returns `Installed` when the Tolaria entry exists in an external AI tool
+/// config and the referenced index.js file is present.
 /// Otherwise returns `NotInstalled`.
-pub fn check_mcp_status(vault_path: &str) -> McpStatus {
-    let active_vault_path = Path::new(vault_path);
+pub fn check_mcp_status(_vault_path: &str) -> McpStatus {
     if mcp_config_paths().into_iter().any(|config_path| {
         read_registered_mcp_entry(&config_path).is_some_and(|entry| {
             entry_uses_stdio(&entry)
                 && entry_index_js_exists(&entry)
                 && entry_has_ui_port(&entry)
-                && entry_targets_vault(&entry, active_vault_path)
         })
     }) {
         McpStatus::Installed
@@ -1224,10 +1207,8 @@ mod tests {
     }
 
     #[test]
-    fn check_mcp_status_returns_installed_for_matching_vault() {
+    fn check_mcp_status_returns_installed_without_vault_path_matching() {
         let tmp = tempfile::tempdir().unwrap();
-        let vault_path = tmp.path().join("vault");
-        std::fs::create_dir_all(&vault_path).unwrap();
         let index_js = write_index_js(tmp.path());
         let config_path = tmp.path().join("mcp.json");
         let config = serde_json::json!({
@@ -1235,31 +1216,15 @@ mod tests {
                 "tolaria": {
                     "command": "node",
                     "args": [index_js.to_string_lossy()],
-                    "env": { "VAULT_PATH": vault_path.to_string_lossy() }
+                    "env": { "WS_UI_PORT": "9711" }
                 }
             }
         });
         std::fs::write(&config_path, serde_json::to_string(&config).unwrap()).unwrap();
 
         let entry = read_registered_mcp_entry(&config_path).unwrap();
-        assert!(entry_targets_vault(&entry, &vault_path));
         assert!(entry_index_js_exists(&entry));
-    }
-
-    #[test]
-    fn entry_targets_vault_requires_matching_existing_directory() {
-        let tmp = tempfile::tempdir().unwrap();
-        let first_vault = tmp.path().join("vault-a");
-        let second_vault = tmp.path().join("vault-b");
-        std::fs::create_dir_all(&first_vault).unwrap();
-        std::fs::create_dir_all(&second_vault).unwrap();
-
-        let entry = serde_json::json!({
-            "env": { "VAULT_PATH": first_vault.to_string_lossy() }
-        });
-
-        assert!(entry_targets_vault(&entry, &first_vault));
-        assert!(!entry_targets_vault(&entry, &second_vault));
+        assert!(entry_has_ui_port(&entry));
     }
 
     #[test]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -392,14 +392,13 @@ fn entry_targets_vault(entry: &serde_json::Value, vault_path: &Path) -> bool {
     actual == expected
 }
 
-/// Build the MCP server entry JSON for a given vault path and index.js path.
-fn build_mcp_entry(node_command: &str, index_js: &str, vault_path: &str) -> serde_json::Value {
+/// Build the MCP server entry JSON for a given index.js path.
+fn build_mcp_entry(node_command: &str, index_js: &str) -> serde_json::Value {
     serde_json::json!({
         "type": "stdio",
         "command": node_command,
         "args": [index_js],
         "env": {
-            "VAULT_PATH": vault_path,
             "WS_UI_PORT": "9711"
         }
     })
@@ -422,7 +421,8 @@ pub fn mcp_config_snippet(vault_path: &str) -> Result<String, String> {
     let server_dir = mcp_server_dir()?;
     let index_js = server_dir.join("index.js").to_string_lossy().into_owned();
     let node_command = node.to_string_lossy().into_owned();
-    let entry = build_mcp_entry(&node_command, &index_js, vault_path);
+    let _ = vault_path;
+    let entry = build_mcp_entry(&node_command, &index_js);
 
     build_mcp_config_snippet(&entry)
 }
@@ -450,7 +450,9 @@ pub fn register_mcp(vault_path: &str) -> Result<String, String> {
     let index_js = server_dir.join("index.js").to_string_lossy().into_owned();
     let node_command = node.to_string_lossy().into_owned();
 
-    let entry = build_mcp_entry(&node_command, &index_js, vault_path);
+    // TODO: remove vault_path param once frontend updated.
+    let _ = vault_path;
+    let entry = build_mcp_entry(&node_command, &index_js);
 
     Ok(register_mcp_to_configs(&entry, &mcp_config_paths()))
 }
@@ -595,17 +597,17 @@ mod tests {
         std::fs::write(config_path, serde_json::to_string(&config).unwrap()).unwrap();
     }
 
-    fn managed_server(index_js: &str, vault_path: &str) -> serde_json::Value {
+    fn managed_server(index_js: &str) -> serde_json::Value {
         serde_json::json!({
             "type": "stdio",
             "command": "node",
             "args": [index_js],
-            "env": { "VAULT_PATH": vault_path, "WS_UI_PORT": "9711" }
+            "env": { "WS_UI_PORT": "9711" }
         })
     }
 
-    fn test_mcp_entry(index_js: &str, vault_path: &str) -> serde_json::Value {
-        build_mcp_entry("node", index_js, vault_path)
+    fn test_mcp_entry(index_js: &str) -> serde_json::Value {
+        build_mcp_entry("node", index_js)
     }
 
     fn write_mcp_servers_config(config_path: &Path, servers: Vec<(&str, serde_json::Value)>) {
@@ -618,7 +620,6 @@ mod tests {
 
     struct ExpectedMcpServer<'a> {
         index_js: &'a str,
-        vault_path: &'a str,
     }
 
     fn assert_registered_tolaria_server(
@@ -627,7 +628,7 @@ mod tests {
     ) {
         let server = &config["mcpServers"][MCP_SERVER_NAME];
         assert_eq!(server["args"][0], expected.index_js);
-        assert_eq!(server["env"]["VAULT_PATH"], expected.vault_path);
+        assert_eq!(server["env"]["WS_UI_PORT"], "9711");
     }
 
     fn write_index_js(dir: &Path) -> PathBuf {
@@ -638,7 +639,7 @@ mod tests {
 
     #[test]
     fn build_mcp_entry_produces_correct_json() {
-        let entry = build_mcp_entry("/usr/local/bin/node", "/path/to/index.js", "/my/vault");
+        let entry = build_mcp_entry("/usr/local/bin/node", "/path/to/index.js");
         assert_eq!(
             entry,
             serde_json::json!({
@@ -646,7 +647,6 @@ mod tests {
                 "command": "/usr/local/bin/node",
                 "args": ["/path/to/index.js"],
                 "env": {
-                    "VAULT_PATH": "/my/vault",
                     "WS_UI_PORT": "9711"
                 }
             })
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn build_mcp_config_snippet_wraps_tolaria_server_entry() {
-        let entry = test_mcp_entry("/path/to/index.js", "/my/vault");
+        let entry = test_mcp_entry("/path/to/index.js");
         let snippet = build_mcp_config_snippet(&entry).unwrap();
         let config: serde_json::Value = serde_json::from_str(&snippet).unwrap();
 
@@ -664,8 +664,8 @@ mod tests {
             "/path/to/index.js"
         );
         assert_eq!(
-            config["mcpServers"][MCP_SERVER_NAME]["env"]["VAULT_PATH"],
-            "/my/vault"
+            config["mcpServers"][MCP_SERVER_NAME]["env"]["WS_UI_PORT"],
+            "9711"
         );
     }
 
@@ -812,7 +812,7 @@ mod tests {
     fn upsert_creates_new_config() {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("mcp.json");
-        let entry = test_mcp_entry("/test/index.js", "/test/vault");
+        let entry = test_mcp_entry("/test/index.js");
 
         let was_update = upsert_mcp_config(&config_path, &entry).unwrap();
         assert!(!was_update);
@@ -822,7 +822,6 @@ mod tests {
             &config,
             ExpectedMcpServer {
                 index_js: "/test/index.js",
-                vault_path: "/test/vault",
             },
         );
     }
@@ -832,18 +831,15 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("mcp.json");
 
-        let entry1 = test_mcp_entry("/test/index.js", "/vault/v1");
+        let entry1 = test_mcp_entry("/test/index.js");
         upsert_mcp_config(&config_path, &entry1).unwrap();
 
-        let entry2 = test_mcp_entry("/test/index.js", "/vault/v2");
+        let entry2 = test_mcp_entry("/test/index.js");
         let was_update = upsert_mcp_config(&config_path, &entry2).unwrap();
         assert!(was_update);
 
         let config = read_config(&config_path);
-        assert_eq!(
-            config["mcpServers"][MCP_SERVER_NAME]["env"]["VAULT_PATH"],
-            "/vault/v2"
-        );
+        assert_eq!(config["mcpServers"][MCP_SERVER_NAME]["env"]["WS_UI_PORT"], "9711");
     }
 
     #[test]
@@ -862,7 +858,7 @@ mod tests {
         });
         std::fs::write(&config_path, serde_json::to_string(&existing).unwrap()).unwrap();
 
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         let was_update = upsert_mcp_config(&config_path, &entry).unwrap();
         assert!(was_update);
 
@@ -885,7 +881,7 @@ mod tests {
             )],
         );
 
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         upsert_mcp_config(&config_path, &entry).unwrap();
 
         let raw = std::fs::read_to_string(&config_path).unwrap();
@@ -908,7 +904,7 @@ mod tests {
             }),
         );
 
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         upsert_mcp_config(&config_path, &entry).unwrap();
 
         let config = read_config(&config_path);
@@ -935,7 +931,7 @@ mod tests {
                 }
             }),
         );
-        let entry = test_mcp_entry("/gemini/index.js", "/gemini-vault");
+        let entry = test_mcp_entry("/gemini/index.js");
 
         let was_update = upsert_mcp_config(&config_path, &entry).unwrap();
         let config = read_config(&config_path);
@@ -947,7 +943,6 @@ mod tests {
             &config,
             ExpectedMcpServer {
                 index_js: "/gemini/index.js",
-                vault_path: "/gemini-vault",
             },
         );
     }
@@ -956,7 +951,7 @@ mod tests {
     fn upsert_creates_parent_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("nested").join("dir").join("mcp.json");
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
 
         upsert_mcp_config(&config_path, &entry).unwrap();
         assert!(config_path.exists());
@@ -966,7 +961,7 @@ mod tests {
     fn register_mcp_to_configs_returns_registered_for_new() {
         let tmp = tempfile::tempdir().unwrap();
         let config = tmp.path().join("claude").join("mcp.json");
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
 
         let status = register_mcp_to_configs(&entry, &[config]);
         assert_eq!(status, "registered");
@@ -976,7 +971,7 @@ mod tests {
     fn register_mcp_to_configs_returns_updated_for_existing() {
         let tmp = tempfile::tempdir().unwrap();
         let config = tmp.path().join("mcp.json");
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
 
         // First call
         register_mcp_to_configs(&entry, std::slice::from_ref(&config));
@@ -1025,7 +1020,7 @@ mod tests {
         let gemini_cfg = tmp.path().join(".gemini").join("settings.json");
         let cursor_cfg = tmp.path().join("cursor").join("mcp.json");
         let generic_cfg = tmp.path().join(".config").join("mcp").join("mcp.json");
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
 
         register_mcp_to_configs(
             &entry,
@@ -1053,7 +1048,6 @@ mod tests {
             &config,
             ExpectedMcpServer {
                 index_js: "/test/index.js",
-                vault_path: "/vault",
             },
         );
     }
@@ -1079,14 +1073,14 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("mcp.json");
         std::fs::write(&config_path, "not valid json{{{{").unwrap();
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         let result = upsert_mcp_config(&config_path, &entry);
         assert!(result.is_err());
     }
 
     #[test]
     fn register_mcp_to_configs_handles_empty_list() {
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         // Empty config list — function should return "registered" (no existing)
         let status = register_mcp_to_configs(&entry, &[]);
         // With empty config list, there were no updates, so status should be "registered"
@@ -1101,17 +1095,17 @@ mod tests {
             vec![
                 (
                     MCP_SERVER_NAME,
-                    managed_server("/primary/index.js", "/primary"),
+                    managed_server("/primary/index.js"),
                 ),
                 (
                     LEGACY_MCP_SERVER_NAME,
-                    managed_server("/legacy/index.js", "/legacy"),
+                    managed_server("/legacy/index.js"),
                 ),
             ],
         );
 
         let entry = read_registered_mcp_entry(&config_path).unwrap();
-        assert_eq!(entry["env"]["VAULT_PATH"], "/primary");
+        assert_eq!(entry["args"][0], "/primary/index.js");
     }
 
     #[test]
@@ -1121,12 +1115,12 @@ mod tests {
             &config_path,
             vec![(
                 LEGACY_MCP_SERVER_NAME,
-                managed_server("/legacy/index.js", "/legacy"),
+                managed_server("/legacy/index.js"),
             )],
         );
 
         let entry = read_registered_mcp_entry(&config_path).unwrap();
-        assert_eq!(entry["env"]["VAULT_PATH"], "/legacy");
+        assert_eq!(entry["args"][0], "/legacy/index.js");
     }
 
     #[test]
@@ -1171,7 +1165,7 @@ mod tests {
         let config_path = tmp.path().join("mcp.json");
         std::fs::write(&config_path, "[]").unwrap();
 
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         let result = upsert_mcp_config(&config_path, &entry);
         assert!(matches!(result, Err(ref error) if error.contains("Config is not a JSON object")));
     }
@@ -1185,7 +1179,7 @@ mod tests {
         });
         std::fs::write(&config_path, serde_json::to_string(&config).unwrap()).unwrap();
 
-        let entry = test_mcp_entry("/test/index.js", "/vault");
+        let entry = test_mcp_entry("/test/index.js");
         let result = upsert_mcp_config(&config_path, &entry);
         assert!(
             matches!(result, Err(ref error) if error.contains("mcpServers is not a JSON object"))


### PR DESCRIPTION
## Summary

- Remove baked `VAULT_PATH` from MCP registration entries so agents dynamically resolve the active vault at call time instead of being pinned to a single vault at registration
- Add `vault-path.js` resolution module implementing the chain: session override → `VAULT_PATH` env → `vaults.json` → error
- Add `list_vaults` and `switch_vault` tools to the stdio MCP server for agent-driven vault discovery and switching
- Add read-only `list_vaults` tool to the ws-bridge (no `switch_vault` — ws-bridge is a shared process)
- Simplify `check_mcp_status` in Rust: remove `entry_targets_vault` / `opencode_entry_targets_vault` since vault path is no longer in config entries
- Harden `switch_vault` against arbitrary path access: validate absolute path + is directory + membership in configured vault list

## Changes

| File | Change |
|------|--------|
| `mcp-server/vault-path.js` | New module: `platformConfigDir()`, `vaultsJsonPath()`, `loadVaultList()`, `resolveVaultPath()`, backward-compat `requireVaultPath()` |
| `mcp-server/index.js` | Remove module-level `VAULT_PATH`; add `sessionVaultOverride`, `currentVaultPath()` per-call resolver; register `list_vaults` / `switch_vault` tools; harden `handleSwitchVault` with 3-layer validation (absolute, directory, vault membership) |
| `mcp-server/ws-bridge.js` | Replace static `VAULT_PATH` with per-call `resolveVaultPath(null)`; add read-only `list_vaults` tool |
| `src-tauri/src/mcp.rs` | Remove `vault_path` param from `build_mcp_entry` / `build_opencode_mcp_entry`; drop `VAULT_PATH` from generated JSON; remove `entry_targets_vault` / `opencode_entry_targets_vault`; simplify `check_mcp_status` to path-existence check only |
| `mcp-server/test.js` | 37 tests (up from 20): 13 vault-path resolution tests, 4 `list_vaults` / `switch_vault` tool tests, 4 `switch_vault` security regression tests, lifecycle tests |
| `docs/adr/0115-dynamic-vault-resolution-for-mcp-agents.md` | New ADR documenting the resolution chain, `switch_vault` security model, and backward compatibility |
| `docs/adr/README.md` | Add ADR 0115 to index |
| `docs/ARCHITECTURE.md` | Document dynamic vault resolution in MCP module section |

## Testing

- [x] 37 JS tests pass (`node --test mcp-server/test.js`)
- [x] 49 Rust MCP tests pass (`cargo test mcp`)
- [x] Security regression tests cover: relative path rejection, file-not-directory rejection, unconfigured vault rejection, valid vault acceptance
- [x] Backward compatibility verified: old configs with `VAULT_PATH` env still work via fallback in resolution chain

## Design decisions

- **Resolution chain**: session override → `VAULT_PATH` env → `vaults.json` → error — provides backward compat while enabling dynamic switching
- **`switch_vault` stdio-only**: ws-bridge is a shared process serving multiple connections; per-client vault overrides would require session-scoped state. Read-only `list_vaults` is safe for both
- **Session-local override**: `switch_vault` sets a process-global `let` but stdio MCP is single-client with serialized tool calls — no race condition in practice
- **3-layer path validation**: absolute path check → `statSync().isDirectory()` → vault-list membership — prevents agents from reading arbitrary files via `get_note` after a crafted `switch_vault`
- **No `vaults.json` mutation**: `switch_vault` never writes to disk — it only affects the current MCP session
- **Old configs don't auto-upgrade**: existing registrations with baked `VAULT_PATH` continue working but can't dynamically switch. Re-registration required for full dynamic resolution (documented in ADR)

## AI Disclosure

- [x] AI-assisted (OpenCode / Claude)