### PR TITLE
fix: ignore stationary palette mouse hover

### DIFF
--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -281,7 +281,12 @@ describe('CommandPalette', () => {
   it('keeps keyboard selection stable when the mouse is already over a row', () => {
     render(<CommandPalette open={true} commands={commands} onClose={onClose} />)
 
-    fireEvent.mouseEnter(screen.getByText('Commit & Push'))
+    fireEvent.mouseMove(screen.getByText('Commit & Push'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
     fireEvent.keyDown(window, { key: 'ArrowDown' })
     fireEvent.keyDown(window, { key: 'Enter' })
 
@@ -293,10 +298,50 @@ describe('CommandPalette', () => {
   it('lets real mouse movement take over command selection', () => {
     render(<CommandPalette open={true} commands={commands} onClose={onClose} />)
 
-    fireEvent.mouseMove(screen.getByText('Commit & Push'))
+    fireEvent.mouseMove(screen.getByText('Commit & Push'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
+    fireEvent.mouseMove(screen.getByText('Commit & Push'), {
+      clientX: 10,
+      clientY: 11,
+      screenX: 10,
+      screenY: 11,
+    })
     fireEvent.keyDown(window, { key: 'Enter' })
 
     expect(commands[2].execute).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('ignores stationary mouse hover again after keyboard navigation changes selection', () => {
+    render(<CommandPalette open={true} commands={commands} onClose={onClose} />)
+
+    fireEvent.mouseMove(screen.getByText('Commit & Push'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
+    fireEvent.mouseMove(screen.getByText('Commit & Push'), {
+      clientX: 10,
+      clientY: 11,
+      screenX: 10,
+      screenY: 11,
+    })
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+    fireEvent.mouseMove(screen.getByText('Commit & Push'), {
+      clientX: 10,
+      clientY: 11,
+      screenX: 10,
+      screenY: 11,
+    })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(commands[1].execute).toHaveBeenCalledOnce()
+    expect(commands[2].execute).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalledOnce()
   })
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import type { VaultEntry } from '../types'
 import { fuzzyMatch } from '../utils/fuzzyMatch'
+import { detectIntentionalMouseMovement, type MouseMovementSnapshot } from '../utils/mouseMovement'
 import { queueAiPrompt, requestOpenAiChat } from '../utils/aiPromptBridge'
 import type { NoteReference } from '../utils/ai-context'
 import type { CommandAction, CommandGroup } from '../hooks/useCommandRegistry'
@@ -196,6 +197,13 @@ function CommandPaletteResults({
   onSelect: (command: CommandAction) => void
 }) {
   const flatList = groups.flatMap((group) => group.items)
+  const lastMouseMoveRef = useRef<MouseMovementSnapshot | null>(null)
+
+  const handleHover = (index: number, event: React.MouseEvent<HTMLButtonElement>) => {
+    const decision = detectIntentionalMouseMovement(event.nativeEvent, lastMouseMoveRef.current)
+    lastMouseMoveRef.current = decision.snapshot
+    if (decision.moved) onHover(index)
+  }
 
   if (flatList.length === 0) {
     return (
@@ -234,7 +242,7 @@ function CommandPaletteResults({
                   key={command.id}
                   command={command}
                   selected={globalIndex === selectedIndex}
-                  onHover={() => onHover(globalIndex)}
+                  onHover={(event) => handleHover(globalIndex, event)}
                   onSelect={() => onSelect(command)}
                 />
               )
@@ -470,7 +478,7 @@ function OpenCommandPalette({
 interface CommandRowProps {
   command: CommandAction
   selected: boolean
-  onHover: () => void
+  onHover: (event: React.MouseEvent<HTMLButtonElement>) => void
   onSelect: () => void
 }
 

--- a/src/components/NoteSearchList.test.tsx
+++ b/src/components/NoteSearchList.test.tsx
@@ -198,8 +198,22 @@ describe('NoteSearchList', () => {
 
   it('calls onItemHover when the mouse actually moves over an item', () => {
     renderList({ itemHover: onItemHover })
-    fireEvent.mouseMove(screen.getByText('Gamma Experiment'))
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), { clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), { clientX: 10, clientY: 11 })
     expect(onItemHover).toHaveBeenCalledWith(2)
+  })
+
+  it('does not call onItemHover for a zero-delta mousemove after a keyboard-opened list appears', () => {
+    renderList({ itemHover: onItemHover })
+
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
+
+    expect(onItemHover).not.toHaveBeenCalled()
   })
 
   it('highlights selected item with accent background', () => {

--- a/src/components/NoteSearchList.tsx
+++ b/src/components/NoteSearchList.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, type ComponentType, type MouseEvent, type PointerEve
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { scrollSelectedHTMLChildIntoView } from '../utils/domScroll'
+import { detectIntentionalMouseMovement, type MouseMovementSnapshot } from '../utils/mouseMovement'
 import { NoteTitleIcon } from './NoteTitleIcon'
 import { WorkspaceInitialsBadge } from './WorkspaceInitialsBadge'
 import type { WorkspaceIdentity } from '../types'
@@ -32,7 +33,7 @@ interface NoteSearchListItemProps<T extends NoteSearchResultItem> {
   index: number
   selected: boolean
   onItemClick: (item: T, index: number) => void
-  onItemHover?: (index: number) => void
+  onItemHover?: (index: number, event: MouseEvent<HTMLButtonElement>) => void
   activateOnMouseDown?: boolean
 }
 
@@ -105,7 +106,7 @@ function NoteSearchListItem<T extends NoteSearchResultItem>({
         onPointerDownCapture={activateFromPress}
         onMouseDownCapture={activateFromPress}
         onClick={handleClick}
-        onMouseMove={() => onItemHover?.(index)}
+        onMouseMove={(event) => onItemHover?.(index, event)}
       >
         <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-sm text-foreground">
           {item.TypeIcon && (
@@ -149,6 +150,13 @@ export function NoteSearchList<T extends NoteSearchResultItem>({
   className,
 }: NoteSearchListProps<T>) {
   const listRef = useRef<HTMLDivElement>(null)
+  const lastMouseMoveRef = useRef<MouseMovementSnapshot | null>(null)
+
+  const handleItemHover = (index: number, event: MouseEvent<HTMLButtonElement>) => {
+    const decision = detectIntentionalMouseMovement(event.nativeEvent, lastMouseMoveRef.current)
+    lastMouseMoveRef.current = decision.snapshot
+    if (decision.moved) onItemHover?.(index)
+  }
 
   useEffect(() => {
     scrollSelectedHTMLChildIntoView(listRef.current, selectedIndex)
@@ -173,7 +181,7 @@ export function NoteSearchList<T extends NoteSearchResultItem>({
           index={i}
           selected={i === selectedIndex}
           onItemClick={onItemClick}
-          onItemHover={onItemHover}
+          onItemHover={handleItemHover}
           activateOnMouseDown={activateOnMouseDown}
         />
       ))}

--- a/src/components/QuickOpenPalette.test.tsx
+++ b/src/components/QuickOpenPalette.test.tsx
@@ -164,8 +164,62 @@ describe('QuickOpenPalette', () => {
   it('keeps keyboard selection stable when the mouse is already over a result', () => {
     render(<QuickOpenPalette open={true} entries={entries} onSelect={onSelect} onClose={onClose} />)
 
-    fireEvent.mouseEnter(screen.getByText('Gamma Experiment'))
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
     fireEvent.keyDown(window, { key: 'ArrowDown' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith(entries[1])
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('lets mouse movement take over after the cursor position actually changes', () => {
+    render(<QuickOpenPalette open={true} entries={entries} onSelect={onSelect} onClose={onClose} />)
+
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 11,
+      screenX: 10,
+      screenY: 11,
+    })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith(entries[2])
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('ignores stationary mouse hover again after keyboard navigation changes selection', () => {
+    render(<QuickOpenPalette open={true} entries={entries} onSelect={onSelect} onClose={onClose} />)
+
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 10,
+      screenX: 10,
+      screenY: 10,
+    })
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 11,
+      screenX: 10,
+      screenY: 11,
+    })
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+    fireEvent.mouseMove(screen.getByText('Gamma Experiment'), {
+      clientX: 10,
+      clientY: 11,
+      screenX: 10,
+      screenY: 11,
+    })
     fireEvent.keyDown(window, { key: 'Enter' })
 
     expect(onSelect).toHaveBeenCalledWith(entries[1])

--- a/src/utils/mouseMovement.test.ts
+++ b/src/utils/mouseMovement.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { detectIntentionalMouseMovement } from './mouseMovement'
+
+function mouseEvent(overrides: Partial<MouseEvent> = {}) {
+  return {
+    clientX: 10,
+    clientY: 20,
+    screenX: 30,
+    screenY: 40,
+    movementX: 0,
+    movementY: 0,
+    ...overrides,
+  } as MouseEvent
+}
+
+function mouseEventWithoutMovementDeltas() {
+  return {
+    clientX: 10,
+    clientY: 20,
+    screenX: 30,
+    screenY: 40,
+  } as MouseEvent
+}
+
+describe('detectIntentionalMouseMovement', () => {
+  it('treats the first zero-delta mousemove as positioning noise', () => {
+    const decision = detectIntentionalMouseMovement(mouseEvent(), null)
+
+    expect(decision.moved).toBe(false)
+    expect(decision.snapshot).toEqual({
+      clientX: 10,
+      clientY: 20,
+      screenX: 30,
+      screenY: 40,
+    })
+  })
+
+  it('treats missing movement deltas as zero', () => {
+    const decision = detectIntentionalMouseMovement(mouseEventWithoutMovementDeltas(), null)
+
+    expect(decision.moved).toBe(false)
+  })
+
+  it('detects movement from browser movement deltas', () => {
+    const decision = detectIntentionalMouseMovement(mouseEvent({ movementX: 1 }), null)
+
+    expect(decision.moved).toBe(true)
+  })
+
+  it('detects movement by comparing coordinates', () => {
+    const previous = detectIntentionalMouseMovement(mouseEvent(), null).snapshot
+
+    const decision = detectIntentionalMouseMovement(mouseEvent({ clientY: 21 }), previous)
+
+    expect(decision.moved).toBe(true)
+  })
+
+  it('ignores repeated mousemove events at the same coordinates', () => {
+    const previous = detectIntentionalMouseMovement(mouseEvent(), null).snapshot
+
+    const decision = detectIntentionalMouseMovement(mouseEvent(), previous)
+
+    expect(decision.moved).toBe(false)
+  })
+})

--- a/src/utils/mouseMovement.ts
+++ b/src/utils/mouseMovement.ts
@@ -1,0 +1,36 @@
+export interface MouseMovementSnapshot {
+  clientX: number
+  clientY: number
+  screenX: number
+  screenY: number
+}
+
+export interface MouseMovementDecision {
+  moved: boolean
+  snapshot: MouseMovementSnapshot
+}
+
+export function detectIntentionalMouseMovement(
+  event: Pick<MouseEvent, 'clientX' | 'clientY' | 'screenX' | 'screenY' | 'movementX' | 'movementY'>,
+  previous: MouseMovementSnapshot | null,
+): MouseMovementDecision {
+  const snapshot = {
+    clientX: event.clientX,
+    clientY: event.clientY,
+    screenX: event.screenX,
+    screenY: event.screenY,
+  }
+
+  const movedByEventDelta = (event.movementX ?? 0) !== 0 || (event.movementY ?? 0) !== 0
+  const movedFromPrevious = previous !== null && (
+    snapshot.clientX !== previous.clientX ||
+    snapshot.clientY !== previous.clientY ||
+    snapshot.screenX !== previous.screenX ||
+    snapshot.screenY !== previous.screenY
+  )
+
+  return {
+    moved: movedByEventDelta || movedFromPrevious,
+    snapshot,
+  }
+}

--- a/src/utils/mouseMovement.ts
+++ b/src/utils/mouseMovement.ts
@@ -10,6 +10,22 @@ export interface MouseMovementDecision {
   snapshot: MouseMovementSnapshot
 }
 
+const MOUSE_POSITION_KEYS: Array<keyof MouseMovementSnapshot> = ['clientX', 'clientY', 'screenX', 'screenY']
+
+function hasNonZeroMovementDelta(
+  event: Pick<MouseEvent, 'movementX' | 'movementY'>,
+): boolean {
+  return (event.movementX ?? 0) !== 0 || (event.movementY ?? 0) !== 0
+}
+
+function hasChangedMousePosition(
+  snapshot: MouseMovementSnapshot,
+  previous: MouseMovementSnapshot | null,
+): boolean {
+  if (!previous) return false
+  return MOUSE_POSITION_KEYS.some((key) => snapshot[key] !== previous[key])
+}
+
 export function detectIntentionalMouseMovement(
   event: Pick<MouseEvent, 'clientX' | 'clientY' | 'screenX' | 'screenY' | 'movementX' | 'movementY'>,
   previous: MouseMovementSnapshot | null,
@@ -21,16 +37,8 @@ export function detectIntentionalMouseMovement(
     screenY: event.screenY,
   }
 
-  const movedByEventDelta = (event.movementX ?? 0) !== 0 || (event.movementY ?? 0) !== 0
-  const movedFromPrevious = previous !== null && (
-    snapshot.clientX !== previous.clientX ||
-    snapshot.clientY !== previous.clientY ||
-    snapshot.screenX !== previous.screenX ||
-    snapshot.screenY !== previous.screenY
-  )
-
   return {
-    moved: movedByEventDelta || movedFromPrevious,
+    moved: hasNonZeroMovementDelta(event) || hasChangedMousePosition(snapshot, previous),
     snapshot,
   }
 }


### PR DESCRIPTION
Fixes #819.

## Summary
- Ignore zero-delta/stationary mousemove events in command palette and quick-open result lists.
- Allow mouse hover selection only after the cursor position actually changes.
- Add regression coverage for keyboard selection staying stable after palette open and after keyboard navigation reclaims selection.

## Verification
- pnpm test src/utils/mouseMovement.test.ts src/components/NoteSearchList.test.tsx src/components/QuickOpenPalette.test.tsx src/components/CommandPalette.test.tsx
- npx tsc --noEmit
- pnpm lint
- temporary Chromium smoke: stationary mouse did not steal command palette keyboard selection
- pre-commit hook: lint + tsc + 400 test files / 4394 tests passed
- pre-push hook to fork/main completed successfully; captured output included lint, build, frontend coverage, Rust skip for no src-tauri changes, and Playwright smoke progress before the push completed