### PR TITLE
Sidebar collapse toggle

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,13 @@
       "Read(*)",
       "Bash(cat*)",
       "Bash(ls*)",
-      "Write(*)"
+      "Write(*)",
+      "Bash(hunk *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(pnpm test *)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Sidebar } from './components/Sidebar'
+import { isSelectionActive } from './components/SidebarParts'
 import { NoteList } from './components/NoteList'
 import { Editor } from './components/Editor'
 import { ResizeHandle } from './components/ResizeHandle'
@@ -1184,6 +1185,8 @@ function App() {
   const findInNoteRef = useRef<((options?: { replace?: boolean }) => void) | null>(null)
 
   const { setViewMode, sidebarVisible, noteListVisible } = useViewMode(noteWindowParams ? 'editor-only' : undefined)
+  const [noteListHidden, setNoteListHidden] = useState(false)
+  const effectiveNoteListVisible = noteListVisible && !noteListHidden
   const zoom = useZoom()
   const buildNumber = useBuildNumber()
 
@@ -1214,6 +1217,16 @@ function App() {
   const handleCollapseSidebar = useCallback(() => {
     handleSetViewMode('editor-list')
   }, [handleSetViewMode])
+
+  const handleSidebarNavSelect = useCallback((sel: SidebarSelection) => {
+    const isSame = isSelectionActive(selectionRef.current, sel)
+    if (isSame && !noteListHidden) {
+      setNoteListHidden(true)
+    } else {
+      setNoteListHidden(false)
+      handleSetSelection(sel)
+    }
+  }, [noteListHidden, handleSetSelection])
 
   const handleToggleInspector = useCallback(() => {
     const nextInspectorCollapsed = !layout.inspectorCollapsed
@@ -1595,12 +1608,12 @@ function App() {
           {sidebarVisible && (
             <>
               <div className="app__sidebar" style={{ width: layout.sidebarWidth }}>
-                <Sidebar entries={visibleEntries} folders={vault.folders} views={vault.views} selection={effectiveSelection} onSelect={handleSetSelection} onSelectNote={notes.handleSelectNote} onSelectFavorite={handleOpenFavorite} onReorderFavorites={entryActions.handleReorderFavorites} onCreateType={notes.handleCreateNoteImmediate} onCreateNewType={dialogs.openCreateType} onCustomizeType={entryActions.handleCustomizeType} onUpdateTypeTemplate={entryActions.handleUpdateTypeTemplate} onReorderSections={entryActions.handleReorderSections} onRenameSection={entryActions.handleRenameSection} onDeleteType={handleDeleteType} onToggleTypeVisibility={entryActions.handleToggleTypeVisibility} onCreateFolder={handleCreateFolder} onRenameFolder={folderActions.renameFolder} onDeleteFolder={folderActions.requestDeleteFolder} folderFileActions={fileActions.folderActions} renamingFolderPath={folderActions.renamingFolderPath} onStartRenameFolder={folderActions.startFolderRename} onCancelRenameFolder={folderActions.cancelFolderRename} onCreateView={dialogs.openCreateView} onEditView={handleEditView} onDeleteView={handleDeleteView} onUpdateViewDefinition={handleSidebarUpdateViewDefinition} onReorderViews={viewOrdering.onReorderViews} showInbox={explicitOrganizationEnabled} inboxCount={inboxCount} allNotesFileVisibility={allNotesFileVisibility} pluralizeTypeLabels={settings.sidebar_type_pluralization_enabled ?? true} onCollapse={handleCollapseSidebar} onGoBack={handleGoBack} onGoForward={handleGoForward} canGoBack={canGoBack} canGoForward={canGoForward} locale={appLocale} loading={isVaultContentLoading} vaultRootPath={resolvedPath} />
+                <Sidebar entries={visibleEntries} folders={vault.folders} views={vault.views} selection={effectiveSelection} onSelect={handleSidebarNavSelect} onSelectNote={notes.handleSelectNote} onSelectFavorite={handleOpenFavorite} onReorderFavorites={entryActions.handleReorderFavorites} onCreateType={notes.handleCreateNoteImmediate} onCreateNewType={dialogs.openCreateType} onCustomizeType={entryActions.handleCustomizeType} onUpdateTypeTemplate={entryActions.handleUpdateTypeTemplate} onReorderSections={entryActions.handleReorderSections} onRenameSection={entryActions.handleRenameSection} onDeleteType={handleDeleteType} onToggleTypeVisibility={entryActions.handleToggleTypeVisibility} onCreateFolder={handleCreateFolder} onRenameFolder={folderActions.renameFolder} onDeleteFolder={folderActions.requestDeleteFolder} folderFileActions={fileActions.folderActions} renamingFolderPath={folderActions.renamingFolderPath} onStartRenameFolder={folderActions.startFolderRename} onCancelRenameFolder={folderActions.cancelFolderRename} onCreateView={dialogs.openCreateView} onEditView={handleEditView} onDeleteView={handleDeleteView} onUpdateViewDefinition={handleSidebarUpdateViewDefinition} onReorderViews={viewOrdering.onReorderViews} showInbox={explicitOrganizationEnabled} inboxCount={inboxCount} allNotesFileVisibility={allNotesFileVisibility} pluralizeTypeLabels={settings.sidebar_type_pluralization_enabled ?? true} onCollapse={handleCollapseSidebar} onGoBack={handleGoBack} onGoForward={handleGoForward} canGoBack={canGoBack} canGoForward={canGoForward} locale={appLocale} loading={isVaultContentLoading} vaultRootPath={resolvedPath} />
               </div>
               <ResizeHandle onResize={layout.handleSidebarResize} />
             </>
           )}
-          {noteListVisible && (
+          {effectiveNoteListVisible && (
             <>
               <div className={`app__note-list${aiActivity.highlightElement === 'notelist' ? ' ai-highlight' : ''}`} style={{ width: layout.noteListWidth }}>
                 {effectiveSelection.kind === 'filter' && effectiveSelection.filter === 'pulse' ? (
@@ -1672,7 +1685,7 @@ function App() {
               canGoForward={canGoForward}
               onGoBack={handleGoBack}
               onGoForward={handleGoForward}
-              leftPanelsCollapsed={!sidebarVisible && !noteListVisible}
+              leftPanelsCollapsed={!sidebarVisible && !effectiveNoteListVisible}
               onFileCreated={vaultBridge.handleAgentFileCreated}
               onFileModified={vaultBridge.handleAgentFileModified}
               onVaultChanged={vaultBridge.handleAgentVaultChanged}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1218,12 +1218,18 @@ function App() {
     handleSetViewMode('editor-list')
   }, [handleSetViewMode])
 
+  const lastExplicitSelectionRef = useRef<SidebarSelection | null>(null)
+
   const handleSidebarNavSelect = useCallback((sel: SidebarSelection) => {
-    if (isSelectionActive(effectiveSelection, sel)) {
+    const isAlreadySelected = isSelectionActive(effectiveSelection, sel)
+    const userWasAlreadyHere = lastExplicitSelectionRef.current !== null && isSelectionActive(lastExplicitSelectionRef.current, sel)
+
+    if (isAlreadySelected && userWasAlreadyHere) {
       setNoteListHidden((h) => !h)
     } else {
+      lastExplicitSelectionRef.current = sel
       setNoteListHidden(false)
-      handleSetSelection(sel)
+      if (!isAlreadySelected) handleSetSelection(sel)
     }
   }, [effectiveSelection, handleSetSelection])
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1184,9 +1184,7 @@ function App() {
   const diffToggleRef = useRef<() => void>(() => {})
   const findInNoteRef = useRef<((options?: { replace?: boolean }) => void) | null>(null)
 
-  const { setViewMode, sidebarVisible, noteListVisible } = useViewMode(noteWindowParams ? 'editor-only' : undefined)
-  const [noteListHidden, setNoteListHidden] = useState(false)
-  const effectiveNoteListVisible = noteListVisible && !noteListHidden
+  const { setViewMode, sidebarVisible, noteListVisible, effectiveNoteListVisible, setNoteListHidden } = useViewMode(noteWindowParams ? 'editor-only' : undefined)
   const zoom = useZoom()
   const buildNumber = useBuildNumber()
 
@@ -1232,6 +1230,8 @@ function App() {
       if (!isAlreadySelected) handleSetSelection(sel)
     }
   }, [effectiveSelection, handleSetSelection])
+
+  const handleCollapseNoteList = useCallback(() => setNoteListHidden(true), [setNoteListHidden])
 
   const handleToggleInspector = useCallback(() => {
     const nextInspectorCollapsed = !layout.inspectorCollapsed
@@ -1624,7 +1624,7 @@ function App() {
                 {effectiveSelection.kind === 'filter' && effectiveSelection.filter === 'pulse' ? (
                   <PulseView vaultPath={gitSurfaces.historyRepositoryPath} onOpenNote={handlePulseOpenNote} sidebarCollapsed={!sidebarVisible} onExpandSidebar={() => handleSetViewMode('all')} repositories={gitRepositories} selectedRepositoryPath={gitSurfaces.historyRepositoryPath} onRepositoryChange={gitSurfaces.setHistoryRepositoryPath} locale={appLocale} />
                 ) : (
-                  <NoteList entries={visibleEntries} selection={effectiveSelection} selectedNote={activeTab?.entry ?? null} loading={isVaultContentLoading} noteListFilter={noteListFilter} onNoteListFilterChange={setNoteListFilter} inboxPeriod={inboxPeriod} modifiedFiles={noteListModifiedFiles} modifiedFilesError={noteListModifiedFilesError} gitRepositories={gitRepositories} selectedGitRepositoryPath={gitSurfaces.changesRepositoryPath} onGitRepositoryChange={gitSurfaces.setChangesRepositoryPath} getNoteStatus={vault.getNoteStatus} sidebarCollapsed={!sidebarVisible} onSelectNote={notes.handleSelectNote} onReplaceActiveTab={handleReplaceActiveTabWithQueuedDiff} onEnterNeighborhood={handleEnterNeighborhood} onCreateNote={notes.handleCreateNoteImmediate} onBulkOrganize={explicitOrganizationEnabled ? bulkActions.handleBulkOrganize : undefined} onBulkArchive={bulkActions.handleBulkArchive} onBulkDeletePermanently={deleteActions.handleBulkDeletePermanently} onUpdateTypeSort={notes.handleUpdateFrontmatter} onUpdateViewDefinition={handleUpdateViewDefinition} updateEntry={vault.updateEntry} onOpenInNewWindow={handleOpenEntryInNewWindow} onDiscardFile={handleDiscardFile} onOpenDeletedNote={handleOpenDeletedNote} allNotesNoteListProperties={vaultConfig.allNotes?.noteListProperties ?? null} onUpdateAllNotesNoteListProperties={handleUpdateAllNotesNoteListProperties} inboxNoteListProperties={vaultConfig.inbox?.noteListProperties ?? null} onUpdateInboxNoteListProperties={handleUpdateInboxNoteListProperties} views={vault.views} visibleNotesRef={visibleNotesRef} allNotesFileVisibility={allNotesFileVisibility} multiSelectionCommandRef={multiSelectionCommandRef} locale={appLocale} />
+                  <NoteList entries={visibleEntries} selection={effectiveSelection} selectedNote={activeTab?.entry ?? null} loading={isVaultContentLoading} noteListFilter={noteListFilter} onNoteListFilterChange={setNoteListFilter} inboxPeriod={inboxPeriod} modifiedFiles={noteListModifiedFiles} modifiedFilesError={noteListModifiedFilesError} gitRepositories={gitRepositories} selectedGitRepositoryPath={gitSurfaces.changesRepositoryPath} onGitRepositoryChange={gitSurfaces.setChangesRepositoryPath} getNoteStatus={vault.getNoteStatus} sidebarCollapsed={!sidebarVisible} onSelectNote={notes.handleSelectNote} onReplaceActiveTab={handleReplaceActiveTabWithQueuedDiff} onEnterNeighborhood={handleEnterNeighborhood} onCreateNote={notes.handleCreateNoteImmediate} onBulkOrganize={explicitOrganizationEnabled ? bulkActions.handleBulkOrganize : undefined} onBulkArchive={bulkActions.handleBulkArchive} onBulkDeletePermanently={deleteActions.handleBulkDeletePermanently} onUpdateTypeSort={notes.handleUpdateFrontmatter} onUpdateViewDefinition={handleUpdateViewDefinition} updateEntry={vault.updateEntry} onOpenInNewWindow={handleOpenEntryInNewWindow} onDiscardFile={handleDiscardFile} onOpenDeletedNote={handleOpenDeletedNote} allNotesNoteListProperties={vaultConfig.allNotes?.noteListProperties ?? null} onUpdateAllNotesNoteListProperties={handleUpdateAllNotesNoteListProperties} inboxNoteListProperties={vaultConfig.inbox?.noteListProperties ?? null} onUpdateInboxNoteListProperties={handleUpdateInboxNoteListProperties} views={vault.views} visibleNotesRef={visibleNotesRef} allNotesFileVisibility={allNotesFileVisibility} multiSelectionCommandRef={multiSelectionCommandRef} locale={appLocale} onCollapse={handleCollapseNoteList} />
                 )}
               </div>
               <ResizeHandle onResize={layout.handleNoteListResize} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1219,14 +1219,13 @@ function App() {
   }, [handleSetViewMode])
 
   const handleSidebarNavSelect = useCallback((sel: SidebarSelection) => {
-    const isSame = isSelectionActive(selectionRef.current, sel)
-    if (isSame && !noteListHidden) {
-      setNoteListHidden(true)
+    if (isSelectionActive(effectiveSelection, sel)) {
+      setNoteListHidden((h) => !h)
     } else {
       setNoteListHidden(false)
       handleSetSelection(sel)
     }
-  }, [noteListHidden, handleSetSelection])
+  }, [effectiveSelection, handleSetSelection])
 
   const handleToggleInspector = useCallback(() => {
     const nextInspectorCollapsed = !layout.inspectorCollapsed

--- a/src/components/NoteList.tsx
+++ b/src/components/NoteList.tsx
@@ -6,10 +6,11 @@ import { useMultiSelectKeyboard } from './note-list/useMultiSelectKeyboard'
 
 type NoteListInnerProps = NoteListProps & {
   onBulkOrganize?: (paths: string[]) => void
+  onCollapse?: () => void
   multiSelectionCommandRef?: React.MutableRefObject<NoteListMultiSelectionCommands | null>
 }
 
-function NoteListInner({ onBulkOrganize, multiSelectionCommandRef, ...props }: NoteListInnerProps) {
+function NoteListInner({ onBulkOrganize, onCollapse, multiSelectionCommandRef, ...props }: NoteListInnerProps) {
   const model = useNoteListModel(props)
 
   const handleBulkOrganize = useCallback(() => {
@@ -47,7 +48,7 @@ function NoteListInner({ onBulkOrganize, multiSelectionCommandRef, ...props }: N
     props.onBulkDeletePermanently,
   ])
 
-  return <NoteListLayout {...model} handleBulkOrganize={onBulkOrganize ? handleBulkOrganize : undefined} />
+  return <NoteListLayout {...model} handleBulkOrganize={onBulkOrganize ? handleBulkOrganize : undefined} onCollapse={onCollapse} />
 }
 
 export const NoteList = memo(NoteListInner)

--- a/src/components/note-list/NoteListHeader.tsx
+++ b/src/components/note-list/NoteListHeader.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass, Plus, SidebarSimple } from '@phosphor-icons/react'
+import { ArrowLineLeft, MagnifyingGlass, Plus, SidebarSimple } from '@phosphor-icons/react'
 import { Loader2 } from 'lucide-react'
 import type { VaultEntry } from '../../types'
 import type { SortOption, SortDirection } from '../../utils/noteListHelpers'
@@ -51,6 +51,7 @@ interface NoteListHeaderProps {
   onSearchChange: (value: string) => void
   onSearchKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
   onGitRepositoryChange?: (path: string) => void
+  onCollapse?: () => void
 }
 
 function dispatchExpandSidebarFromHeader() {
@@ -154,6 +155,7 @@ function HeaderActions({
   onSortChange,
   onCreateNote,
   onToggleSearch,
+  onCollapse,
 }: Pick<
   NoteListHeaderProps,
   | 'isEntityView'
@@ -165,9 +167,12 @@ function HeaderActions({
   | 'onSortChange'
   | 'onCreateNote'
   | 'onToggleSearch'
+  | 'onCollapse'
 > & {
   locale: AppLocale
 }) {
+  const collapseLabel = translate(locale, 'noteList.action.collapse')
+
   return (
     <div className="ml-3 flex shrink-0 items-center justify-end gap-2" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
       {!isEntityView && <SortDropdown groupLabel="__list__" current={listSort} direction={listDirection} customProperties={customProperties} locale={locale} onChange={onSortChange} />}
@@ -185,6 +190,11 @@ function HeaderActions({
       <Button type="button" variant="ghost" size="icon-xs" className={NOTE_LIST_ACTION_BUTTON_CLASSNAME} onClick={onCreateNote} title={translate(locale, 'noteList.createNote')} aria-label={translate(locale, 'noteList.createNote')}>
         <Plus size={16} />
       </Button>
+      {onCollapse && (
+        <Button type="button" variant="ghost" size="icon-xs" className={NOTE_LIST_ACTION_BUTTON_CLASSNAME} onClick={onCollapse} title={collapseLabel} aria-label={collapseLabel}>
+          <ArrowLineLeft size={16} />
+        </Button>
+      )}
     </div>
   )
 }
@@ -259,6 +269,7 @@ export function NoteListHeader({
   onSearchChange,
   onSearchKeyDown,
   onGitRepositoryChange,
+  onCollapse,
 }: NoteListHeaderProps) {
   const { onMouseDown: onDragMouseDown } = useDragRegion()
 
@@ -282,6 +293,7 @@ export function NoteListHeader({
           onSortChange={onSortChange}
           onCreateNote={onCreateNote}
           onToggleSearch={onToggleSearch}
+          onCollapse={onCollapse}
         />
       </div>
       <RepositorySelectorRow

--- a/src/components/note-list/NoteListLayout.tsx
+++ b/src/components/note-list/NoteListLayout.tsx
@@ -6,6 +6,7 @@ import type { useNoteListModel } from './useNoteListModel'
 
 type NoteListLayoutProps = ReturnType<typeof useNoteListModel> & {
   handleBulkOrganize?: () => void
+  onCollapse?: () => void
 }
 
 const NOTE_LIST_LOADING_ROWS = [
@@ -272,6 +273,7 @@ function NoteListLayoutHeader({
   toggleSearch,
   setSearch,
   handleSearchKeyDown,
+  onCollapse,
 }: Pick<
   NoteListLayoutProps,
   | 'title'
@@ -297,6 +299,7 @@ function NoteListLayoutHeader({
   | 'toggleSearch'
   | 'setSearch'
   | 'handleSearchKeyDown'
+  | 'onCollapse'
 >) {
   return (
     <NoteListHeader
@@ -323,6 +326,7 @@ function NoteListLayoutHeader({
       onToggleSearch={toggleSearch}
       onSearchChange={setSearch}
       onSearchKeyDown={handleSearchKeyDown}
+      onCollapse={onCollapse}
     />
   )
 }

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -19,22 +19,28 @@ function loadViewMode(): ViewMode {
 
 export function useViewMode(initialOverride?: ViewMode) {
   const [viewMode, setViewModeState] = useState<ViewMode>(initialOverride ?? loadViewMode)
+  const [noteListHidden, setNoteListHidden] = useState(false)
 
   // Re-sync when vault config becomes available
   useEffect(() => {
     return subscribeVaultConfig(() => {
       const stored = getVaultConfig().view_mode
-      if (isViewMode(stored)) setViewModeState(stored)
+      if (isViewMode(stored)) {
+        setViewModeState(stored)
+        setNoteListHidden(false)
+      }
     })
   }, [])
 
   const setViewMode = useCallback((mode: ViewMode) => {
     setViewModeState(mode)
+    setNoteListHidden(false)
     updateVaultConfigField('view_mode', mode)
   }, [])
 
   const sidebarVisible = viewMode === 'all'
   const noteListVisible = viewMode === 'all' || viewMode === 'editor-list'
+  const effectiveNoteListVisible = noteListVisible && !noteListHidden
 
-  return { viewMode, setViewMode, sidebarVisible, noteListVisible }
+  return { viewMode, setViewMode, sidebarVisible, noteListVisible, effectiveNoteListVisible, setNoteListHidden }
 }

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -374,6 +374,7 @@
   "noteList.title.notes": "Notes",
   "noteList.searchPlaceholder": "Search notes...",
   "noteList.searchAction": "Search notes",
+  "noteList.action.collapse": "Collapse note list",
   "noteList.createNote": "Create new note",
   "noteList.empty.changesError": "Failed to load changes: {error}",
   "noteList.empty.noChanges": "No pending changes",


### PR DESCRIPTION
 Summary

  - Clicking an already-active sidebar item (Inbox, All Notes, a type section, etc.) now toggles the note list panel closed, keeping the editor content intact
  - Clicking the same item again, or navigating to a different item, restores the note list
  - The toggle requires the user to have explicitly navigated to the selection first — prevents accidental collapse on first load when the default item is already active

  How it works

  - noteListHidden — plain React state (not persisted), resets on page reload so it can't get stuck
  - lastExplicitSelectionRef — tracks the last item the user deliberately clicked; the toggle only fires on a second click of the same item
  - effectiveNoteListVisible gates the note list render instead of the raw noteListVisible, leaving all view mode logic untouched

  Test

  1. Open the app with the note list visible
  2. Click any active sidebar item (e.g. Inbox if already on Inbox) — note list hides, editor stays
  3. Click it again — note list restores
  4. Click a different sidebar item while note list is hidden — note list restores and navigates
  5. Reload the page — note list is visible on load regardless of last state

https://github.com/user-attachments/assets/3550272f-0526-4c3f-b957-998bd7ffa8f4



