### PR TITLE
fix: measure status bar width before stacking

### DIFF
--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, render, screen, fireEvent, within } from '@testing-library/react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { StatusBar } from './StatusBar'
@@ -25,6 +25,8 @@ const installedAiAgentsStatus = {
 }
 
 const DEFAULT_WINDOW_WIDTH = 1280
+const originalResizeObserver = window.ResizeObserver
+let resizeObserverCallback: ResizeObserverCallback | null = null
 
 function setWindowWidth(width: number) {
   Object.defineProperty(window, 'innerWidth', {
@@ -54,6 +56,35 @@ function renderDenseStatusBar() {
   )
 }
 
+function mockResizeObserver() {
+  resizeObserverCallback = null
+  class MockResizeObserver implements ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      resizeObserverCallback = callback
+    }
+
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+  }
+
+  Object.defineProperty(window, 'ResizeObserver', {
+    configurable: true,
+    writable: true,
+    value: MockResizeObserver,
+  })
+}
+
+function resizeObservedStatusBar(width: number) {
+  if (!resizeObserverCallback) throw new Error('Expected status bar resize observer to be registered')
+  act(() => {
+    resizeObserverCallback(
+      [{ contentRect: { width } } as ResizeObserverEntry],
+      {} as ResizeObserver,
+    )
+  })
+}
+
 async function expectTooltip(trigger: HTMLElement, ...parts: string[]) {
   act(() => {
     fireEvent.focus(trigger)
@@ -71,6 +102,20 @@ describe('StatusBar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setWindowWidth(DEFAULT_WINDOW_WIDTH)
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      writable: true,
+      value: originalResizeObserver,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      writable: true,
+      value: originalResizeObserver,
+    })
+    resizeObserverCallback = null
   })
 
   it('does not display the bottom-bar note count readout', () => {
@@ -584,6 +629,21 @@ describe('StatusBar', () => {
     })
     expect(screen.getByTestId('status-commit-push')).toBeInTheDocument()
     expect(screen.getByTestId('status-pulse')).toBeInTheDocument()
+    expect(screen.getByTestId('status-feedback')).toBeInTheDocument()
+  })
+
+  it('uses the measured footer width so constrained layouts stack before controls overlap', () => {
+    mockResizeObserver()
+    setWindowWidth(1280)
+    renderDenseStatusBar()
+
+    resizeObservedStatusBar(880)
+
+    expect(screen.getByTestId('status-bar')).toHaveStyle({
+      flexWrap: 'wrap',
+      height: 'auto',
+    })
+    expect(screen.getByTestId('status-commit-push')).toBeInTheDocument()
     expect(screen.getByTestId('status-feedback')).toBeInTheDocument()
   })
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,7 +1,7 @@
 import type { AiAgentId, AiAgentsStatus } from '../lib/aiAgents'
 import type { AiModelProvider } from '../lib/aiTargets'
 import type { VaultAiGuidanceStatus } from '../lib/vaultAiGuidance'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
 import type { ClaudeCodeStatus } from '../hooks/useClaudeCodeStatus'
 import type { McpStatus } from '../hooks/useMcpStatus'
 import type { ThemeMode } from '../lib/themeMode'
@@ -35,6 +35,11 @@ function getStatusBarLayout(windowWidth: number) {
   }
 }
 
+function getMeasuredStatusBarWidth(element: HTMLElement | null) {
+  const measuredWidth = element?.getBoundingClientRect().width ?? 0
+  return measuredWidth > 0 ? measuredWidth : getWindowWidth()
+}
+
 function useStatusBarTicker() {
   const [, setTick] = useState(0)
 
@@ -44,17 +49,29 @@ function useStatusBarTicker() {
   }, [])
 }
 
-function useStatusBarLayout() {
+function useStatusBarLayout(statusBarRef: RefObject<HTMLElement | null>) {
   const [windowWidth, setWindowWidth] = useState(() => getWindowWidth())
 
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    const handleResize = () => setWindowWidth(getWindowWidth())
+    const element = statusBarRef.current
+    const setMeasuredWidth = (width = getMeasuredStatusBarWidth(element)) => setWindowWidth(width)
 
+    setMeasuredWidth()
+
+    if (element && typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(([entry]) => {
+        setMeasuredWidth(entry?.contentRect.width)
+      })
+      observer.observe(element)
+      return () => observer.disconnect()
+    }
+
+    const handleResize = () => setMeasuredWidth()
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
-  }, [])
+  }, [statusBarRef])
 
   return getStatusBarLayout(windowWidth)
 }
@@ -122,6 +139,7 @@ interface StatusBarProps {
 
 interface StatusBarFooterProps extends StatusBarProps {
   compact: boolean
+  footerRef: RefObject<HTMLElement | null>
   stacked: boolean
 }
 
@@ -267,10 +285,11 @@ function StatusBarSecondaryFromFooter({
 }
 
 function StatusBarFooter(props: StatusBarFooterProps) {
-  const { compact, stacked } = props
+  const { compact, footerRef, stacked } = props
 
   return (
     <footer
+      ref={footerRef}
       data-testid="status-bar"
       style={{
         minHeight: 30,
@@ -299,11 +318,12 @@ function StatusBarFooter(props: StatusBarFooterProps) {
 
 export function StatusBar(props: StatusBarProps) {
   useStatusBarTicker()
-  const { compact, stacked } = useStatusBarLayout()
+  const statusBarRef = useRef<HTMLElement | null>(null)
+  const { compact, stacked } = useStatusBarLayout(statusBarRef)
 
   return (
     <TooltipProvider>
-      <StatusBarFooter {...props} compact={compact} stacked={stacked} />
+      <StatusBarFooter {...props} compact={compact} footerRef={statusBarRef} stacked={stacked} />
     </TooltipProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Measure the status bar footer itself when deciding compact and stacked layout.
- Keep the existing window-width fallback for environments without ResizeObserver.
- Add a regression test for constrained footer width so dense controls stack before overlapping.

Closes #737.

## Tests
- pnpm exec vitest run src/components/StatusBar.test.tsx --reporter=dot
- pnpm exec eslint src/components/StatusBar.tsx src/components/StatusBar.test.tsx
- pnpm exec tsc --noEmit

## Manual check
- Verified the Vite app footer stays one row at 980px and stacks at 880px.